### PR TITLE
Prepare release 1.7.1-beta1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,18 +3,25 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dariogriffo/postg-mem</PackageProjectUrl>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.7.1-beta1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
-    <PackageReleaseNotes>**Features**
-- [Add configurable CORS support for MCP SSE endpoints](https://github.com/petabridge/memorizer-v1/pull/53) - Enables MCP clients to connect with customizable CORS policies
-- [Make embedding dimensions configurable](https://github.com/petabridge/memorizer-v1/pull/18) - Support different embedding models via `Dimensions` setting
+    <PackageReleaseNotes>**🚧 BETA RELEASE - For Testing MCP Connectivity Fixes**
+
+**Breaking Changes**
+- **MCP Endpoint Configuration Updated**: The recommended MCP endpoint has changed from `/sse` to the root path `/` to use modern Streamable HTTP transport (MCP spec 2025-03-26+)
+  - **Before:** `"url": "http://localhost:5000/sse"`
+  - **After:** `"url": "http://localhost:5000"`
+  - The `/sse` endpoint still works for backward compatibility but is no longer recommended
+  - [Update MCP endpoint from /sse to root path for Streamable HTTP](https://github.com/petabridge/memorizer-v1/pull/57)
 
 **Updates**
-- [Bump all MSFT dependencies to 9.0.9](https://github.com/petabridge/memorizer-v1/pull/54) - Updated to .NET 9 framework
-- [Bump ModelContextProtocol from 0.3.0-preview.3 to 0.3.0-preview.4](https://github.com/petabridge/memorizer-v1/pull/36) - Framework improvements and bug fixes
-- [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.3 to 0.3.0-preview.4](https://github.com/petabridge/memorizer-v1/pull/39) - Framework improvements and bug fixes</PackageReleaseNotes>
+- [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
+- [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support
+
+**Motivation**
+This beta release addresses MCP client connectivity issues, particularly with Claude Code. The updated SDK (0.4.0-preview.2) includes critical fixes for server notifications and better protocol version negotiation.</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+#### 1.7.1-beta1 October 10th 2025 ####
+
+**🚧 BETA RELEASE - For Testing MCP Connectivity Fixes**
+
+**Breaking Changes**
+- **MCP Endpoint Configuration Updated**: The recommended MCP endpoint has changed from `/sse` to the root path `/` to use modern Streamable HTTP transport (MCP spec 2025-03-26+)
+  - **Before:** `"url": "http://localhost:5000/sse"`
+  - **After:** `"url": "http://localhost:5000"`
+  - The `/sse` endpoint still works for backward compatibility but is no longer recommended
+  - [Update MCP endpoint from /sse to root path for Streamable HTTP](https://github.com/petabridge/memorizer-v1/pull/57)
+
+**Updates**
+- [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
+- [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support
+
+**Motivation**
+This beta release addresses MCP client connectivity issues, particularly with Claude Code. The updated SDK (0.4.0-preview.2) includes critical fixes for server notifications and better protocol version negotiation.
+
 #### 1.7.0 October 9th 2025 ####
 
 **Features**


### PR DESCRIPTION
## Summary
Prepare release 1.7.1-beta1 - a beta release for testing MCP connectivity fixes.

## Changes
- Updated RELEASE_NOTES.md with 1.7.1-beta1 release notes
- Updated Directory.Build.props with version 1.7.1-beta1

## Release Highlights

**🚧 BETA RELEASE - For Testing MCP Connectivity Fixes**

### Breaking Changes
- MCP endpoint configuration updated from `/sse` to `/` for Streamable HTTP transport
- Clients need to update their configuration

### Updates
- ModelContextProtocol packages updated to 0.4.0-preview.2
- Fixes server notification bugs and protocol compatibility issues

### Motivation
Addresses MCP client connectivity issues, particularly with Claude Code.

## Test Plan
- [x] Build script executed successfully
- [ ] CI checks pass
- [ ] After merge, create tag `1.7.1-beta1` and push to trigger GitHub release