### PR TITLE
Release Memorizer 2.1.0-beta1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,19 +3,24 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/petabridge/memorizer-v1</PackageProjectUrl>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.1.0-beta1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
-    <PackageReleaseNotes>**Improvements**
-- [Add link to homepage on sidebar Memorizer logo](https://github.com/petabridge/memorizer/pull/148) - Sidebar logo is now clickable and navigates to the Memorizer homepage
+    <PackageReleaseNotes>**Features**
+- [Improve search quality with hybrid text + vector search](https://github.com/petabridge/memorizer/pull/157) - Combines PostgreSQL full-text search with vector similarity search using Reciprocal Rank Fusion (RRF) to dramatically improve search relevance
+  - Queries like "race condition", "phobos", and "dependency injection" that previously returned zero results now surface relevant matches
+  - AND-prefix FTS matching handles stemming mismatches (e.g., "postgres" matches "postgresql")
+  - Adaptive weighting favors text matching for short queries, both methods equally for longer queries
+  - Workspace and project search also use hybrid approach for better name matching
+  - New database migration adds `search_vector` tsvector column with GIN index
 
 **Bug Fixes**
-- [Fix Docker commands in README for PostgreSQL backup](https://github.com/petabridge/memorizer/pull/139) - Corrected container name from `memorizer-postgres` to `postgmem-postgres` in backup instructions
+- [Fix inconsistent memory counts by excluding system memories from user-facing queries](https://github.com/petabridge/memorizer/pull/154) - Memory list and stats no longer inflate counts with internal system index memories
 
-**Documentation**
-- [Add commands reference documentation for Memorizer](https://github.com/petabridge/memorizer/pull/141) - New reference guide documenting all available Memorizer commands
-- [Update README with detailed update instructions](https://github.com/petabridge/memorizer/pull/140) - Added step-by-step bash commands for the upgrade process</PackageReleaseNotes>
+**Updates**
+- [Bump Microsoft.AspNetCore.Mvc.Testing from 10.0.2 to 10.0.3](https://github.com/petabridge/memorizer/pull/156)
+- [Bump Akka.Streams from 1.5.58 to 1.5.60](https://github.com/petabridge/memorizer/pull/152)</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+#### 2.1.0-beta1 February 15th 2026 ####
+
+**Features**
+- [Improve search quality with hybrid text + vector search](https://github.com/petabridge/memorizer/pull/157) - Combines PostgreSQL full-text search with vector similarity search using Reciprocal Rank Fusion (RRF) to dramatically improve search relevance
+  - Queries like "race condition", "phobos", and "dependency injection" that previously returned zero results now surface relevant matches
+  - AND-prefix FTS matching handles stemming mismatches (e.g., "postgres" matches "postgresql")
+  - Adaptive weighting favors text matching for short queries, both methods equally for longer queries
+  - Workspace and project search also use hybrid approach for better name matching
+  - New database migration adds `search_vector` tsvector column with GIN index
+
+**Bug Fixes**
+- [Fix inconsistent memory counts by excluding system memories from user-facing queries](https://github.com/petabridge/memorizer/pull/154) - Memory list and stats no longer inflate counts with internal system index memories
+
+**Updates**
+- [Bump Microsoft.AspNetCore.Mvc.Testing from 10.0.2 to 10.0.3](https://github.com/petabridge/memorizer/pull/156)
+- [Bump Akka.Streams from 1.5.58 to 1.5.60](https://github.com/petabridge/memorizer/pull/152)
+
 #### 2.0.1 February 12th 2026 ####
 
 **Improvements**


### PR DESCRIPTION
## Summary
- Bump version to 2.1.0-beta1
- Update RELEASE_NOTES.md with changelog since 2.0.1

## Changes since 2.0.1
- **Hybrid search** (#157) — combines FTS + vector search with RRF for dramatically improved search relevance
- **Fix memory counts** (#154) — exclude system memories from user-facing lists and stats
- Dependency bumps: Akka.Streams 1.5.60, Microsoft.AspNetCore.Mvc.Testing 10.0.3