### PR TITLE
Add embedding documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The Web UI provides a user-friendly interface for all Memorizer functionality, m
 
 - [Configuration & Advanced Setup](docs/configuration.md)
 - [Security Configuration](docs/security.md)
+- [Embedding Models & Dimensions](docs/embedding-models.md)
+- [Embedding Dimension Migration](docs/embedding-migration.md)
 - [Local Development](docs/local-development.md)
 - [Schema Migrations](docs/schema-migrations.md)
 - [Architecture Decision Records](docs/adr/README.md)


### PR DESCRIPTION
## Summary

Adds links to the new embedding documentation in the README's Documentation section:

- [Embedding Models & Dimensions](docs/embedding-models.md) - Guide to supported models, dimensions, and recommendations
- [Embedding Dimension Migration](docs/embedding-migration.md) - How to migrate when changing embedding models

These docs were added in PR #107 but weren't linked from the README.

## Test Plan

- [x] Verify links resolve correctly