### PR TITLE
Fix warning button text visibility in dark mode

### DIFF
--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -267,6 +267,20 @@ footer a:hover {
     text-decoration: underline;
 }
 
+/* Warning button styling for dark mode - ensure text visibility */
+[data-theme="dark"] .btn-warning {
+    background-color: #ffc107;
+    border-color: #ffc107;
+    color: #000;
+}
+
+[data-theme="dark"] .btn-warning:hover,
+[data-theme="dark"] .btn-warning:focus {
+    background-color: #ffca2c;
+    border-color: #ffc720;
+    color: #000;
+}
+
 /* Spinner styling */
 [data-theme="dark"] .spinner-border.text-primary {
     color: var(--brand-primary) !important;


### PR DESCRIPTION
## Summary
- Fixed the "Run Migration Tool" button in the dimension mismatch warning banner being invisible in dark mode
- Added explicit dark mode CSS styling for `btn-warning` class to ensure yellow background with black text

## Test plan
- [ ] Navigate to a page showing the "Embedding Dimension Mismatch Detected" warning banner
- [ ] Toggle to dark mode and verify the "Run Migration Tool" button is now visible with yellow background and black text
- [ ] Verify hover state also maintains proper contrast