### PR TITLE
Make embedding dimensions configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,13 +38,22 @@ Configure the application settings in the `.env` file or as environment variable
 MEMORIZER_ConnectionStrings__Storage=Host=localhost;Port=5432;Database=memorizer;Username=postgres;Password=postgres
 MEMORIZER_Embeddings__ApiUrl=http://localhost:11434
 MEMORIZER_Embeddings__Model=all-minilm:33m-l12-v2-fp16
+MEMORIZER_Embeddings__Dimensions=384
 MEMORIZER_Server__CanonicalUrl=example.com:8080
 ```
 
 - `MEMORIZER_ConnectionStrings__Storage`: PostgreSQL connection string
 - `MEMORIZER_Embeddings__ApiUrl`: URL of your embedding API (defaults to Ollama)
 - `MEMORIZER_Embeddings__Model`: The embedding model to use
+- `MEMORIZER_Embeddings__Dimensions`: The dimension size for embeddings (default: 384)
 - `MEMORIZER_Server__CanonicalUrl`: (Optional) The canonical URL/hostname for this server. Used for generating MCP configuration. Defaults to `localhost:{port}` where port is extracted from `ASPNETCORE_URLS`
+
+> ⚠️ **IMPORTANT**: Changing the `Dimensions` configuration after the database has been initialized will cause runtime errors. PostgreSQL's `pgvector` extension uses fixed-dimension columns that cannot accept vectors of different sizes. If you need to change dimensions:
+> 1. For new deployments: Set the desired dimension value before first run
+> 2. For existing databases: You must manually migrate the database by either:
+>    - Dropping and recreating the tables with new vector dimensions
+>    - Creating new columns with the desired dimensions and migrating data
+>    - Re-embedding all existing content with the new model
 
 ### MCP Configuration
 

--- a/src/Memorizer.IntegrationTests/PostgresContainerTests.cs
+++ b/src/Memorizer.IntegrationTests/PostgresContainerTests.cs
@@ -66,7 +66,7 @@ public class IntegrationTests : TestKit
         await using var conn = new NpgsqlConnection(_fixture.PostgresConnectionString);
         await conn.OpenAsync();
         await using var cmd = conn.CreateCommand();
-        // Create a vector with 384 dimensions (all zeros)
+        // Create a vector with default dimensions (384) - matches database schema
         var vector = string.Join(",", Enumerable.Repeat("0", 384));
         cmd.CommandText = $"INSERT INTO memories (id, type, content, text, source, embedding, tags, confidence, created_at, updated_at) VALUES (gen_random_uuid(), 'test', '{{}}'::jsonb, 'test text', 'test', '[{vector}]'::vector, ARRAY['tag'], 1.0, now(), now()) RETURNING id;";
         var id = await cmd.ExecuteScalarAsync();

--- a/src/Memorizer/Models/Memory.cs
+++ b/src/Memorizer/Models/Memory.cs
@@ -9,7 +9,7 @@ public class Memory
     public string Type { get; init; } = string.Empty;
     public JsonDocument Content { get; init; } = JsonDocument.Parse("{}");
     public string Source { get; init; } = string.Empty;
-    public Vector Embedding { get; init; } = new(new float[384]);
+    public Vector Embedding { get; init; } = new(new float[384]); // Default size - actual embeddings use configured dimensions
     public Vector? EmbeddingMetadata { get; init; } = null;
     public string[]? Tags { get; init; }
     public double Confidence { get; init; }

--- a/src/Memorizer/Services/EmbeddingService.cs
+++ b/src/Memorizer/Services/EmbeddingService.cs
@@ -73,7 +73,7 @@ public class EmbeddingService : IEmbeddingService
             // Fallback to a random embedding in case of error
             _logger.LogWarning("Falling back to random embedding generation");
             Random random = new();
-            float[] embedding = new float[384];
+            float[] embedding = new float[_settings.Dimensions];
             for (int i = 0; i < embedding.Length; i++)
             {
                 embedding[i] = (float)random.NextDouble();

--- a/src/Memorizer/Services/MemoryStatsService.cs
+++ b/src/Memorizer/Services/MemoryStatsService.cs
@@ -1,3 +1,4 @@
+using Memorizer.Settings;
 using Npgsql;
 using Registrator.Net;
 
@@ -22,16 +23,23 @@ public class MemoryStats
     /// Average size of memory content in bytes
     /// </summary>
     public long AverageMemorySizeBytes { get; set; }
+    
+    /// <summary>
+    /// Configured embedding dimensions
+    /// </summary>
+    public int EmbeddingDimensions { get; set; }
 }
 
 [AutoRegisterInterfaces(ServiceLifetime.Singleton)]
 public class MemoryStatsService : IMemoryStatsService
 {
     private readonly NpgsqlDataSource _dataSource;
+    private readonly EmbeddingSettings _embeddingSettings;
     
-    public MemoryStatsService(NpgsqlDataSource dataSource)
+    public MemoryStatsService(NpgsqlDataSource dataSource, EmbeddingSettings embeddingSettings)
     {
         _dataSource = dataSource;
+        _embeddingSettings = embeddingSettings;
     }
     
     public async Task<MemoryStats> GetStatsAsync(CancellationToken cancellationToken = default)
@@ -61,7 +69,8 @@ public class MemoryStatsService : IMemoryStatsService
         return new MemoryStats
         {
             TotalMemories = totalMemories,
-            AverageMemorySizeBytes = avgSizeBytes
+            AverageMemorySizeBytes = avgSizeBytes,
+            EmbeddingDimensions = _embeddingSettings.Dimensions
         };
     }
 } 

--- a/src/Memorizer/Settings/EmbeddingSettings.cs
+++ b/src/Memorizer/Settings/EmbeddingSettings.cs
@@ -5,4 +5,5 @@ public class EmbeddingSettings
     public required Uri ApiUrl { get; init; }
     public required string Model { get; init; }
     public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(10);
+    public int Dimensions { get; init; } = 384;
 }

--- a/src/Memorizer/Views/Home/Stats.cshtml
+++ b/src/Memorizer/Views/Home/Stats.cshtml
@@ -58,7 +58,7 @@
                 <div class="mb-3">
                     <i class="fas fa-vector-square fa-3x text-warning"></i>
                 </div>
-                <h3 class="mb-1">384D</h3>
+                <h3 class="mb-1">@(Model.EmbeddingDimensions)D</h3>
                 <p class="text-muted mb-0">Vector Dimensions</p>
             </div>
         </div>
@@ -105,7 +105,7 @@
                             <h6 class="text-muted mb-1">Embedding Model</h6>
                             <p class="mb-0">
                                 <i class="fas fa-brain me-2 text-warning"></i>
-                                384-dimensional vectors
+                                @(Model.EmbeddingDimensions)-dimensional vectors
                             </p>
                         </div>
                         <div class="mb-3">

--- a/src/Memorizer/appsettings.example.json
+++ b/src/Memorizer/appsettings.example.json
@@ -5,7 +5,8 @@
   "Embeddings": {
     "ApiUrl": "http://localhost:11434",
     "Model": "all-minilm",
-    "Timeout": "00:01:00"
+    "Timeout": "00:01:00",
+    "Dimensions": 384
   },
   "LLM": {
     "ApiUrl": "http://localhost:11434",

--- a/src/Memorizer/appsettings.json
+++ b/src/Memorizer/appsettings.json
@@ -11,7 +11,8 @@
   },
   "Embeddings": {
     "ApiUrl": "http://localhost:11434",
-    "Model": "all-minilm:33m-l12-v2-fp16"
+    "Model": "all-minilm:33m-l12-v2-fp16",
+    "Dimensions": 384
   },
   "LLM": {
     "ApiUrl": "http://localhost:11434",


### PR DESCRIPTION
Adds `Dimensions` property to `EmbeddingSettings` to support different embedding models.

**Changes:**
- Replace hardcoded 384 with configurable setting
- Add `MEMORIZER_Embeddings__Dimensions` environment variable
- Update UI to display configured dimensions

**Note:** Changing dimensions requires database migration due to pgvector fixed-size columns.

Defaults to 384 for backward compatibility.