### PR TITLE
Switch search and similarity to use metadata embeddings

### DIFF
--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -569,15 +569,16 @@ public class Storage : IStorage
     {
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
 
-        // First, get the source memory's embedding
-        const string getEmbeddingSql = "SELECT embedding FROM memories WHERE id = @id";
+        // Get the source memory's metadata embedding (title + tags)
+        // Using metadata embeddings for better keyword-style similarity matching
+        const string getEmbeddingSql = "SELECT embedding_metadata FROM memories WHERE id = @id";
         await using NpgsqlCommand getEmbeddingCmd = new(getEmbeddingSql, connection);
         getEmbeddingCmd.Parameters.AddWithValue("id", memoryId);
 
         var embeddingResult = await getEmbeddingCmd.ExecuteScalarAsync(cancellationToken);
         if (embeddingResult is null || embeddingResult is DBNull)
         {
-            return []; // No embedding for this memory
+            return []; // No metadata embedding for this memory
         }
 
         var sourceEmbedding = (Vector)embeddingResult;
@@ -587,10 +588,10 @@ public class Storage : IStorage
         // similarity = 1 - distance, so distance = 1 - similarity
         double maxDistance = 1.0 - minSimilarity;
 
-        // Query for similar memories, excluding self and checking for existing relationships
+        // Query for similar memories using metadata embeddings, excluding self and checking for existing relationships
         const string sql = @"
             SELECT m.id, m.title, m.type,
-                   1 - (m.embedding <=> @embedding) AS similarity,
+                   1 - (m.embedding_metadata <=> @embedding) AS similarity,
                    CASE WHEN EXISTS (
                        SELECT 1 FROM memory_relationships r
                        WHERE (r.from_memory_id = @sourceId AND r.to_memory_id = m.id)
@@ -598,9 +599,9 @@ public class Storage : IStorage
                    ) THEN true ELSE false END AS has_relationship
             FROM memories m
             WHERE m.id != @sourceId
-              AND m.embedding IS NOT NULL
-              AND m.embedding <=> @embedding < @maxDistance
-            ORDER BY m.embedding <=> @embedding
+              AND m.embedding_metadata IS NOT NULL
+              AND m.embedding_metadata <=> @embedding < @maxDistance
+            ORDER BY m.embedding_metadata <=> @embedding
             LIMIT @limit";
 
         await using NpgsqlCommand cmd = new(sql, connection);

--- a/src/Memorizer/Tools/MemoryTools.cs
+++ b/src/Memorizer/Tools/MemoryTools.cs
@@ -239,8 +239,9 @@ public class MemoryTools
             {"query.filterTags", filterTags != null ? string.Join(", ", filterTags) : "none"}
         }));
 
-        // Search for similar memories
-        List<Memory> memories = await _storage.Search(
+        // Search for similar memories using metadata embeddings (title + tags)
+        // This is optimized for keyword-style LLM queries vs full content embeddings
+        List<Memory> memories = await _storage.SearchWithMetadataEmbedding(
             query,
             limit,
             minSimilarity,
@@ -267,7 +268,7 @@ public class MemoryTools
                 {"original.threshold", minSimilarity.ToString()}
             }));
 
-            memories = await _storage.Search(
+            memories = await _storage.SearchWithMetadataEmbedding(
                 query,
                 limit,
                 fallbackThreshold,


### PR DESCRIPTION
## Summary
- Update MCP `SearchMemories` tool to use `SearchWithMetadataEmbedding` instead of `Search`
- Update `GetSimilarMemories` storage method to compare `embedding_metadata` columns instead of `embedding`
- Aligns MCP tool behavior with web UI search which already uses metadata embeddings

## Why
Full content embeddings dilute keyword signals with detailed body text, resulting in poor similarity scores for keyword-style LLM queries. For example, searching "Ollama" would return generic LLM-related content instead of actual Ollama-specific memories.

Metadata embeddings (title + tags) preserve keyword signals and provide much better results:
- Web UI search at 0.7 threshold: Multiple results with 80-86% similarity
- MCP search at 0.7 threshold (before): 1 result, not even Ollama-specific
- Similarity discovery at 0.5 threshold (before): Only 2 results for obviously related content

## Test plan
- [x] All 100 integration tests pass
- [ ] Verify MCP `SearchMemories` returns better results for keyword queries
- [ ] Verify similarity discovery surfaces more related memories