### PR TITLE
Prepare release 2.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## GitHub Workflow
 
-- **Always create pull requests against `petabridge/memorizer-v1`**, not any fork
-- Use `gh pr create --repo petabridge/memorizer-v1` when creating PRs
+- **Always create pull requests against `petabridge/memorizer`**, not any fork
+- Use `gh pr create --repo petabridge/memorizer` when creating PRs
 
 ## NuGet Package Management
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,34 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
-    <PackageReleaseNotes>Memorizer V2 merge - adds workspaces, projects, provider settings, structured memory types (documents, records, references), and unit tests. See RELEASE_NOTES.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>**Major Release - Memorizer V2 Merge**
+
+This release merges all Memorizer V2 features into the open-source repository, bringing significant new capabilities for organizing and managing AI agent memories.
+
+&gt; [!CAUTION]
+&gt; **Back up your database before upgrading.** Memorizer 2.0 runs automatic schema migrations on startup that alter tables and add new columns. These migrations are not reversible. Create a `pg_dump` of your database before pulling the new image. See the [Upgrading to Memorizer 2.0](README.md#upgrading-to-memorizer-20) section in the README for backup instructions.
+
+**Breaking Changes**
+- MCP endpoint moved from `/` to `/mcp`. Update client configs from `http://localhost:5000` to `http://localhost:5000/mcp`
+- Web UI moved from `/ui` to `/`. The Web UI is now at the root path.
+
+**New Features**
+- **Workspaces**: Organize memories into isolated workspaces with independent configurations
+- **Projects**: Group related memories within workspaces for better organization
+- **Provider Settings**: Configure AI providers (embedding models, LLM endpoints) per-workspace
+- **Structured Memory Types**: Support for documents, records, and references with distinct behaviors
+- **Memory Archiving**: Archive memories instead of deleting them, with restore capability
+- **System Memories**: Hidden system index memories for semantic project/workspace search
+- **Unit Tests**: New unit test project for core domain logic
+
+**Database Migrations**
+- Migrations 011-019 run automatically on startup
+- Existing V1 databases will be upgraded seamlessly with new tables for workspaces, projects, provider settings, and structured memory types
+
+**V2 Release History (from private development)**
+- 2.0.9: Fix broken navigation links, add Archetype field to MemorySummaryDto
+- 2.0.8: Fix archived memories filtering, add archetype visibility to MCP tools
+- 2.0.7: Add system memories for semantic project/workspace search</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/src/Memorizer.IntegrationTests/PostgresContainerTests.cs
+++ b/src/Memorizer.IntegrationTests/PostgresContainerTests.cs
@@ -23,7 +23,7 @@ public class IntegrationTests : TestKit
     private IStorage _storage = null!;
     private IEmbeddingService _embeddingService = null!;
 
-    public IntegrationTests(IntegrationTestFixture fixture, ITestOutputHelper output) 
+    public IntegrationTests(IntegrationTestFixture fixture, ITestOutputHelper output)
         : base(output: output)
     {
         _fixture = fixture;

--- a/src/Memorizer.IntegrationTests/TestEnvironmentInitializer.cs
+++ b/src/Memorizer.IntegrationTests/TestEnvironmentInitializer.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+
+namespace Memorizer.IntegrationTests;
+
+internal static class TestEnvironmentInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        // Disable config file watching in test hosts
+        // Prevents file descriptor exhaustion (inotify watch limit) on Linux
+        Environment.SetEnvironmentVariable("DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE", "false");
+    }
+}


### PR DESCRIPTION
## Summary

Prepares version 2.0.0 release with:
- Repository name updates (memorizer-v1 → memorizer) in project guidelines
- Updated package release notes with complete V2 feature descriptions

## Release Notes

Version 2.0.0 includes the major Memorizer V2 merge bringing workspaces, projects, provider settings, structured memory types, memory archiving, and system memories. Full release notes are already documented in RELEASE_NOTES.md.

## Post-Merge Steps

After this PR is merged:
1. Create and push git tag `2.0.0` from the dev branch
2. CI/CD will automatically create the GitHub release