### PR TITLE
Update release notes with stateless mode fix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,9 @@
   - The `/sse` endpoint still works for backward compatibility but is no longer recommended
   - [Update MCP endpoint from /sse to root path for Streamable HTTP](https://github.com/petabridge/memorizer-v1/pull/57)
 
+**Bug Fixes**
+- [Enable stateless mode for MCP HTTP transport](https://github.com/petabridge/memorizer-v1/pull/64) - Fixes "Session not found" errors when clients reconnect or server restarts by enabling sessionless operation
+
 **Updates**
 - [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
 - [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support</PackageReleaseNotes>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,9 @@
   - The `/sse` endpoint still works for backward compatibility but is no longer recommended
   - [Update MCP endpoint from /sse to root path for Streamable HTTP](https://github.com/petabridge/memorizer-v1/pull/57)
 
+**Bug Fixes**
+- [Enable stateless mode for MCP HTTP transport](https://github.com/petabridge/memorizer-v1/pull/64) - Fixes "Session not found" errors when clients reconnect or server restarts by enabling sessionless operation
+
 **Updates**
 - [Bump ModelContextProtocol from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Fixes server notification bugs and improves protocol compatibility
 - [Bump ModelContextProtocol.AspNetCore from 0.3.0-preview.4 to 0.4.0-preview.2](https://github.com/petabridge/memorizer-v1/pull/56) - Adds Streamable HTTP transport support

--- a/src/Memorizer/Program.cs
+++ b/src/Memorizer/Program.cs
@@ -40,7 +40,9 @@ otelLogger.LogInformation("OTEL_RESOURCE_ATTRIBUTES: {ResourceAttributes}", Envi
 // Add services
 builder.Services.AddMemorizer();
 builder.Services.AddMemorizerOtel();
-builder.Services.AddMcpServer().WithHttpTransport().WithTools<MemoryTools>();
+builder.Services.AddMcpServer()
+    .WithHttpTransport(options => options.Stateless = true)
+    .WithTools<MemoryTools>();
 
 // Add MVC support for web UI
 builder.Services.AddControllersWithViews();


### PR DESCRIPTION
## Summary

Updates the 1.7.1 release notes to include the stateless mode fix from PR #64.

## Changes

- Cherry-picked commit from PR #64 (Enable stateless mode for MCP HTTP transport)
- Updated RELEASE_NOTES.md with new Bug Fixes section
- Updated Directory.Build.props PackageReleaseNotes with the fix

## Bug Fix Added

- [Enable stateless mode for MCP HTTP transport](https://github.com/petabridge/memorizer-v1/pull/64) - Fixes "Session not found" errors when clients reconnect or server restarts by enabling sessionless operation

This completes the 1.7.1 release with all fixes included.