### PR TITLE
Restore petabridge/ prefix on ContainerRepository

### DIFF
--- a/src/Memorizer/Memorizer.csproj
+++ b/src/Memorizer/Memorizer.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <ContainerRepository>memorizer</ContainerRepository>
+        <ContainerRepository>petabridge/memorizer</ContainerRepository>
         <ContainerTitle>Memorizer</ContainerTitle>
         <ContainerDescription>A .NET-based service that allows AI agents to store, retrieve, and search through memories using vector embeddings. Leverages PostgreSQL with pgvector extension for efficient similarity search capabilities.</ContainerDescription>
         <ContainerImageTags>$(VersionPrefix);latest</ContainerImageTags>


### PR DESCRIPTION
## Summary
- Restore `petabridge/` prefix on `ContainerRepository` in Memorizer.csproj
- The V2 merge dropped this prefix, causing Docker Hub publish to fail with CONTAINER1016

## Test plan
- [ ] Merge, re-tag 2.0.0, verify Docker Hub publish succeeds