### PR TITLE
Fix MCP endpoint configuration for Streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ To use Memorizer with any MCP-compatible client, add the following to your confi
 ```json
 {
   "memorizer": {
-    "url": "http://localhost:5000/sse"
+    "url": "http://localhost:5000"
   }
 }
 ```
+
+This uses the modern Streamable HTTP transport (MCP spec 2025-03-26+).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,7 +153,7 @@ If you're running both your client application and Memorizer in Docker container
 ```json
 {
   "memorizer": {
-    "url": "http://memorizer-api:5000/sse"
+    "url": "http://memorizer-api:5000"
   }
 }
 ```
@@ -168,10 +168,10 @@ To test if your MCP connection is working:
 2. Send a simple curl request to verify the server is responding:
 
 ```bash
-curl http://localhost:5000/sse
+curl http://localhost:5000
 ```
 
-You should receive a response confirming the SSE endpoint is available.
+You should receive a response from the MCP endpoint.
 
 ### MCP Configuration Endpoint
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -95,7 +95,7 @@ For production deployments, especially when exposed to the internet:
 
 ### CORS and MCP Clients
 
-MCP (Model Context Protocol) clients connect to the `/sse` endpoint using Server-Sent Events. This endpoint requires CORS to be properly configured to work with external clients.
+MCP (Model Context Protocol) clients connect using the Streamable HTTP transport. The MCP endpoint requires CORS to be properly configured to work with external clients.
 
 If you're experiencing connection issues with Claude Code or other MCP clients:
 

--- a/src/Memorizer/Controllers/HomeController.cs
+++ b/src/Memorizer/Controllers/HomeController.cs
@@ -104,7 +104,7 @@ public class HomeController : Controller
             {
                 memorizer = new
                 {
-                    url = $"{canonicalUrl}/sse"
+                    url = canonicalUrl
                 }
             }
         };

--- a/src/Memorizer/Views/Home/McpConfig.cshtml
+++ b/src/Memorizer/Views/Home/McpConfig.cshtml
@@ -34,12 +34,12 @@
                                         </button>
                                     </div>
                                     <div class="card-body">
-                                        <pre id="mcpConfig" class="mb-0"><code class="language-json">{  "mcpServers": {    "memorizer": {      "url": "<span id="serverUrl">http://localhost:5000/sse</span>"    }  }}</code></pre>
+                                        <pre id="mcpConfig" class="mb-0"><code class="language-json">{  "mcpServers": {    "memorizer": {      "url": "<span id="serverUrl">http://localhost:5000</span>"    }  }}</code></pre>
                                     </div>
                                 </div>
                             </div>
 
-                                                        <div class="alert alert-info mt-4">                                <i class="fas fa-info-circle me-2"></i>                                <strong>Note:</strong> This simplified configuration uses the SSE (Server-Sent Events) endpoint.                                 The URL is automatically configured based on your server settings.                            </div>
+                                                        <div class="alert alert-info mt-4">                                <i class="fas fa-info-circle me-2"></i>                                <strong>Note:</strong> This configuration uses the Streamable HTTP transport.                                 The URL is automatically configured based on your server settings.                            </div>
                         </div>
                         
                         <div class="col-lg-4">


### PR DESCRIPTION
## Summary
Updates MCP endpoint configuration from `/sse` to root path `/` to use modern Streamable HTTP transport.

## Changes
- Updated `HomeController.cs` to return root URL instead of `/sse` in MCP config endpoint
- Updated `README.md` to show modern configuration
- Updated documentation (`configuration.md`, `security.md`)
- Updated `McpConfig.cshtml` view with correct endpoint and messaging

## Context
The MCP C# SDK 0.4.0-preview.2 (merged in #56) uses Streamable HTTP transport (MCP spec 2025-03-26+) which maps to the root path `/` instead of the legacy `/sse` endpoint.

## Breaking Change
⚠️ **This is a breaking change for MCP clients**

Clients using the old `/sse` endpoint configuration will need to update to use the root URL:
- **Before:** `http://localhost:5000/sse`
- **After:** `http://localhost:5000`

The `/sse` endpoint still works for backward compatibility, but is no longer the recommended configuration.

## Motivation
Fixes Claude Code connectivity issues caused by endpoint mismatch between client expectations (Streamable HTTP at `/`) and documented configuration (SSE at `/sse`).

## Test Plan
- [x] Tested locally - both `/` and `/sse` endpoints work
- [x] Build succeeds
- [ ] Verify Claude Code can connect after deploying with new configuration