### PR TITLE
Disable container publishing for unit test project

### DIFF
--- a/src/Memorizer.UnitTests/Memorizer.UnitTests.csproj
+++ b/src/Memorizer.UnitTests/Memorizer.UnitTests.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <EnableSdkContainerSupport>false</EnableSdkContainerSupport>
         <RootNamespace>Memorizer.UnitTests</RootNamespace>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Add `EnableSdkContainerSupport=false` to Memorizer.UnitTests.csproj
- The unit test project was being picked up by `dotnet publish /t:PublishContainer` at the solution level, causing the publish workflow to fail trying to push `memorizer-unittests` to Docker Hub
- The integration test project already had this set; the unit test project was missing it

## Test plan
- [ ] Merge, re-tag 2.0.0, verify Docker Hub publish succeeds end-to-end