### PR TITLE
Fix footer link styling in light and dark themes

### DIFF
--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -147,14 +147,13 @@ footer {
     border-color: var(--footer-border) !important;
 }
 
-footer .text-muted,
-footer .text-muted a {
+footer .text-muted {
     color: var(--footer-text) !important;
 }
 
 footer a {
-    color: var(--footer-link);
-    text-decoration: underline;
+    color: var(--footer-link) !important;
+    text-decoration: underline !important;
 }
 
 footer a:hover {

--- a/src/Memorizer/wwwroot/css/theme-variables.css
+++ b/src/Memorizer/wwwroot/css/theme-variables.css
@@ -48,7 +48,7 @@
     /* Footer */
     --footer-border: #dee2e6;
     --footer-text: #6c757d;
-    --footer-link: #6c757d;
+    --footer-link: #0d6efd;
 }
 
 /* Dark Theme */
@@ -94,7 +94,7 @@
     /* Footer */
     --footer-border: #333333;
     --footer-text: #94a3b8;
-    --footer-link: #94a3b8;
+    --footer-link: #60a5fa;
 }
 
 /* Mermaid container styling */


### PR DESCRIPTION
## Summary

- Fixes footer links (Petabridge, Dario Griffo, postg-mem, Memorizer) not displaying as proper links
- Links were inheriting muted text color instead of blue link styling
- Added `!important` to ensure link styles override `.text-muted` parent styling

## Changes

- Updated `--footer-link` color to proper blue in both themes:
  - Light: `#0d6efd` (Bootstrap primary blue)
  - Dark: `#60a5fa` (lighter blue for dark backgrounds)
- Removed `footer .text-muted a` selector that was overriding link colors
- Added `!important` to `footer a` color and text-decoration rules

## Test plan

- [x] Verified footer links are blue and underlined in light mode
- [x] Verified footer links are blue and underlined in dark mode
- [ ] CI passes