### PR TITLE
Add memory similarity discovery feature

### DIFF
--- a/docs/adr/2025-11-28-memory-similarity-discovery.md
+++ b/docs/adr/2025-11-28-memory-similarity-discovery.md
@@ -1,0 +1,113 @@
+# ADR: Memory Similarity Discovery Feature
+
+**Date:** 2025-11-28
+**Status:** Accepted
+**Context:** Pre-workspace/project taxonomy feature for evaluating embedding quality
+
+## Decision
+
+Implement a "Similar Memories" feature in the memory detail view that:
+1. Uses pgvector similarity search to surface related memories on-demand
+2. Allows users to optionally persist confirmed similarities as bidirectional `similar-to` relationships with scores
+3. Provides configurable threshold (default 70%, adjustable via UI slider)
+
+## Context
+
+- Production Memorizer has ~1,900 memories with 384-dimension embeddings
+- This feature serves as a stepping stone before implementing workspace/project taxonomy
+- Helps validate embedding model quality after changes (post-1.9.0-beta1)
+- Relationships in Memorizer are currently one-directional; similar-to relationships need to be bidirectional for semantic correctness
+
+## Rationale
+
+### Why On-Demand vs Pre-Computed Similarity?
+
+We chose "Light Persistence" (on-demand queries with optional relationship creation) over:
+
+- **Full pre-computation**: Would require background jobs to maintain a large similarity matrix, complexity not justified for evaluation use case
+- **Pure ephemeral**: No persistence means users can't build a knowledge graph from discovered similarities
+
+### Why Bidirectional Relationships?
+
+Similarity is symmetric by definition (A similar to B implies B similar to A). Creating relationships in both directions:
+- Ensures consistency regardless of which memory is viewed
+- Shows "Similar Memories" correctly from either side
+- Stores the same score in both relationship records
+
+### Why Configurable Threshold?
+
+- Default threshold (70%) balances precision vs recall for typical content
+- Users can adjust per-session to explore different similarity levels
+- Configuration in appsettings.json allows deployment-specific tuning
+
+## Technical Approach
+
+### Schema Change
+
+Added `score` column to `memory_relationships` table:
+```sql
+ALTER TABLE memory_relationships
+ADD COLUMN score DOUBLE PRECISION DEFAULT NULL;
+```
+
+### Similarity Query
+
+Uses pgvector cosine distance operator:
+```sql
+SELECT m.id, m.title, m.type,
+       1 - (m.embedding <=> @sourceEmbedding) AS similarity
+FROM memories m
+WHERE m.id != @sourceId
+  AND 1 - (m.embedding <=> @sourceEmbedding) >= @minSimilarity
+ORDER BY m.embedding <=> @sourceEmbedding
+LIMIT @limit;
+```
+
+### API Endpoints
+
+- `GET /api/memory/{id}/similar?threshold=0.7&limit=10` - Query similar memories
+- `POST /api/memory/{id}/similar` - Create bidirectional relationships
+- `GET /api/memory/similarity/settings` - Get configured thresholds for UI
+
+## Consequences
+
+### Benefits
+
+- Users can evaluate embedding quality by exploring similar memories
+- Knowledge graph grows through user-confirmed relationships
+- Low implementation complexity (no background jobs, actors)
+- Configurable for different deployment needs
+
+### Trade-offs
+
+- Similarity is computed on-demand (minor latency on view)
+- No automatic relationship creation (requires user action)
+- Score stored redundantly in bidirectional relationships
+
+### Deferred Decisions
+
+The following were explicitly deferred for post-workspace/project implementation:
+- DBSCAN cluster discovery
+- LLM-generated cluster names
+- Background pre-computation
+- MCP tool exposure for similarity queries
+- Automatic relationship creation
+
+## Files Changed
+
+| File | Change Type |
+|------|-------------|
+| `src/Memorizer/appsettings.json` | MODIFY |
+| `src/Memorizer/Settings/SimilaritySettings.cs` | NEW |
+| `src/Memorizer/migrations/010_add_relationship_score.sql` | NEW |
+| `src/Memorizer/Models/MemoryRelationship.cs` | MODIFY |
+| `src/Memorizer/Models/SimilarMemory.cs` | NEW |
+| `src/Memorizer/Services/Memory.cs` | MODIFY |
+| `src/Memorizer/Controllers/MemoryController.cs` | MODIFY |
+| `src/Memorizer/Views/Home/View.cshtml` | MODIFY |
+| `src/Memorizer/wwwroot/css/site.css` | MODIFY |
+
+## Related
+
+- [Memorizer Evolution Master Plan](memorizer://memory/0dc98f5b-7f2c-44b9-940c-a16e97763de8)
+- [Implementation Plan](memorizer://memory/e3fd98d0-c2a3-4bf0-b5c4-b534a8cb8b47)

--- a/src/Memorizer.IntegrationTests/TitleGenerationActorTests.cs
+++ b/src/Memorizer.IntegrationTests/TitleGenerationActorTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Pgvector;
 using Xunit.Abstractions;
+using SimilarMemory = Memorizer.Models.SimilarMemory;
 
 namespace Memorizer.IntegrationTests;
 
@@ -180,8 +181,14 @@ public class TitleGenerationActorTests : TestKit
         public Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string relationshipType, CancellationToken cancellationToken = default)
             => throw new NotImplementedException("Test mock");
 
+        public Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string relationshipType, double? score, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException("Test mock");
+
         public Task<List<MemoryRelationship>> GetRelationships(Guid memoryId, string? relationshipType = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException("Test mock");
+
+        public Task<List<SimilarMemory>> GetSimilarMemories(Guid memoryId, double minSimilarity = 0.7, int limit = 10, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<SimilarMemory>());
 
         Task<List<string>> IStorage.GetDistinctMemoryTypes(CancellationToken cancellationToken)
             => Task.FromResult(new List<string> { "test", "mock" });
@@ -259,8 +266,14 @@ public class TitleGenerationActorTests : TestKit
         public Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string relationshipType, CancellationToken cancellationToken = default)
             => throw new NotImplementedException("Test mock");
 
+        public Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string relationshipType, double? score, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException("Test mock");
+
         public Task<List<MemoryRelationship>> GetRelationships(Guid memoryId, string? relationshipType = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException("Test mock");
+
+        public Task<List<SimilarMemory>> GetSimilarMemories(Guid memoryId, double minSimilarity = 0.7, int limit = 10, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<SimilarMemory>());
 
         public Task<List<Memory>> GetMemoriesWithoutTitles(int limit, CancellationToken cancellationToken = default)
             => Task.FromResult(new List<Memory>());

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -1,6 +1,8 @@
 using Memorizer.Models;
 using Memorizer.Services;
+using Memorizer.Settings;
 using Microsoft.AspNetCore.Mvc;
+using SimilarMemory = Memorizer.Models.SimilarMemory;
 
 // ReSharper disable ClassNeverInstantiated.Global
 
@@ -11,10 +13,12 @@ namespace Memorizer.Controllers;
 public class MemoryController : ControllerBase
 {
     private readonly IStorage _storage;
+    private readonly SimilaritySettings _similaritySettings;
 
-    public MemoryController(IStorage storage)
+    public MemoryController(IStorage storage, SimilaritySettings similaritySettings)
     {
         _storage = storage;
+        _similaritySettings = similaritySettings;
     }
 
     /// <summary>
@@ -404,6 +408,107 @@ public class MemoryController : ControllerBase
             Message = $"Purged {purged} old version(s), keeping latest {request.VersionsToKeep}"
         });
     }
+
+    // ==================== Similar Memory Discovery Endpoints ====================
+
+    /// <summary>
+    /// Get similarity settings (thresholds and limits) for the UI
+    /// </summary>
+    [HttpGet("similarity/settings")]
+    public ActionResult<SimilaritySettingsResponse> GetSimilaritySettings()
+    {
+        return Ok(new SimilaritySettingsResponse
+        {
+            DefaultThreshold = _similaritySettings.DefaultThreshold,
+            MinThreshold = _similaritySettings.MinThreshold,
+            MaxThreshold = _similaritySettings.MaxThreshold,
+            DefaultLimit = _similaritySettings.DefaultLimit
+        });
+    }
+
+    /// <summary>
+    /// Get memories similar to the specified memory using vector similarity search
+    /// </summary>
+    [HttpGet("{id}/similar")]
+    public async Task<ActionResult<SimilarMemoriesResponse>> GetSimilarMemories(
+        Guid id,
+        [FromQuery] double? threshold = null,
+        [FromQuery] int? limit = null)
+    {
+        var memory = await _storage.Get(id);
+        if (memory == null)
+        {
+            return NotFound();
+        }
+
+        // Use configured defaults if not specified
+        var effectiveThreshold = threshold ?? _similaritySettings.DefaultThreshold;
+        var effectiveLimit = limit ?? _similaritySettings.DefaultLimit;
+
+        // Clamp threshold to configured bounds
+        effectiveThreshold = Math.Clamp(effectiveThreshold, _similaritySettings.MinThreshold, _similaritySettings.MaxThreshold);
+
+        var similarMemories = await _storage.GetSimilarMemories(id, effectiveThreshold, effectiveLimit);
+
+        return Ok(new SimilarMemoriesResponse
+        {
+            SourceMemoryId = id,
+            Threshold = effectiveThreshold,
+            Limit = effectiveLimit,
+            SimilarMemories = similarMemories
+        });
+    }
+
+    /// <summary>
+    /// Create bidirectional 'similar-to' relationships between memories with similarity scores
+    /// </summary>
+    [HttpPost("{id}/similar")]
+    public async Task<ActionResult<CreateSimilarRelationshipsResponse>> CreateSimilarRelationships(
+        Guid id,
+        [FromBody] CreateSimilarRelationshipsRequest request)
+    {
+        var sourceMemory = await _storage.Get(id);
+        if (sourceMemory == null)
+        {
+            return NotFound();
+        }
+
+        if (request.Relationships == null || request.Relationships.Count == 0)
+        {
+            return BadRequest("At least one relationship must be specified");
+        }
+
+        var createdRelationships = new List<MemoryRelationship>();
+        var errors = new List<string>();
+
+        foreach (var rel in request.Relationships)
+        {
+            // Validate the target memory exists
+            var targetMemory = await _storage.Get(rel.TargetMemoryId);
+            if (targetMemory == null)
+            {
+                errors.Add($"Target memory {rel.TargetMemoryId} not found");
+                continue;
+            }
+
+            // Create bidirectional relationships
+            // Source -> Target
+            var forwardRel = await _storage.CreateRelationship(id, rel.TargetMemoryId, "similar-to", rel.Score);
+            createdRelationships.Add(forwardRel);
+
+            // Target -> Source (same score, bidirectional)
+            var backwardRel = await _storage.CreateRelationship(rel.TargetMemoryId, id, "similar-to", rel.Score);
+            createdRelationships.Add(backwardRel);
+        }
+
+        return Ok(new CreateSimilarRelationshipsResponse
+        {
+            SourceMemoryId = id,
+            RelationshipsCreated = createdRelationships.Count,
+            Relationships = createdRelationships,
+            Errors = errors
+        });
+    }
 }
 
 public class MemoryListResponse
@@ -482,4 +587,51 @@ public class PurgeResult
 {
     public int VersionsPurged { get; set; }
     public string Message { get; set; } = string.Empty;
+}
+
+// ==================== Similarity Discovery DTOs ====================
+
+public class SimilaritySettingsResponse
+{
+    public double DefaultThreshold { get; set; }
+    public double MinThreshold { get; set; }
+    public double MaxThreshold { get; set; }
+    public int DefaultLimit { get; set; }
+}
+
+public class SimilarMemoriesResponse
+{
+    public Guid SourceMemoryId { get; set; }
+    public double Threshold { get; set; }
+    public int Limit { get; set; }
+    public List<SimilarMemory> SimilarMemories { get; set; } = [];
+}
+
+public class CreateSimilarRelationshipsRequest
+{
+    /// <summary>
+    /// List of relationships to create (each will be created bidirectionally)
+    /// </summary>
+    public List<SimilarRelationshipItem> Relationships { get; set; } = [];
+}
+
+public class SimilarRelationshipItem
+{
+    /// <summary>
+    /// ID of the target memory to create a relationship with
+    /// </summary>
+    public Guid TargetMemoryId { get; set; }
+
+    /// <summary>
+    /// Similarity score (0.0 to 1.0)
+    /// </summary>
+    public double Score { get; set; }
+}
+
+public class CreateSimilarRelationshipsResponse
+{
+    public Guid SourceMemoryId { get; set; }
+    public int RelationshipsCreated { get; set; }
+    public List<MemoryRelationship> Relationships { get; set; } = [];
+    public List<string> Errors { get; set; } = [];
 } 

--- a/src/Memorizer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Memorizer/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
         services.AddServerSettings();
         services.AddCorsSettings();
         services.AddVersioningSettings();
+        services.AddSimilaritySettings();
         if(initialize)
             services.AddHostedService<InitializationService>();
         services.AutoRegisterTypesInAssemblies(typeof(Storage).Assembly);
@@ -171,6 +172,16 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<VersioningSettings>(sp =>
             sp.GetRequiredService<IConfiguration>().GetSection("Versioning").Get<VersioningSettings>() ??
             new VersioningSettings());
+
+        return services;
+    }
+
+    public static IServiceCollection AddSimilaritySettings(
+        this IServiceCollection services)
+    {
+        services.AddSingleton<SimilaritySettings>(sp =>
+            sp.GetRequiredService<IConfiguration>().GetSection("Similarity").Get<SimilaritySettings>() ??
+            new SimilaritySettings());
 
         return services;
     }

--- a/src/Memorizer/Models/MemoryRelationship.cs
+++ b/src/Memorizer/Models/MemoryRelationship.cs
@@ -11,4 +11,10 @@ public class MemoryRelationship
     public int? DeletedInVersion { get; init; }
     public string? RelatedMemoryTitle { get; set; }
     public string? RelatedMemoryType { get; set; }
+
+    /// <summary>
+    /// Similarity score (0.0 to 1.0) for 'similar-to' relationships.
+    /// Null for other relationship types.
+    /// </summary>
+    public double? Score { get; init; }
 } 

--- a/src/Memorizer/Models/SimilarMemory.cs
+++ b/src/Memorizer/Models/SimilarMemory.cs
@@ -1,0 +1,22 @@
+namespace Memorizer.Models;
+
+/// <summary>
+/// Represents a memory that is similar to another memory,
+/// including similarity score and relationship status.
+/// </summary>
+public class SimilarMemory
+{
+    public Guid Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Similarity score from 0.0 to 1.0 (higher is more similar).
+    /// </summary>
+    public double Similarity { get; init; }
+
+    /// <summary>
+    /// Whether a relationship already exists between the source memory and this one.
+    /// </summary>
+    public bool HasExistingRelationship { get; init; }
+}

--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -8,6 +8,7 @@ using Registrator.Net;
 using MemoryRelationship = Memorizer.Models.MemoryRelationship;
 using MemoryEvent = Memorizer.Models.MemoryEvent;
 using MemoryVersion = Memorizer.Models.MemoryVersion;
+using SimilarMemory = Memorizer.Models.SimilarMemory;
 
 namespace Memorizer.Services;
 
@@ -45,7 +46,11 @@ public interface IStorage
 
     Task<List<Memorizer.Models.Memory>> GetMany(IEnumerable<Guid> ids, CancellationToken cancellationToken = default);
     Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string type, CancellationToken cancellationToken = default);
+    Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string type, double? score, CancellationToken cancellationToken = default);
     Task<List<MemoryRelationship>> GetRelationships(Guid memoryId, string? type = null, CancellationToken cancellationToken = default);
+
+    // Similarity discovery
+    Task<List<SimilarMemory>> GetSimilarMemories(Guid memoryId, double minSimilarity = 0.7, int limit = 10, CancellationToken cancellationToken = default);
     
     // Pagination support
     Task<(List<Memorizer.Models.Memory> Memories, int TotalCount)> GetMemoriesPaginated(
@@ -487,19 +492,25 @@ public class Storage : IStorage
         return memories;
     }
 
-    public async Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string type, CancellationToken cancellationToken = default)
+    public Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string type, CancellationToken cancellationToken = default)
+    {
+        return CreateRelationship(fromId, toId, type, null, cancellationToken);
+    }
+
+    public async Task<MemoryRelationship> CreateRelationship(Guid fromId, Guid toId, string type, double? score, CancellationToken cancellationToken = default)
     {
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
         const string sql = @"
-            INSERT INTO memory_relationships (id, from_memory_id, to_memory_id, type, created_at)
-            VALUES (@id, @from, @to, @type, @createdAt)";
+            INSERT INTO memory_relationships (id, from_memory_id, to_memory_id, type, created_at, score)
+            VALUES (@id, @from, @to, @type, @createdAt, @score)";
         var rel = new MemoryRelationship
         {
             Id = Guid.NewGuid(),
             FromMemoryId = fromId,
             ToMemoryId = toId,
             Type = type,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            Score = score
         };
         await using NpgsqlCommand cmd = new(sql, connection);
         cmd.Parameters.AddWithValue("id", rel.Id);
@@ -507,6 +518,7 @@ public class Storage : IStorage
         cmd.Parameters.AddWithValue("to", rel.ToMemoryId);
         cmd.Parameters.AddWithValue("type", type);
         cmd.Parameters.AddWithValue("createdAt", rel.CreatedAt);
+        cmd.Parameters.AddWithValue("score", score.HasValue ? score.Value : DBNull.Value);
         await cmd.ExecuteNonQueryAsync(cancellationToken);
         return rel;
     }
@@ -514,26 +526,26 @@ public class Storage : IStorage
     public async Task<List<MemoryRelationship>> GetRelationships(Guid memoryId, string? type = null, CancellationToken cancellationToken = default)
     {
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
-        
+
         // Single query with JOIN to get relationships and related memory titles/types - NO RECURSION!
         string sql = @"
             SELECT r.id, r.from_memory_id, r.to_memory_id, r.type, r.created_at,
-                   m.title as related_title, m.type as related_type
+                   m.title as related_title, m.type as related_type, r.score
             FROM memory_relationships r
             LEFT JOIN memories m ON r.to_memory_id = m.id
             WHERE r.from_memory_id = @id";
-            
+
         if (!string.IsNullOrEmpty(type))
             sql += " AND r.type = @type";
-            
+
         await using NpgsqlCommand cmd = new(sql, connection);
         cmd.Parameters.AddWithValue("id", memoryId);
         if (!string.IsNullOrEmpty(type))
             cmd.Parameters.AddWithValue("type", type);
-            
+
         List<MemoryRelationship> rels = [];
         await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-        
+
         while (await reader.ReadAsync(cancellationToken))
         {
             var rel = new MemoryRelationship
@@ -544,12 +556,76 @@ public class Storage : IStorage
                 Type = reader.GetString(3),
                 CreatedAt = reader.GetDateTime(4),
                 RelatedMemoryTitle = reader.IsDBNull(5) ? null : reader.GetString(5),
-                RelatedMemoryType = reader.IsDBNull(6) ? null : reader.GetString(6)
+                RelatedMemoryType = reader.IsDBNull(6) ? null : reader.GetString(6),
+                Score = reader.IsDBNull(7) ? null : reader.GetDouble(7)
             };
             rels.Add(rel);
         }
-        
+
         return rels;
+    }
+
+    public async Task<List<SimilarMemory>> GetSimilarMemories(Guid memoryId, double minSimilarity = 0.7, int limit = 10, CancellationToken cancellationToken = default)
+    {
+        await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+
+        // First, get the source memory's embedding
+        const string getEmbeddingSql = "SELECT embedding FROM memories WHERE id = @id";
+        await using NpgsqlCommand getEmbeddingCmd = new(getEmbeddingSql, connection);
+        getEmbeddingCmd.Parameters.AddWithValue("id", memoryId);
+
+        var embeddingResult = await getEmbeddingCmd.ExecuteScalarAsync(cancellationToken);
+        if (embeddingResult is null || embeddingResult is DBNull)
+        {
+            return []; // No embedding for this memory
+        }
+
+        var sourceEmbedding = (Vector)embeddingResult;
+
+        // Convert similarity threshold to distance threshold
+        // pgvector uses cosine distance where 0 = identical, 2 = opposite
+        // similarity = 1 - distance, so distance = 1 - similarity
+        double maxDistance = 1.0 - minSimilarity;
+
+        // Query for similar memories, excluding self and checking for existing relationships
+        const string sql = @"
+            SELECT m.id, m.title, m.type,
+                   1 - (m.embedding <=> @embedding) AS similarity,
+                   CASE WHEN EXISTS (
+                       SELECT 1 FROM memory_relationships r
+                       WHERE (r.from_memory_id = @sourceId AND r.to_memory_id = m.id)
+                          OR (r.from_memory_id = m.id AND r.to_memory_id = @sourceId)
+                   ) THEN true ELSE false END AS has_relationship
+            FROM memories m
+            WHERE m.id != @sourceId
+              AND m.embedding IS NOT NULL
+              AND m.embedding <=> @embedding < @maxDistance
+            ORDER BY m.embedding <=> @embedding
+            LIMIT @limit";
+
+        await using NpgsqlCommand cmd = new(sql, connection);
+        cmd.Parameters.AddWithValue("embedding", sourceEmbedding);
+        cmd.Parameters.AddWithValue("sourceId", memoryId);
+        cmd.Parameters.AddWithValue("maxDistance", maxDistance);
+        cmd.Parameters.AddWithValue("limit", limit);
+
+        List<SimilarMemory> results = [];
+        await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var similar = new SimilarMemory
+            {
+                Id = reader.GetGuid(0),
+                Title = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+                Type = reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+                Similarity = reader.GetDouble(3),
+                HasExistingRelationship = reader.GetBoolean(4)
+            };
+            results.Add(similar);
+        }
+
+        return results;
     }
 
     public async Task<(List<Memorizer.Models.Memory> Memories, int TotalCount)> GetMemoriesPaginated(

--- a/src/Memorizer/Settings/SimilaritySettings.cs
+++ b/src/Memorizer/Settings/SimilaritySettings.cs
@@ -1,0 +1,27 @@
+namespace Memorizer.Settings;
+
+/// <summary>
+/// Settings for the memory similarity discovery feature.
+/// </summary>
+public class SimilaritySettings
+{
+    /// <summary>
+    /// Default similarity threshold (0.0 to 1.0). Memories with similarity below this won't be shown.
+    /// </summary>
+    public double DefaultThreshold { get; init; } = 0.7;
+
+    /// <summary>
+    /// Minimum threshold the UI slider can be set to.
+    /// </summary>
+    public double MinThreshold { get; init; } = 0.5;
+
+    /// <summary>
+    /// Maximum threshold the UI slider can be set to.
+    /// </summary>
+    public double MaxThreshold { get; init; } = 0.95;
+
+    /// <summary>
+    /// Default number of similar memories to return.
+    /// </summary>
+    public int DefaultLimit { get; init; } = 10;
+}

--- a/src/Memorizer/Views/Home/View.cshtml
+++ b/src/Memorizer/Views/Home/View.cshtml
@@ -112,6 +112,85 @@
                         </div>
                     </div>
 
+                    <!-- Similar Memories Discovery section -->
+                    <div id="similarMemoriesSection" class="mt-4">
+                        <div class="card">
+                            <div class="card-header">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <h5 class="mb-0">
+                                        <i class="fas fa-brain me-2"></i>
+                                        Similar Memories
+                                    </h5>
+                                    <button type="button" class="btn btn-sm btn-light" onclick="toggleSimilarMemoriesSettings()" title="Adjust similarity settings">
+                                        <i class="fas fa-sliders-h"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                <!-- Settings panel (collapsed by default) -->
+                                <div id="similarMemoriesSettings" class="mb-3" style="display:none;">
+                                    <div class="card bg-light similar-settings-card">
+                                        <div class="card-body py-2">
+                                            <div class="row align-items-center g-3">
+                                                <div class="col-md-8">
+                                                    <label for="similarityThreshold" class="form-label mb-1 small">
+                                                        Similarity Threshold: <span id="thresholdValue" class="fw-bold">70%</span>
+                                                    </label>
+                                                    <input type="range" class="form-range" id="similarityThreshold"
+                                                           min="50" max="95" step="5" value="70"
+                                                           oninput="updateThresholdDisplay(this.value)">
+                                                    <div class="d-flex justify-content-between small text-muted">
+                                                        <span>More results</span>
+                                                        <span>More similar</span>
+                                                    </div>
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <button type="button" class="btn btn-primary btn-sm w-100" onclick="loadSimilarMemories()">
+                                                        <i class="fas fa-search me-1"></i>
+                                                        Search
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Loading state -->
+                                <div id="similarMemoriesLoading" class="text-center py-3">
+                                    <div class="spinner-border spinner-border-sm text-primary" role="status">
+                                        <span class="visually-hidden">Finding similar memories...</span>
+                                    </div>
+                                    <p class="text-muted small mt-2 mb-0">Searching for similar memories...</p>
+                                </div>
+
+                                <!-- Empty state -->
+                                <div id="similarMemoriesEmpty" style="display:none;">
+                                    <p class="text-muted mb-0">
+                                        <i class="fas fa-info-circle me-2"></i>
+                                        No similar memories found. Try lowering the similarity threshold.
+                                    </p>
+                                </div>
+
+                                <!-- Results -->
+                                <div id="similarMemoriesContent" style="display:none;">
+                                    <div class="d-flex justify-content-between align-items-center mb-3">
+                                        <small class="text-muted">
+                                            Found <span id="similarMemoriesCount">0</span> similar memories
+                                        </small>
+                                        <button type="button" class="btn btn-success btn-sm" id="createRelationshipsBtn"
+                                                onclick="createSelectedRelationships()" style="display:none;">
+                                            <i class="fas fa-link me-1"></i>
+                                            Link Selected (<span id="selectedCount">0</span>)
+                                        </button>
+                                    </div>
+                                    <div id="similarMemoriesList">
+                                        <!-- Similar memories will be inserted here -->
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Version History section -->
                     <div class="mt-4">
                         <div class="card">
@@ -623,5 +702,201 @@ async function confirmRevert() {
         btn.disabled = false;
     }
 }
+
+// =====================
+// Similar Memories Functions
+// =====================
+
+let similaritySettings = {
+    defaultThreshold: 0.7,
+    minThreshold: 0.5,
+    maxThreshold: 0.95,
+    defaultLimit: 10
+};
+let selectedSimilarMemories = new Map(); // Map of id -> {score, title}
+
+// Load similarity settings from server
+async function loadSimilaritySettings() {
+    try {
+        const response = await fetch('/api/memory/similarity/settings');
+        if (response.ok) {
+            similaritySettings = await response.json();
+            // Update slider bounds and default value
+            const slider = document.getElementById('similarityThreshold');
+            slider.min = Math.round(similaritySettings.minThreshold * 100);
+            slider.max = Math.round(similaritySettings.maxThreshold * 100);
+            slider.value = Math.round(similaritySettings.defaultThreshold * 100);
+            updateThresholdDisplay(slider.value);
+        }
+    } catch (error) {
+        console.warn('Could not load similarity settings, using defaults:', error);
+    }
+}
+
+function toggleSimilarMemoriesSettings() {
+    const settings = document.getElementById('similarMemoriesSettings');
+    settings.style.display = settings.style.display === 'none' ? 'block' : 'none';
+}
+
+function updateThresholdDisplay(value) {
+    document.getElementById('thresholdValue').textContent = value + '%';
+}
+
+async function loadSimilarMemories() {
+    const loadingEl = document.getElementById('similarMemoriesLoading');
+    const emptyEl = document.getElementById('similarMemoriesEmpty');
+    const contentEl = document.getElementById('similarMemoriesContent');
+    const listEl = document.getElementById('similarMemoriesList');
+
+    // Show loading state
+    loadingEl.style.display = 'block';
+    emptyEl.style.display = 'none';
+    contentEl.style.display = 'none';
+
+    try {
+        const threshold = document.getElementById('similarityThreshold').value / 100;
+        const response = await fetch(`/api/memory/${memoryId}/similar?threshold=${threshold}&limit=${similaritySettings.defaultLimit}`);
+
+        if (!response.ok) {
+            throw new Error('Failed to load similar memories');
+        }
+
+        const data = await response.json();
+        loadingEl.style.display = 'none';
+
+        if (!data.similarMemories || data.similarMemories.length === 0) {
+            emptyEl.style.display = 'block';
+            return;
+        }
+
+        // Clear previous selection
+        selectedSimilarMemories.clear();
+        updateSelectionUI();
+
+        // Display results
+        document.getElementById('similarMemoriesCount').textContent = data.similarMemories.length;
+        listEl.innerHTML = '';
+
+        data.similarMemories.forEach(mem => {
+            const similarityPercent = (mem.similarity * 100).toFixed(1);
+            const hasRelationship = mem.hasExistingRelationship;
+
+            const item = document.createElement('div');
+            item.className = 'similar-memory-item d-flex align-items-start p-3 border-bottom';
+            item.innerHTML = `
+                <div class="form-check me-3" style="min-width: 25px;">
+                    ${!hasRelationship ? `
+                    <input class="form-check-input similar-memory-checkbox" type="checkbox"
+                           id="similar-${mem.id}" data-id="${mem.id}" data-score="${mem.similarity}" data-title="${escapeHtml(mem.title)}"
+                           onchange="toggleSimilarMemorySelection('${mem.id}', ${mem.similarity}, '${escapeHtml(mem.title).replace(/'/g, "\\'")}')">
+                    ` : ''}
+                </div>
+                <div class="flex-grow-1">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <h6 class="mb-1">
+                                <a href="/ui/view/${mem.id}" class="text-decoration-none">
+                                    ${escapeHtml(mem.title || 'Untitled')}
+                                </a>
+                            </h6>
+                            <span class="badge bg-secondary me-2">${escapeHtml(mem.type)}</span>
+                            ${hasRelationship ?
+                                '<span class="badge bg-success"><i class="fas fa-check me-1"></i>Already linked</span>' :
+                                ''}
+                        </div>
+                        <div class="text-end">
+                            <div class="similarity-score ${getSimilarityClass(mem.similarity)}">
+                                ${similarityPercent}%
+                            </div>
+                            <small class="text-muted">similarity</small>
+                        </div>
+                    </div>
+                </div>
+            `;
+            listEl.appendChild(item);
+        });
+
+        contentEl.style.display = 'block';
+    } catch (error) {
+        console.error('Error loading similar memories:', error);
+        loadingEl.style.display = 'none';
+        emptyEl.innerHTML = '<p class="text-danger mb-0"><i class="fas fa-exclamation-triangle me-2"></i>Error loading similar memories. Please try again.</p>';
+        emptyEl.style.display = 'block';
+    }
+}
+
+function getSimilarityClass(similarity) {
+    if (similarity >= 0.9) return 'similarity-very-high';
+    if (similarity >= 0.8) return 'similarity-high';
+    if (similarity >= 0.7) return 'similarity-medium';
+    return 'similarity-low';
+}
+
+function toggleSimilarMemorySelection(id, score, title) {
+    if (selectedSimilarMemories.has(id)) {
+        selectedSimilarMemories.delete(id);
+    } else {
+        selectedSimilarMemories.set(id, { score, title });
+    }
+    updateSelectionUI();
+}
+
+function updateSelectionUI() {
+    const count = selectedSimilarMemories.size;
+    const btn = document.getElementById('createRelationshipsBtn');
+    const countSpan = document.getElementById('selectedCount');
+
+    countSpan.textContent = count;
+    btn.style.display = count > 0 ? 'inline-block' : 'none';
+}
+
+async function createSelectedRelationships() {
+    if (selectedSimilarMemories.size === 0) return;
+
+    const btn = document.getElementById('createRelationshipsBtn');
+    const originalText = btn.innerHTML;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Linking...';
+    btn.disabled = true;
+
+    try {
+        const relationships = Array.from(selectedSimilarMemories.entries()).map(([id, data]) => ({
+            targetMemoryId: id,
+            score: data.score
+        }));
+
+        const response = await fetch(`/api/memory/${memoryId}/similar`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ relationships })
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to create relationships');
+        }
+
+        const result = await response.json();
+
+        // Show success message
+        const count = result.relationshipsCreated / 2; // Divide by 2 since bidirectional
+        alert(`Successfully linked ${count} similar ${count === 1 ? 'memory' : 'memories'}.`);
+
+        // Reload the page to show updated relationships
+        window.location.reload();
+    } catch (error) {
+        console.error('Error creating relationships:', error);
+        alert('Failed to create relationships. Please try again.');
+        btn.innerHTML = originalText;
+        btn.disabled = false;
+    }
+}
+
+// Initialize similar memories on page load
+document.addEventListener('DOMContentLoaded', function() {
+    // Load similarity settings then load similar memories
+    loadSimilaritySettings().then(() => {
+        // Small delay to let the memory load first
+        setTimeout(() => loadSimilarMemories(), 500);
+    });
+});
 </script>
 }

--- a/src/Memorizer/appsettings.json
+++ b/src/Memorizer/appsettings.json
@@ -29,5 +29,11 @@
   },
   "Versioning": {
     "MaxVersionsPerMemory": 50
+  },
+  "Similarity": {
+    "DefaultThreshold": 0.7,
+    "MinThreshold": 0.5,
+    "MaxThreshold": 0.95,
+    "DefaultLimit": 10
   }
 } 

--- a/src/Memorizer/migrations/010_add_relationship_score.sql
+++ b/src/Memorizer/migrations/010_add_relationship_score.sql
@@ -1,0 +1,14 @@
+-- Add score column to memory_relationships for similarity scoring
+-- This enables storing similarity scores when creating 'similar-to' relationships
+
+ALTER TABLE memory_relationships
+ADD COLUMN IF NOT EXISTS score DOUBLE PRECISION DEFAULT NULL;
+
+-- Index for efficient querying of scored relationships
+-- Partial index only covers rows with scores (similarity relationships)
+CREATE INDEX IF NOT EXISTS idx_memory_relationships_score
+ON memory_relationships(score)
+WHERE score IS NOT NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN memory_relationships.score IS 'Similarity score (0.0 to 1.0) for similar-to relationships. NULL for other relationship types.';

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -280,3 +280,103 @@ footer a:hover {
 .theme-toggle-btn:hover {
     transform: scale(1.1);
 }
+
+/* =================================================================
+   SIMILAR MEMORIES DISCOVERY STYLES
+   ================================================================= */
+
+/* Similar memory item */
+.similar-memory-item {
+    transition: background-color 0.2s ease;
+}
+
+.similar-memory-item:hover {
+    background-color: var(--surface-card-alt);
+}
+
+.similar-memory-item:last-child {
+    border-bottom: none !important;
+}
+
+/* Similarity score display */
+.similarity-score {
+    font-size: 1.25rem;
+    font-weight: bold;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+}
+
+/* Light mode similarity colors */
+.similarity-very-high {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.similarity-high {
+    background-color: #cce5ff;
+    color: #004085;
+}
+
+.similarity-medium {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+.similarity-low {
+    background-color: #f8d7da;
+    color: #721c24;
+}
+
+/* Dark mode similarity colors */
+[data-theme="dark"] .similarity-very-high {
+    background-color: #1e4620;
+    color: #75d47b;
+}
+
+[data-theme="dark"] .similarity-high {
+    background-color: #1a365d;
+    color: #90cdf4;
+}
+
+[data-theme="dark"] .similarity-medium {
+    background-color: #5c4813;
+    color: #f6e05e;
+}
+
+[data-theme="dark"] .similarity-low {
+    background-color: #5c1f1f;
+    color: #f56565;
+}
+
+/* Similar settings card */
+.similar-settings-card {
+    background-color: var(--surface-card-alt) !important;
+}
+
+[data-theme="dark"] .similar-settings-card {
+    background-color: var(--surface-card-alt) !important;
+    border-color: var(--border-default) !important;
+}
+
+/* Slider styling */
+.form-range {
+    cursor: pointer;
+}
+
+[data-theme="dark"] .form-range::-webkit-slider-track {
+    background-color: var(--border-default);
+}
+
+[data-theme="dark"] .form-range::-moz-range-track {
+    background-color: var(--border-default);
+}
+
+/* Similar memory checkbox alignment */
+.similar-memory-checkbox {
+    margin-top: 0.25rem;
+}
+
+/* Border color in dark mode for similar items */
+[data-theme="dark"] .similar-memory-item {
+    border-color: var(--border-default) !important;
+}

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -371,12 +371,38 @@ footer a:hover {
     background-color: var(--border-default);
 }
 
-/* Similar memory checkbox alignment */
+/* Similar memory checkbox alignment and visibility */
 .similar-memory-checkbox {
     margin-top: 0.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 2px solid #6c757d;
+    cursor: pointer;
+}
+
+.similar-memory-checkbox:checked {
+    background-color: var(--brand-primary);
+    border-color: var(--brand-primary);
 }
 
 /* Border color in dark mode for similar items */
 [data-theme="dark"] .similar-memory-item {
     border-color: var(--border-default) !important;
+}
+
+/* Light mode slider track - better contrast */
+.form-range::-webkit-slider-runnable-track {
+    background-color: #dee2e6;
+}
+
+.form-range::-moz-range-track {
+    background-color: #dee2e6;
+}
+
+.form-range::-webkit-slider-thumb {
+    background-color: var(--brand-primary);
+}
+
+.form-range::-moz-range-thumb {
+    background-color: var(--brand-primary);
 }


### PR DESCRIPTION
## Summary

- Add on-demand vector similarity search to surface related memories in the memory detail view
- Allow users to persist discovered similarities as bidirectional `similar-to` relationships with scores
- Configurable similarity threshold (default 70%, adjustable 50-95% via UI slider)

## Changes

### Backend
- Add `SimilaritySettings` configuration class with threshold bounds and defaults
- Add database migration for `score` column on `memory_relationships` table
- Add `SimilarMemory` model for similarity query results
- Extend `IStorage` with `GetSimilarMemories` and `CreateRelationship` (with score) methods
- Add API endpoints:
  - `GET /api/memory/similarity/settings` - Returns configured thresholds
  - `GET /api/memory/{id}/similar` - Query similar memories
  - `POST /api/memory/{id}/similar` - Create bidirectional relationships

### Frontend
- Add "Similar Memories" section to memory detail view
- Adjustable threshold slider with search button
- Checkbox selection for creating relationships
- Color-coded similarity scores (very-high/high/medium/low)
- Light and dark theme support

### Documentation
- Add ADR documenting design decisions

## Test plan

- [x] Build succeeds
- [x] All 100 tests pass
- [ ] View memory with similar content → verify similar memories appear
- [ ] Adjust threshold slider → verify results update
- [ ] Select memories and link → verify bidirectional relationships created
- [ ] Refresh page → verify new relationships appear in "Related Memories"