### PR TITLE
Update gitignore to exclude .claude/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,9 @@ FodyWeavers.xsd
 .devcontainer/.persisted_credentials/
 .devcontainer/.vscode-server/
 .devcontainer/.features.temp.dockerfile
+
+# Claude worktree management
+.claude-wt/worktrees
+
+# Claude Code files
+.claude/


### PR DESCRIPTION
## Summary
- Add .claude/ folder to .gitignore to prevent committing local development configuration files

## Test plan
- Verify .claude/ folder is ignored by git
- Confirm no other gitignore functionality is affected