### PR TITLE
Prepare release 1.7.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,13 +3,11 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dariogriffo/postg-mem</PackageProjectUrl>
-    <VersionPrefix>1.7.1-beta1</VersionPrefix>
+    <VersionPrefix>1.7.1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
-    <PackageReleaseNotes>**🚧 BETA RELEASE - For Testing MCP Connectivity Fixes**
-
-**Breaking Changes**
+    <PackageReleaseNotes>**Breaking Changes**
 - **MCP Endpoint Configuration Updated**: The recommended MCP endpoint has changed from `/sse` to the root path `/` to use modern Streamable HTTP transport (MCP spec 2025-03-26+)
   - **Before:** `"url": "http://localhost:5000/sse"`
   - **After:** `"url": "http://localhost:5000"`
@@ -18,10 +16,7 @@
 
 **Updates**
 - [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
-- [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support
-
-**Motivation**
-This beta release addresses MCP client connectivity issues, particularly with Claude Code. The updated SDK (0.4.0-preview.2) includes critical fixes for server notifications and better protocol version negotiation.</PackageReleaseNotes>
+- [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,9 @@
   - The `/sse` endpoint still works for backward compatibility but is no longer recommended
   - [Update MCP endpoint from /sse to root path for Streamable HTTP](https://github.com/petabridge/memorizer-v1/pull/57)
 
+**Bug Fixes**
+- [Enable stateless mode for MCP HTTP transport](https://github.com/petabridge/memorizer-v1/pull/64) - Fixes "Session not found" errors when clients reconnect or server restarts by enabling sessionless operation
+
 **Updates**
 - [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
 - [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support</PackageReleaseNotes>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,4 @@
-#### 1.7.1-beta1 October 10th 2025 ####
-
-**🚧 BETA RELEASE - For Testing MCP Connectivity Fixes**
+#### 1.7.1 October 10th 2025 ####
 
 **Breaking Changes**
 - **MCP Endpoint Configuration Updated**: The recommended MCP endpoint has changed from `/sse` to the root path `/` to use modern Streamable HTTP transport (MCP spec 2025-03-26+)
@@ -12,9 +10,6 @@
 **Updates**
 - [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
 - [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support
-
-**Motivation**
-This beta release addresses MCP client connectivity issues, particularly with Claude Code. The updated SDK (0.4.0-preview.2) includes critical fixes for server notifications and better protocol version negotiation.
 
 #### 1.7.0 October 9th 2025 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,9 @@
   - The `/sse` endpoint still works for backward compatibility but is no longer recommended
   - [Update MCP endpoint from /sse to root path for Streamable HTTP](https://github.com/petabridge/memorizer-v1/pull/57)
 
+**Bug Fixes**
+- [Enable stateless mode for MCP HTTP transport](https://github.com/petabridge/memorizer-v1/pull/64) - Fixes "Session not found" errors when clients reconnect or server restarts by enabling sessionless operation
+
 **Updates**
 - [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
 - [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support

--- a/src/Memorizer/Program.cs
+++ b/src/Memorizer/Program.cs
@@ -40,7 +40,9 @@ otelLogger.LogInformation("OTEL_RESOURCE_ATTRIBUTES: {ResourceAttributes}", Envi
 // Add services
 builder.Services.AddMemorizer();
 builder.Services.AddMemorizerOtel();
-builder.Services.AddMcpServer().WithHttpTransport().WithTools<MemoryTools>();
+builder.Services.AddMcpServer()
+    .WithHttpTransport(options => options.Stateless = true)
+    .WithTools<MemoryTools>();
 
 // Add MVC support for web UI
 builder.Services.AddControllersWithViews();


### PR DESCRIPTION
## Summary
- Update version from 1.7.1-beta1 to final 1.7.1 release
- Remove beta release language from release notes
- Update Directory.Build.props with final version and release notes

## Changes
- Version bumped to 1.7.1 (from 1.7.1-beta1)
- Release notes updated to remove beta language