### PR TITLE
Bump `ModelContextProtocol` from 0.1.0-preview.14 to 0.3.0-preview.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.7" />
-    <PackageVersion Include="ModelContextProtocol" Version="0.1.0-preview.14" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.1.0-preview.14" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.3" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.3" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="OllamaSharp" Version="5.3.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />


### PR DESCRIPTION
Long overdue update to these packages