### PR TITLE
Upgrade MCP packages to 0.4.0-preview.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ FodyWeavers.xsd
 
 # Claude Code files
 .claude/
+/.playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Memorizer Project Guidelines
+
+## NuGet Package Management
+
+This project uses Central Package Management (CPM) via `Directory.Packages.props`.
+
+- **Never use `VersionOverride` attributes** in `.csproj` files
+- All package versions must be defined in `Directory.Packages.props`
+- When adding new packages, add the `<PackageVersion>` entry to `Directory.Packages.props` first
+- Project files should only contain `<PackageReference Include="PackageName" />` without version attributes

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,8 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(MsftVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MsftVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MsftVersion)" />
-    <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.2" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.2" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
     <PackageVersion Include="Npgsql" Version="9.0.4" />
     <PackageVersion Include="OllamaSharp" Version="5.3.6" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />

--- a/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
+++ b/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
@@ -28,8 +28,8 @@
 
     <ItemGroup>
       <PackageReference Include="Akka.Persistence.Sql.Hosting" />
-      <PackageReference Include="ModelContextProtocol.AspNetCore" VersionOverride="0.4.0-preview.2" />
-      <PackageReference Include="OllamaSharp" VersionOverride="5.3.6" />
+      <PackageReference Include="ModelContextProtocol.AspNetCore" />
+      <PackageReference Include="OllamaSharp" />
         <ProjectReference Include="..\Memorizer\Memorizer.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Upgrades `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from 0.4.0-preview.2 to 0.4.0-preview.3
- Removes `VersionOverride` attributes from integration tests project to properly follow Central Package Management (CPM) conventions
- Adds `CLAUDE.md` with project guidelines to prevent future CPM violations

## Changes in MCP 0.4.0-preview.3

Per the [release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v0.4.0-preview.3):
- Icon/metadata support for tools and resources
- Performance improvements
- .NET 10 support improvements
- No breaking changes

## Test plan

- [x] Solution builds successfully
- [ ] CI passes