### PR TITLE
Add lightweight search results to optimize context window usage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,16 @@ MEMORIZER_Server__CanonicalUrl=example.com:8080
 
 For security-related configuration (CORS, database security, etc.), see [docs/security.md](security.md).
 
+### Search Settings
+
+Configure how MCP search results are returned to agents:
+
+```bash
+MEMORIZER_Search__ReturnFullContent=false
+```
+
+- `MEMORIZER_Search__ReturnFullContent`: When `false` (default), MCP search returns lightweight results containing only ID, title, type, tags, similarity score, and creation date. Agents should use `Get` or `GetMany` tools to retrieve full memory content. When `true`, search returns the full memory body in results. **Default is `false` to optimize context window usage for LLM agents.**
+
 > ⚠️ **IMPORTANT**: Changing the `Dimensions` configuration after the database has been initialized will cause runtime errors. PostgreSQL's `pgvector` extension uses fixed-dimension columns that cannot accept vectors of different sizes. If you need to change dimensions:
 > 1. For new deployments: Set the desired dimension value before first run
 > 2. For existing databases: You must manually migrate the database by either:

--- a/src/Memorizer/Controllers/ConfigurationController.cs
+++ b/src/Memorizer/Controllers/ConfigurationController.cs
@@ -10,17 +10,20 @@ public class ConfigurationController : ControllerBase
     private readonly EmbeddingSettings _embeddingSettings;
     private readonly LlmSettings _llmSettings;
     private readonly ServerSettings _serverSettings;
+    private readonly SearchSettings _searchSettings;
     private readonly IConfiguration _configuration;
 
     public ConfigurationController(
         EmbeddingSettings embeddingSettings,
         LlmSettings llmSettings,
         ServerSettings serverSettings,
+        SearchSettings searchSettings,
         IConfiguration configuration)
     {
         _embeddingSettings = embeddingSettings;
         _llmSettings = llmSettings;
         _serverSettings = serverSettings;
+        _searchSettings = searchSettings;
         _configuration = configuration;
     }
 
@@ -32,22 +35,26 @@ public class ConfigurationController : ControllerBase
     {
         return Ok(new SystemConfiguration
         {
-            EmbeddingSettings = new
+            EmbeddingSettings = new EmbeddingConfigDto
             {
                 ApiConfigured = _embeddingSettings.ApiUrl != null,
                 Model = _embeddingSettings.Model,
                 Timeout = _embeddingSettings.Timeout.ToString()
             },
-            ServerSettings = new
+            ServerSettings = new ServerConfigDto
             {
                 CanonicalUrlConfigured = !string.IsNullOrEmpty(_serverSettings.CanonicalUrl),
                 CanonicalUrl = _serverSettings.CanonicalUrl
             },
-            ConnectionStrings = new
+            SearchSettings = new SearchConfigDto
+            {
+                ReturnFullContent = _searchSettings.ReturnFullContent
+            },
+            ConnectionStrings = new ConnectionStringsConfigDto
             {
                 StorageConfigured = !string.IsNullOrEmpty(_configuration.GetConnectionString("Storage"))
             },
-            Environment = new
+            Environment = new EnvironmentConfigDto
             {
                 AspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
                 OtelConfigured = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT")),
@@ -59,8 +66,39 @@ public class ConfigurationController : ControllerBase
 
 public class SystemConfiguration
 {
-    public object EmbeddingSettings { get; set; } = null!;
-    public object ServerSettings { get; set; } = null!;
-    public object ConnectionStrings { get; set; } = null!;
-    public object Environment { get; set; } = null!;
+    public EmbeddingConfigDto EmbeddingSettings { get; set; } = null!;
+    public ServerConfigDto ServerSettings { get; set; } = null!;
+    public SearchConfigDto SearchSettings { get; set; } = null!;
+    public ConnectionStringsConfigDto ConnectionStrings { get; set; } = null!;
+    public EnvironmentConfigDto Environment { get; set; } = null!;
+}
+
+public class EmbeddingConfigDto
+{
+    public bool ApiConfigured { get; set; }
+    public string Model { get; set; } = string.Empty;
+    public string Timeout { get; set; } = string.Empty;
+}
+
+public class ServerConfigDto
+{
+    public bool CanonicalUrlConfigured { get; set; }
+    public string? CanonicalUrl { get; set; }
+}
+
+public class SearchConfigDto
+{
+    public bool ReturnFullContent { get; set; }
+}
+
+public class ConnectionStringsConfigDto
+{
+    public bool StorageConfigured { get; set; }
+}
+
+public class EnvironmentConfigDto
+{
+    public string? AspNetCoreEnvironment { get; set; }
+    public bool OtelConfigured { get; set; }
+    public string? OtelServiceName { get; set; }
 } 

--- a/src/Memorizer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Memorizer/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddCorsSettings();
         services.AddVersioningSettings();
         services.AddSimilaritySettings();
+        services.AddSearchSettings();
         if(initialize)
             services.AddHostedService<InitializationService>();
         services.AutoRegisterTypesInAssemblies(typeof(Storage).Assembly);
@@ -182,6 +183,16 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<SimilaritySettings>(sp =>
             sp.GetRequiredService<IConfiguration>().GetSection("Similarity").Get<SimilaritySettings>() ??
             new SimilaritySettings());
+
+        return services;
+    }
+
+    public static IServiceCollection AddSearchSettings(
+        this IServiceCollection services)
+    {
+        services.AddSingleton<SearchSettings>(sp =>
+            sp.GetRequiredService<IConfiguration>().GetSection("Search").Get<SearchSettings>() ??
+            new SearchSettings());
 
         return services;
     }

--- a/src/Memorizer/Settings/SearchSettings.cs
+++ b/src/Memorizer/Settings/SearchSettings.cs
@@ -1,0 +1,16 @@
+namespace Memorizer.Settings;
+
+/// <summary>
+/// Settings for the MCP search tool behavior.
+/// </summary>
+public class SearchSettings
+{
+    /// <summary>
+    /// When true, search results include the full memory content/body text.
+    /// When false (default), search returns lightweight results (ID, title, type, tags, similarity)
+    /// and agents should use Get/GetMany to retrieve full content.
+    ///
+    /// Default is false to optimize context window usage for LLM agents.
+    /// </summary>
+    public bool ReturnFullContent { get; init; } = false;
+}

--- a/src/Memorizer/Tools/MemoryTools.cs
+++ b/src/Memorizer/Tools/MemoryTools.cs
@@ -5,6 +5,7 @@ using Memory = Memorizer.Models.Memory;
 using System.Linq;
 using System.Diagnostics;
 using Memorizer.Services;
+using Memorizer.Settings;
 using Memorizer.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -15,11 +16,13 @@ public class MemoryTools
 {
     private readonly IStorage _storage;
     private readonly ILogger<MemoryTools> _logger;
+    private readonly SearchSettings _searchSettings;
 
-    public MemoryTools(IStorage storage, ILogger<MemoryTools> logger)
+    public MemoryTools(IStorage storage, ILogger<MemoryTools> logger, SearchSettings searchSettings)
     {
         _storage = storage;
         _logger = logger;
+        _searchSettings = searchSettings;
     }
 
     [McpServerTool, Description("Store a new memory in the database, optionally creating a relationship to another memory. Use this to save reference material, how-to guides, coding standards, or any information you (the LLM) may want to refer to when completing tasks. Include as much context as possible, such as markdown, code samples, and detailed explanations. Create relationships to link related reference materials or examples.")]
@@ -312,7 +315,7 @@ public class MemoryTools
 
         // Format the results
         StringBuilder result = new();
-        
+
         if (usedFallback)
         {
             result.AppendLine($"No results found at similarity threshold {minSimilarity:F1}, but found {memories.Count} memories at relaxed threshold {actualThreshold:F1}:");
@@ -323,58 +326,59 @@ public class MemoryTools
         }
         result.AppendLine();
 
-        // Collect all related memory IDs for suggestion
-        var relatedMemoryIds = new HashSet<Guid>();
+        // Collect all memory IDs for retrieval suggestion
+        var memoryIds = new List<Guid>();
 
         foreach (var memory in memories)
         {
+            memoryIds.Add(memory.Id);
+
             result.AppendLine($"ID: {memory.Id}");
             if (memory.Title != null)
             {
                 result.AppendLine($"Title: {memory.Title}");
             }
             result.AppendLine($"Type: {memory.Type}");
-            result.AppendLine($"Text: {memory.Text}");
-            result.AppendLine($"Source: {memory.Source}");
+
+            // Only include full content if configured to do so
+            if (_searchSettings.ReturnFullContent)
+            {
+                result.AppendLine($"Text: {memory.Text}");
+                result.AppendLine($"Source: {memory.Source}");
+            }
+
             result.AppendLine(
                 $"Tags: {(memory.Tags != null ? string.Join(", ", memory.Tags) : "none")}"
             );
-            result.AppendLine($"Confidence: {memory.Confidence:F2}");
+
+            if (_searchSettings.ReturnFullContent)
+            {
+                result.AppendLine($"Confidence: {memory.Confidence:F2}");
+            }
+
             if (memory.Similarity.HasValue)
             {
                 double percent = 100 * (1 - memory.Similarity.Value);
                 result.AppendLine($"Similarity: {percent:F1}%");
             }
-            // List relationships and collect related IDs
-            if (memory.Relationships is { Count: > 0 })
+
+            // Only show relationships if returning full content
+            if (_searchSettings.ReturnFullContent && memory.Relationships is { Count: > 0 })
             {
-                result.AppendLine($"🔗 Relationships ({memory.Relationships.Count}):");
-                foreach (var rel in memory.Relationships)
-                {
-                    var relatedId = rel.FromMemoryId == memory.Id ? rel.ToMemoryId : rel.FromMemoryId;
-                    var direction = rel.FromMemoryId == memory.Id ? "→" : "←";
-                    var relatedTitle = rel.RelatedMemoryTitle ?? "Untitled";
-                    var relatedType = rel.RelatedMemoryType ?? "unknown";
-                    
-                    result.AppendLine($"  • [{rel.Type.ToUpper()}] {direction} \"{relatedTitle}\" ({relatedType}) [ID: {relatedId}]");
-                    
-                    // Collect related memory IDs (excluding the current memory)
-                    if (rel.FromMemoryId != memory.Id)
-                        relatedMemoryIds.Add(rel.FromMemoryId);
-                    if (rel.ToMemoryId != memory.Id)
-                        relatedMemoryIds.Add(rel.ToMemoryId);
-                }
+                result.AppendLine($"Relationships: {memory.Relationships.Count}");
             }
+
             result.AppendLine($"Created: {memory.CreatedAt:yyyy-MM-dd HH:mm:ss}");
             result.AppendLine();
         }
 
-        // Add suggestion to load related memories if any exist
-        if (relatedMemoryIds.Count > 0)
+        // Add retrieval instructions for lightweight results
+        if (!_searchSettings.ReturnFullContent)
         {
-            result.AppendLine("💡 Suggestion: These memories have relationships to other memories in the database.");
-            result.AppendLine($"Consider using GetMany with these IDs to load related context: [{string.Join(", ", relatedMemoryIds)}]");
-            result.AppendLine("This can provide additional relevant information and context for your task.");
+            result.AppendLine("---");
+            result.AppendLine("To retrieve the full content of these memories, use one of the following:");
+            result.AppendLine($"• Get tool with a specific memory ID to fetch one memory");
+            result.AppendLine($"• GetMany tool with IDs: [{string.Join(", ", memoryIds)}]");
         }
 
         activity?.SetStatus(ActivityStatusCode.Ok, $"Found {memories.Count} results" + (usedFallback ? " (with fallback)" : ""));

--- a/src/Memorizer/Views/Home/Config.cshtml
+++ b/src/Memorizer/Views/Home/Config.cshtml
@@ -134,6 +134,30 @@
                 </div>
             </div>
 
+            <!-- Search Configuration -->
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">
+                        <i class="fas fa-search me-2"></i>
+                        MCP Search Settings
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <table class="table table-sm">
+                        <tr>
+                            <td><strong>Return Full Content:</strong></td>
+                            <td><span id="searchReturnFullContent" class="badge"></span></td>
+                        </tr>
+                        <tr>
+                            <td colspan="2" class="text-muted small">
+                                When disabled (default), MCP search returns lightweight results (ID, title, type, tags, similarity)
+                                to optimize context window usage. Agents use Get/GetMany to retrieve full content.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
             <!-- Feature Status Summary -->
             <div class="card border-info">
                 <div class="card-header bg-info text-white">
@@ -199,6 +223,9 @@ function displayConfiguration(config) {
     // Server Settings
     setBadge('canonicalUrlConfigured', config.serverSettings.canonicalUrlConfigured, 'Configured', 'Not Configured');
     setText('canonicalUrl', config.serverSettings.canonicalUrl || 'Not Set');
+
+    // Search Settings
+    setBadge('searchReturnFullContent', config.searchSettings.returnFullContent, 'Enabled', 'Disabled (Lightweight)');
 
     // Feature Status Summary
     displayFeatureStatusSummary(config);

--- a/src/Memorizer/appsettings.json
+++ b/src/Memorizer/appsettings.json
@@ -35,5 +35,8 @@
     "MinThreshold": 0.5,
     "MaxThreshold": 0.95,
     "DefaultLimit": 10
+  },
+  "Search": {
+    "ReturnFullContent": false
   }
 } 


### PR DESCRIPTION
## Summary
- MCP search now returns lightweight results by default (ID, title, type, tags, similarity, created date)
- Prevents swamping agent context windows when searches return many high-quality matches
- Agents use `Get` or `GetMany` tools to retrieve full memory content as needed

## Changes
- Add `SearchSettings` class with `ReturnFullContent` option (default: `false`)
- Update `SearchMemories` tool to return lightweight results with instructions pointing to `Get`/`GetMany`
- Add setting to system config page with explanation
- Document `Search:ReturnFullContent` in `docs/configuration.md`
- Add explicit setting to `appsettings.json` for discoverability
- Convert `ConfigurationController` DTOs from `object` to properly typed classes

## Configuration
```bash
# Environment variable (default is false)
MEMORIZER_Search__ReturnFullContent=false
```

## Test plan
- [x] All 100 integration tests pass
- [ ] Verify lightweight search results work correctly via MCP
- [ ] Verify full content mode works when enabled
- [ ] Verify system config page displays the setting