### PR TITLE
Fix version history display and add version selector to compare view

### DIFF
--- a/src/Memorizer/Views/Home/CompareVersions.cshtml
+++ b/src/Memorizer/Views/Home/CompareVersions.cshtml
@@ -44,12 +44,23 @@
 
                 <!-- Compare content (hidden initially) -->
                 <div id="compareContent" style="display: none;">
-                    <!-- Summary -->
+                    <!-- Version Selector -->
                     <div class="alert alert-secondary mb-4">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div>
-                                <i class="fas fa-info-circle me-2"></i>
-                                Comparing <strong>Version @ViewBag.FromVersion</strong> to <strong>Version @ViewBag.ToVersion</strong>
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                            <div class="d-flex align-items-center flex-wrap gap-2">
+                                <i class="fas fa-code-compare me-2"></i>
+                                <span>Compare</span>
+                                <select id="fromVersionSelect" class="form-select form-select-sm d-inline-block" style="width: auto;">
+                                    <!-- Options populated by JS -->
+                                </select>
+                                <span>to</span>
+                                <select id="toVersionSelect" class="form-select form-select-sm d-inline-block" style="width: auto;">
+                                    <!-- Options populated by JS -->
+                                </select>
+                                <button id="compareBtn" class="btn btn-primary btn-sm" onclick="navigateToComparison()">
+                                    <i class="fas fa-sync-alt me-1"></i>
+                                    Compare
+                                </button>
                             </div>
                             <div id="diffStats">
                                 <!-- Stats will be populated here -->
@@ -90,11 +101,11 @@
                         <div class="btn-group" role="group">
                             <a id="viewFromVersionLink" href="#" class="btn btn-outline-info">
                                 <i class="fas fa-eye me-1"></i>
-                                View Version @ViewBag.FromVersion
+                                <span id="viewFromVersionLabel">View Version</span>
                             </a>
                             <a id="viewToVersionLink" href="#" class="btn btn-outline-info">
                                 <i class="fas fa-eye me-1"></i>
-                                View Version @ViewBag.ToVersion
+                                <span id="viewToVersionLabel">View Version</span>
                             </a>
                         </div>
                     </div>
@@ -107,22 +118,60 @@
 @section Scripts {
 <script>
 const memoryId = '@ViewBag.MemoryId';
-const fromVersion = @ViewBag.FromVersion;
-const toVersion = @ViewBag.ToVersion;
+let fromVersion = @ViewBag.FromVersion;
+let toVersion = @ViewBag.ToVersion;
+let currentVersion = 1; // Will be updated when memory loads
+let availableVersions = []; // All available version numbers
 
 document.addEventListener('DOMContentLoaded', loadComparison);
 
 async function loadComparison() {
     try {
+        // First, load the memory to get current version
+        const memoryResponse = await fetch(`/api/memory/${memoryId}`);
+        if (!memoryResponse.ok) {
+            throw new Error('Memory not found');
+        }
+        const memory = await memoryResponse.json();
+        currentVersion = memory.currentVersion || 1;
+
+        // Load version history to populate dropdowns
+        const versionsResponse = await fetch(`/api/memory/${memoryId}/versions`);
+        const versionSnapshots = versionsResponse.ok ? await versionsResponse.json() : [];
+
+        // Build list of available versions (snapshots + current)
+        availableVersions = versionSnapshots.map(v => v.versionNumber);
+        if (!availableVersions.includes(currentVersion)) {
+            availableVersions.unshift(currentVersion);
+        }
+        availableVersions.sort((a, b) => a - b); // Sort ascending
+
+        // Validate requested versions exist
+        if (!availableVersions.includes(fromVersion)) {
+            showError(`Version ${fromVersion} does not exist. Available versions: ${availableVersions.join(', ')}`);
+            return;
+        }
+        if (!availableVersions.includes(toVersion)) {
+            showError(`Version ${toVersion} does not exist. Available versions: ${availableVersions.join(', ')}`);
+            return;
+        }
+
+        // Populate version selectors
+        populateVersionSelectors();
+
+        // Load comparison
         const response = await fetch(`/api/memory/${memoryId}/versions/compare?fromVersion=${fromVersion}&toVersion=${toVersion}`);
         if (!response.ok) {
-            throw new Error('Failed to load comparison');
+            const errorText = await response.text();
+            throw new Error(errorText || 'Failed to load comparison');
         }
         const comparison = await response.json();
 
         // Set version links
         document.getElementById('viewFromVersionLink').href = `/ui/view/${memoryId}/version/${fromVersion}`;
         document.getElementById('viewToVersionLink').href = `/ui/view/${memoryId}/version/${toVersion}`;
+        document.getElementById('viewFromVersionLabel').textContent = `View Version ${fromVersion}`;
+        document.getElementById('viewToVersionLabel').textContent = `View Version ${toVersion}`;
 
         // Display diff stats
         displayDiffStats(comparison);
@@ -141,9 +190,65 @@ async function loadComparison() {
 
     } catch (error) {
         console.error('Error loading comparison:', error);
-        document.getElementById('loadingSpinner').innerHTML =
-            '<div class="alert alert-danger">Failed to load comparison. Please try again.</div>';
+        showError(error.message || 'Failed to load comparison. Please try again.');
     }
+}
+
+function showError(message) {
+    document.getElementById('loadingSpinner').innerHTML =
+        `<div class="alert alert-danger">
+            <i class="fas fa-exclamation-triangle me-2"></i>
+            ${escapeHtml(message)}
+            <br><br>
+            <a href="/ui/view/${memoryId}" class="btn btn-outline-danger btn-sm">
+                <i class="fas fa-arrow-left me-1"></i>
+                Back to Memory
+            </a>
+        </div>`;
+}
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function populateVersionSelectors() {
+    const fromSelect = document.getElementById('fromVersionSelect');
+    const toSelect = document.getElementById('toVersionSelect');
+
+    fromSelect.innerHTML = '';
+    toSelect.innerHTML = '';
+
+    availableVersions.forEach(v => {
+        const isCurrent = v === currentVersion;
+        const label = isCurrent ? `Version ${v} (current)` : `Version ${v}`;
+
+        const fromOption = document.createElement('option');
+        fromOption.value = v;
+        fromOption.textContent = label;
+        fromOption.selected = v === fromVersion;
+        fromSelect.appendChild(fromOption);
+
+        const toOption = document.createElement('option');
+        toOption.value = v;
+        toOption.textContent = label;
+        toOption.selected = v === toVersion;
+        toSelect.appendChild(toOption);
+    });
+}
+
+function navigateToComparison() {
+    const newFromVersion = parseInt(document.getElementById('fromVersionSelect').value);
+    const newToVersion = parseInt(document.getElementById('toVersionSelect').value);
+
+    if (newFromVersion === newToVersion) {
+        alert('Please select two different versions to compare.');
+        return;
+    }
+
+    // Navigate to the new comparison URL
+    window.location.href = `/ui/view/${memoryId}/compare/${newFromVersion}/${newToVersion}`;
 }
 
 function displayDiffStats(comparison) {

--- a/src/Memorizer/Views/Home/View.cshtml
+++ b/src/Memorizer/Views/Home/View.cshtml
@@ -197,6 +197,7 @@
 <script src="~/js/mermaid-integration.js"></script>
 <script>
 let memoryId = '@(ViewBag.MemoryId?.ToString() ?? "")';
+let currentMemoryData = null; // Store the current memory data for version history display
 
 async function deleteMemory() {
     if (!confirm('Are you sure you want to delete this memory? This action cannot be undone.')) {
@@ -265,6 +266,9 @@ async function loadMemory() {
 
 function populateMemoryView(memory) {
     try {
+        // Store memory data globally for version history display
+        currentMemoryData = memory;
+
         // Set title
         const title = memory.title || 'Untitled Memory';
         document.getElementById('memoryTitle').textContent = title;
@@ -468,34 +472,73 @@ function displayVersionHistory(versions) {
     loadingEl.style.display = 'none';
     contentEl.style.display = 'block';
 
-    // Show empty message only if there are truly no version snapshots
-    // (versions.length === 0 means no edits have been made yet)
-    if (!versions || versions.length === 0) {
+    // Build the complete version list including the current version
+    // Version snapshots only contain historical versions (before edits)
+    // We need to add the current version at the beginning
+    let allVersions = versions ? [...versions] : [];
+
+    // Check if the current version is already in the list
+    // (This happens when current version equals the highest snapshot version,
+    // e.g., for newly created or migrated memories)
+    const hasCurrentInSnapshots = allVersions.some(v => v.versionNumber === currentVersion);
+
+    if (!hasCurrentInSnapshots && currentMemoryData && currentVersion > 0) {
+        // Synthesize a current version entry from the live memory data
+        // Use updatedAt if available, otherwise fall back to createdAt
+        const currentVersionEntry = {
+            versionNumber: currentVersion,
+            versionedAt: currentMemoryData.updatedAt || currentMemoryData.createdAt,
+            events: [], // Current version doesn't have events yet (they describe changes TO reach this version)
+            isCurrent: true // Flag to identify this as the live/current version
+        };
+        allVersions.unshift(currentVersionEntry);
+    }
+
+    // Show empty message only if there are truly no versions at all
+    if (allVersions.length === 0) {
         emptyEl.style.display = 'block';
         return;
     }
 
     timelineEl.innerHTML = '';
 
-    versions.forEach((version, index) => {
-        const isLatest = index === 0;
-        const hasPrevious = index < versions.length - 1;
+    allVersions.forEach((version, index) => {
+        const hasPrevious = index < allVersions.length - 1;
         const isCurrentVersion = version.versionNumber === currentVersion;
 
         // Parse events to display what changed - use displayText from strongly-typed events
-        let changeDescription = 'Version snapshot';
+        let changeDescription = version.isCurrent ? 'Current state' : 'Version snapshot';
         if (version.events && version.events.length > 0) {
             // Use displayText property which contains the rich change description
             changeDescription = version.events.map(e => e.displayText || formatEventType(e.eventType)).join(', ');
         }
 
-        // Version snapshots are historical - they represent the state BEFORE an edit
-        // The most recent snapshot (index 0) shows what was changed to become the current version
+        // Build button group - current version only gets compare button (if applicable)
+        let buttons = '';
+        if (!isCurrentVersion) {
+            buttons += `
+                <a href="/ui/view/${memoryId}/version/${version.versionNumber}" class="btn btn-outline-info btn-sm" title="View this version">
+                    <i class="fas fa-eye"></i>
+                </a>`;
+        }
+        if (hasPrevious) {
+            buttons += `
+                <a href="/ui/view/${memoryId}/compare/${allVersions[index + 1].versionNumber}/${version.versionNumber}" class="btn btn-outline-primary btn-sm" title="Compare with previous">
+                    <i class="fas fa-code-compare"></i>
+                </a>`;
+        }
+        if (!isCurrentVersion) {
+            buttons += `
+                <button class="btn btn-outline-warning btn-sm" onclick="promptRevert(${version.versionNumber})" title="Revert to this version">
+                    <i class="fas fa-undo"></i>
+                </button>`;
+        }
+
         const versionItem = document.createElement('div');
         versionItem.className = 'version-item d-flex align-items-start mb-3 pb-3 border-bottom';
         versionItem.innerHTML = `
             <div class="version-marker me-3">
-                <span class="badge ${isCurrentVersion ? 'bg-primary' : 'bg-secondary'} rounded-pill">v${version.versionNumber}${isCurrentVersion ? ' (current)' : ''}</span>
+                <span class="badge ${isCurrentVersion ? 'bg-primary' : 'bg-secondary'} rounded-pill">v${version.versionNumber}</span>
             </div>
             <div class="version-content flex-grow-1">
                 <div class="d-flex justify-content-between align-items-start">
@@ -513,19 +556,7 @@ function displayVersionHistory(versions) {
                         </small>
                     </div>
                     <div class="btn-group btn-group-sm">
-                        <a href="/ui/view/${memoryId}/version/${version.versionNumber}" class="btn btn-outline-info btn-sm" title="View this version">
-                            <i class="fas fa-eye"></i>
-                        </a>
-                        ${hasPrevious ? `
-                        <a href="/ui/view/${memoryId}/compare/${versions[index + 1].versionNumber}/${version.versionNumber}" class="btn btn-outline-primary btn-sm" title="Compare with previous">
-                            <i class="fas fa-code-compare"></i>
-                        </a>
-                        ` : ''}
-                        ${!isCurrentVersion ? `
-                        <button class="btn btn-outline-warning btn-sm" onclick="promptRevert(${version.versionNumber})" title="Revert to this version">
-                            <i class="fas fa-undo"></i>
-                        </button>
-                        ` : ''}
+                        ${buttons}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- Fix version history to always display current version in the list
- Add version selector dropdowns to compare view for easier version comparison
- Improve error handling when invalid versions are requested

## Changes

### Version History Display
- Store memory data globally for version history display
- Synthesize current version entry from live memory data when not in snapshots
- Clean up button layout (remove disabled view button for current version)
- Simplify badge display

### Compare View Enhancements
- Add dropdown selectors to choose which versions to compare
- Show available versions with "(current)" indicator for live version
- Validate requested versions exist before loading comparison
- Show specific error message when invalid version is requested (e.g., "Version 99 does not exist. Available versions: 1, 2")
- Dynamic "View Version" button labels based on selected versions

## Test plan

- [ ] View a memory with multiple versions - current version should appear in version history list
- [ ] Navigate to compare view - version selectors should be populated
- [ ] Change version selection and click Compare - should navigate to new comparison
- [ ] Try invalid version URL (e.g., `/compare/1/99`) - should show specific error message