### PR TITLE
Fix Docker Compose variable substitution warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       
       echo 'Pulling embedding model...' &&
       for i in 1 2 3 4 5; do
-        echo 'Attempting to pull embedding model (try $i/5)...' &&
+        echo 'Attempting to pull embedding model (try '$$i'/5)...' &&
         if curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"all-minilm:33m-l12-v2-fp16\"}'; then
           echo 'Embedding model pull initiated successfully' &&
           break
@@ -63,7 +63,7 @@ services:
       
       echo 'Pulling lightweight LLM model...' &&
       for i in 1 2 3 4 5; do
-        echo 'Attempting to pull LLM model (try $i/5)...' &&
+        echo 'Attempting to pull LLM model (try '$$i'/5)...' &&
         if curl -s -X POST http://ollama:11434/api/pull -d '{\"name\": \"qwen2:0.5b\"}'; then
           echo 'LLM model pull initiated successfully' &&
           echo 'All models pulled successfully' &&


### PR DESCRIPTION
## Summary
This PR fixes Docker Compose warnings about undefined variable 'i' that appear when running `docker-compose up`.

## Problem
When running the project with Docker Compose, the following warning appears multiple times:
```
WARNING: The i variable is not set. Defaulting to a blank string.
```

This occurs in the `ollama-init` service where shell loop variables `$i` are used in echo statements. Docker Compose attempts to perform variable substitution on these before passing the command to the shell.

## Solution
The fix escapes the dollar sign as `$$i` in the affected echo statements. This tells Docker Compose to pass a literal `$` to the shell, preventing the variable substitution warning while allowing the shell script to function correctly.

## Changes
- Line 55: `echo 'Attempting to pull embedding model (try $i/5)...'` → `echo 'Attempting to pull embedding model (try '$$i'/5)...'`
- Line 66: `echo 'Attempting to pull LLM model (try $i/5)...'` → `echo 'Attempting to pull LLM model (try '$$i'/5)...'`

## Testing
Tested locally by running:
1. `docker-compose down`
2. `docker-compose up -d`

The warnings no longer appear and the ollama-init service executes successfully.

## Compatibility
This is the standard cross-platform approach for handling shell variables in Docker Compose YAML files and works consistently across Linux, macOS, and Windows.