### PR TITLE
Fix inconsistent memory counts by excluding system memories

### DIFF
--- a/src/Memorizer.IntegrationTests/MemoryStatsServiceTests.cs
+++ b/src/Memorizer.IntegrationTests/MemoryStatsServiceTests.cs
@@ -1,6 +1,7 @@
 using Akka.Hosting;
 using Akka.Hosting.TestKit;
 using Memorizer.Extensions;
+using Memorizer.Models.Enums;
 using Memorizer.Models.ValueTypes;
 using Memorizer.Services;
 using Memorizer.Settings;
@@ -109,4 +110,76 @@ public class MemoryStatsServiceTests : TestKit
         // Average size should now be positive
         Assert.True(updatedStats.AverageMemorySizeBytes > 0);
     }
-} 
+
+    [Fact]
+    public async Task MemoryStats_ExcludesSystemMemories()
+    {
+        _storage = Host.Services.GetRequiredService<IStorage>();
+        _statsService = Host.Services.GetRequiredService<IMemoryStatsService>();
+
+        var initialStats = await _statsService.GetStatsAsync();
+
+        // Add a regular document memory
+        await _storage.StoreMemory("test", "regular document memory", "test",
+            new[] { "test" }, new Confidence(1.0), "Regular Memory",
+            archetype: ArchetypeEnum.Document);
+
+        // Add a system memory (should be excluded from stats)
+        await _storage.StoreMemory("test", "system indexing memory", "test",
+            new[] { "system" }, new Confidence(1.0), "System Memory",
+            archetype: ArchetypeEnum.System);
+
+        var updatedStats = await _statsService.GetStatsAsync();
+
+        // Only the regular memory should be counted, not the system one
+        Assert.Equal(initialStats.TotalMemories + 1, updatedStats.TotalMemories);
+    }
+
+    [Fact]
+    public async Task GetMemoriesPaginated_ExcludesSystemMemories()
+    {
+        _storage = Host.Services.GetRequiredService<IStorage>();
+
+        // Get initial paginated count
+        var (_, initialCount) = await _storage.GetMemoriesPaginated(page: 1, pageSize: 1000);
+
+        // Add regular memories
+        await _storage.StoreMemory("test", "paginated test memory 1", "test",
+            new[] { "test" }, new Confidence(1.0), "Paginated Test 1",
+            archetype: ArchetypeEnum.Document);
+        await _storage.StoreMemory("test", "paginated test memory 2", "test",
+            new[] { "test" }, new Confidence(1.0), "Paginated Test 2",
+            archetype: ArchetypeEnum.Record);
+
+        // Add a system memory (should be excluded)
+        await _storage.StoreMemory("test", "system memory for pagination test", "test",
+            new[] { "system" }, new Confidence(1.0), "System Paginated Test",
+            archetype: ArchetypeEnum.System);
+
+        var (memories, totalCount) = await _storage.GetMemoriesPaginated(page: 1, pageSize: 1000);
+
+        // Count should only increase by 2 (the regular memories), not 3
+        Assert.Equal(initialCount + 2, totalCount);
+
+        // No system memories should appear in results
+        Assert.DoesNotContain(memories, m => m.Archetype == ArchetypeEnum.System);
+    }
+
+    [Fact]
+    public async Task CountMemoriesWithoutMetadataEmbeddings_ExcludesSystemMemories()
+    {
+        _storage = Host.Services.GetRequiredService<IStorage>();
+
+        var initialCount = await _storage.CountMemoriesWithoutMetadataEmbeddings();
+
+        // Add a system memory - it should NOT be counted even if it lacks metadata embeddings
+        await _storage.StoreMemory("test", "system memory for embedding count test", "test",
+            new[] { "system" }, new Confidence(1.0), "System Embedding Test",
+            archetype: ArchetypeEnum.System);
+
+        var updatedCount = await _storage.CountMemoriesWithoutMetadataEmbeddings();
+
+        // System memory should not increase the count
+        Assert.Equal(initialCount, updatedCount);
+    }
+}

--- a/src/Memorizer/Actors/DimensionMigrationActor.cs
+++ b/src/Memorizer/Actors/DimensionMigrationActor.cs
@@ -569,6 +569,8 @@ public sealed class DimensionMigrationActor : ReceiveActor
 
     #region Database Operations
 
+    // Intentionally counts ALL memories (including System and Archived) because dimension migration
+    // must regenerate embeddings for every memory type to maintain database consistency.
     private async Task<int> GetTotalMemoryCount()
     {
         await using var conn = await _dataSource.OpenConnectionAsync();
@@ -609,6 +611,7 @@ public sealed class DimensionMigrationActor : ReceiveActor
         // Get total memory count
         await using var conn = await _dataSource.OpenConnectionAsync();
 
+        // Intentionally counts ALL memories (including System and Archived) for migration tracking
         await using var countCmd = new NpgsqlCommand("SELECT COUNT(*) FROM memories", conn);
         var totalMemories = Convert.ToInt32(await countCmd.ExecuteScalarAsync());
 

--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -879,7 +879,8 @@ public class Storage : IStorage
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
         
         // Get total count first
-        const string countSql = "SELECT COUNT(*) FROM memories";
+        // Exclude System (3) and Archived (2) memories from user-facing lists
+        const string countSql = "SELECT COUNT(*) FROM memories WHERE archetype IN (0, 1)";
         await using NpgsqlCommand countCmd = new(countSql, connection);
         var countResult = await countCmd.ExecuteScalarAsync(cancellationToken);
         var totalCount = countResult is null ? 0L : Convert.ToInt64(countResult);
@@ -888,6 +889,7 @@ public class Storage : IStorage
         const string sql = @"
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence, created_at, updated_at, title, current_version, owner_type, owner_id, archetype
             FROM memories
+            WHERE archetype IN (0, 1)
             ORDER BY created_at DESC
             LIMIT @limit OFFSET @offset";
 
@@ -1392,7 +1394,7 @@ public class Storage : IStorage
     // Metadata embedding support
     public async Task<int> CountMemoriesWithoutMetadataEmbeddings(CancellationToken cancellationToken = default)
     {
-        const string sql = "SELECT COUNT(*) FROM memories WHERE embedding_metadata IS NULL";
+        const string sql = "SELECT COUNT(*) FROM memories WHERE embedding_metadata IS NULL AND archetype IN (0, 1)";
         
         await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
         await using var command = new NpgsqlCommand(sql, connection);
@@ -1403,7 +1405,9 @@ public class Storage : IStorage
 
     public async Task<List<Memorizer.Models.Memory>> GetMemoriesWithoutMetadataEmbeddings(int limit, bool includeExisting = false, CancellationToken cancellationToken = default)
     {
-        var whereClause = includeExisting ? "" : "WHERE embedding_metadata IS NULL";
+        var whereClause = includeExisting
+            ? "WHERE archetype IN (0, 1)"
+            : "WHERE embedding_metadata IS NULL AND archetype IN (0, 1)";
         var sql = $@"
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence, created_at, updated_at, title, current_version, owner_type, owner_id, archetype
             FROM memories
@@ -1781,7 +1785,7 @@ public class Storage : IStorage
 
         const string sql = @"
             SELECT
-                (SELECT COUNT(*) FROM memories) as total_memories,
+                (SELECT COUNT(*) FROM memories WHERE archetype IN (0, 1)) as total_memories,
                 (SELECT COUNT(*) FROM memory_versions) as total_versions,
                 (SELECT COUNT(*) FROM memory_events) as total_events,
                 (SELECT AVG(version_count) FROM (

--- a/src/Memorizer/Services/MemoryStatsService.cs
+++ b/src/Memorizer/Services/MemoryStatsService.cs
@@ -85,8 +85,8 @@ public class MemoryStatsService : IMemoryStatsService
         // Get all stats in a single query for efficiency
         const string sql = @"
             SELECT
-                (SELECT COUNT(*) FROM memories) as total_memories,
-                (SELECT COALESCE(AVG(LENGTH(text)), 0) FROM memories) as avg_size,
+                (SELECT COUNT(*) FROM memories WHERE archetype IN (0, 1)) as total_memories,
+                (SELECT COALESCE(AVG(LENGTH(text)), 0) FROM memories WHERE archetype IN (0, 1)) as avg_size,
                 (SELECT COUNT(*) FROM memory_versions) as total_versions,
                 (SELECT COUNT(*) FROM memory_events) as total_events,
                 (SELECT pg_total_relation_size('memories')) as memories_storage,


### PR DESCRIPTION
## Summary

Fixes #142 - Inconsistent memory counts across different UI pages.

- **Root cause**: Internal system memories (archetype = 3) were being included in user-facing statistics and paginated listings, inflating counts
- Added `WHERE archetype IN (0, 1)` filter to 5 SQL queries that were missing it: `MemoryStatsService.GetStatsAsync`, `Memory.GetMemoriesPaginated`, `Memory.CountMemoriesWithoutMetadataEmbeddings`, `Memory.GetMemoriesWithoutMetadataEmbeddings`, and `Memory.GetVersionStats`
- Added explanatory comments to `DimensionMigrationActor` queries that intentionally count ALL memories for migration tracking
- Added 3 integration tests verifying system memories are excluded from stats, paginated results, and metadata embedding counts

## Test plan

- [ ] Verify `dotnet build` succeeds with no warnings
- [ ] Run `dotnet test --filter "FullyQualifiedName~MemoryStatsServiceTests"` to verify new integration tests pass
- [ ] Manual: create a workspace (auto-generates system memory), verify `/stats` count excludes it
- [ ] Manual: compare `SELECT COUNT(*) FROM memories` vs `SELECT COUNT(*) FROM memories WHERE archetype IN (0, 1)` to confirm difference