### PR TITLE
Add move-project-to-workspace and workspace reparenting

### DIFF
--- a/src/Memorizer.IntegrationTests/MoveOperationsIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/MoveOperationsIntegrationTests.cs
@@ -1,0 +1,328 @@
+using Memorizer.Extensions;
+using Memorizer.IntegrationTests.Logging;
+using Memorizer.Models;
+using Memorizer.Models.ValueTypes;
+using Memorizer.Services;
+using Memorizer.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Memorizer.IntegrationTests;
+
+/// <summary>
+/// Integration tests for move operations:
+/// - Moving a project (and descendants) to a different workspace
+/// - Reparenting a workspace under a new parent or promoting to top-level
+/// </summary>
+[Collection(nameof(IntegrationTestCollection))]
+public class MoveOperationsIntegrationTests : IDisposable
+{
+    private readonly IntegrationTestFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private readonly IServiceProvider _services;
+
+    public void Dispose()
+    {
+        (_services as IDisposable)?.Dispose();
+    }
+
+    public MoveOperationsIntegrationTests(IntegrationTestFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+        _services = CreateServices();
+    }
+
+    private IServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:Storage"] = _fixture.PostgresConnectionString,
+                ["Embeddings:ApiUrl"] = _fixture.OllamaApiUrl,
+                ["Embeddings:Model"] = "all-minilm",
+                ["Embeddings:Timeout"] = TimeSpan.FromMinutes(1).ToString()
+            })
+            .Build());
+
+        services.AddHttpClient<IEmbeddingService, EmbeddingService>(client =>
+        {
+            client.BaseAddress = new Uri(_fixture.OllamaApiUrl);
+            client.Timeout = TimeSpan.FromMinutes(1);
+        });
+
+        services.AddSingleton(new EmbeddingSettings
+        {
+            ApiUrl = new Uri(_fixture.OllamaApiUrl),
+            Model = "all-minilm",
+            Timeout = TimeSpan.FromMinutes(1)
+        });
+
+        services.AddMemorizer();
+        services.AddLogging(builder => builder.AddXUnit(_output));
+
+        return services.BuildServiceProvider();
+    }
+
+    // ===== Project Move Tests =====
+
+    [Fact]
+    public async Task MoveProjectToWorkspace_HappyPath_MovesProjectAndDescendants()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        // Arrange
+        var srcWorkspace = await storage.CreateWorkspaceAsync("Source WS", cancellationToken: default);
+        var dstWorkspace = await storage.CreateWorkspaceAsync("Destination WS", cancellationToken: default);
+        var project = await storage.CreateProjectAsync(srcWorkspace.Id, "Root Project", cancellationToken: default);
+        var child = await storage.CreateProjectAsync(srcWorkspace.Id, "Child Project", parentId: project.Id, cancellationToken: default);
+        var grandchild = await storage.CreateProjectAsync(srcWorkspace.Id, "Grandchild Project", parentId: child.Id, cancellationToken: default);
+
+        // Act
+        var moved = await storage.MoveProjectToWorkspaceAsync(project.Id, dstWorkspace.Id, cancellationToken: default);
+
+        // Assert root was moved
+        Assert.Equal(dstWorkspace.Id, moved.WorkspaceId);
+        Assert.Null(moved.ParentId);
+
+        // Assert descendants were moved
+        var movedChild = await storage.GetProjectAsync(child.Id, default);
+        var movedGrandchild = await storage.GetProjectAsync(grandchild.Id, default);
+        Assert.NotNull(movedChild);
+        Assert.NotNull(movedGrandchild);
+        Assert.Equal(dstWorkspace.Id, movedChild!.WorkspaceId);
+        Assert.Equal(dstWorkspace.Id, movedGrandchild!.WorkspaceId);
+
+        _output.WriteLine($"Moved {project.Id} with {child.Id} and {grandchild.Id} to {dstWorkspace.Id}");
+
+        // Cleanup
+        await storage.DeleteProjectAsync(grandchild.Id, default);
+        await storage.DeleteProjectAsync(child.Id, default);
+        await storage.DeleteProjectAsync(project.Id, default);
+        await storage.DeleteWorkspaceAsync(srcWorkspace.Id, default);
+        await storage.DeleteWorkspaceAsync(dstWorkspace.Id, default);
+    }
+
+    [Fact]
+    public async Task MoveProjectToWorkspace_WithNewParent_SetsParentInTargetWorkspace()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var srcWs = await storage.CreateWorkspaceAsync("Src WS Move Parent", cancellationToken: default);
+        var dstWs = await storage.CreateWorkspaceAsync("Dst WS Move Parent", cancellationToken: default);
+        var projectToMove = await storage.CreateProjectAsync(srcWs.Id, "Move Me", cancellationToken: default);
+        var parentInDst = await storage.CreateProjectAsync(dstWs.Id, "Parent In Dst", cancellationToken: default);
+
+        var moved = await storage.MoveProjectToWorkspaceAsync(projectToMove.Id, dstWs.Id, parentInDst.Id, cancellationToken: default);
+
+        Assert.Equal(dstWs.Id, moved.WorkspaceId);
+        Assert.Equal(parentInDst.Id, moved.ParentId);
+
+        // Cleanup
+        await storage.DeleteProjectAsync(moved.Id, default);
+        await storage.DeleteProjectAsync(parentInDst.Id, default);
+        await storage.DeleteWorkspaceAsync(srcWs.Id, default);
+        await storage.DeleteWorkspaceAsync(dstWs.Id, default);
+    }
+
+    [Fact]
+    public async Task MoveProjectToWorkspace_SameWorkspace_ThrowsInvalidOperation()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var ws = await storage.CreateWorkspaceAsync("Same WS Move", cancellationToken: default);
+        var project = await storage.CreateProjectAsync(ws.Id, "Project Same WS", cancellationToken: default);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            storage.MoveProjectToWorkspaceAsync(project.Id, ws.Id, cancellationToken: default));
+
+        // Cleanup
+        await storage.DeleteProjectAsync(project.Id, default);
+        await storage.DeleteWorkspaceAsync(ws.Id, default);
+    }
+
+    [Fact]
+    public async Task MoveProjectToWorkspace_InvalidTargetWorkspace_ThrowsInvalidOperation()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var ws = await storage.CreateWorkspaceAsync("Valid WS Move Invalid Target", cancellationToken: default);
+        var project = await storage.CreateProjectAsync(ws.Id, "Project Invalid Target WS", cancellationToken: default);
+        var nonExistentWorkspaceId = new WorkspaceId(Guid.NewGuid());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            storage.MoveProjectToWorkspaceAsync(project.Id, nonExistentWorkspaceId, cancellationToken: default));
+
+        // Cleanup
+        await storage.DeleteProjectAsync(project.Id, default);
+        await storage.DeleteWorkspaceAsync(ws.Id, default);
+    }
+
+    [Fact]
+    public async Task MoveProjectToWorkspace_NewParentInWrongWorkspace_ThrowsInvalidOperation()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var srcWs = await storage.CreateWorkspaceAsync("Src WS Wrong Parent", cancellationToken: default);
+        var dstWs = await storage.CreateWorkspaceAsync("Dst WS Wrong Parent", cancellationToken: default);
+        var otherWs = await storage.CreateWorkspaceAsync("Other WS Wrong Parent", cancellationToken: default);
+
+        var project = await storage.CreateProjectAsync(srcWs.Id, "Project Wrong Parent", cancellationToken: default);
+        var parentInOtherWs = await storage.CreateProjectAsync(otherWs.Id, "Parent In Other WS", cancellationToken: default);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            storage.MoveProjectToWorkspaceAsync(project.Id, dstWs.Id, parentInOtherWs.Id, cancellationToken: default));
+
+        // Cleanup
+        await storage.DeleteProjectAsync(project.Id, default);
+        await storage.DeleteProjectAsync(parentInOtherWs.Id, default);
+        await storage.DeleteWorkspaceAsync(srcWs.Id, default);
+        await storage.DeleteWorkspaceAsync(dstWs.Id, default);
+        await storage.DeleteWorkspaceAsync(otherWs.Id, default);
+    }
+
+    [Fact]
+    public async Task MoveProjectToWorkspace_MemoriesRemainAssigned()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var srcWs = await storage.CreateWorkspaceAsync("Src WS Memories", cancellationToken: default);
+        var dstWs = await storage.CreateWorkspaceAsync("Dst WS Memories", cancellationToken: default);
+        var project = await storage.CreateProjectAsync(srcWs.Id, "Project With Memories", cancellationToken: default);
+
+        // Add a memory to the project
+        var memory = await storage.StoreMemory(
+            "test", "test content", "test", null,
+            new Models.ValueTypes.Confidence(1.0), "Test Memory",
+            owner: MemoryOwner.ForProject(project.Id));
+
+        // Move
+        var moved = await storage.MoveProjectToWorkspaceAsync(project.Id, dstWs.Id, cancellationToken: default);
+
+        // Memory should still be assigned to the project
+        var memoryCount = await storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForProject(moved.Id), default);
+        Assert.Equal(1, memoryCount);
+
+        // Cleanup
+        await storage.Delete(memory.Id, default);
+        await storage.DeleteProjectAsync(project.Id, default);
+        await storage.DeleteWorkspaceAsync(srcWs.Id, default);
+        await storage.DeleteWorkspaceAsync(dstWs.Id, default);
+    }
+
+    // ===== Workspace Reparent Tests =====
+
+    [Fact]
+    public async Task ReparentWorkspace_HappyPath_MovesUnderNewParent()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var parent = await storage.CreateWorkspaceAsync("Parent WS Reparent", cancellationToken: default);
+        var child = await storage.CreateWorkspaceAsync("Child WS To Move", cancellationToken: default);
+
+        var updated = await storage.UpdateWorkspaceAsync(child.Id, newParentId: parent.Id, cancellationToken: default);
+
+        Assert.Equal(parent.Id, updated.ParentId);
+
+        // Verify it appears under the parent
+        var children = await storage.GetWorkspacesAsync(parentId: parent.Id, includeSystem: false, cancellationToken: default);
+        Assert.Contains(children, w => w.Id == child.Id);
+
+        // Cleanup
+        await storage.DeleteWorkspaceAsync(child.Id, default);
+        await storage.DeleteWorkspaceAsync(parent.Id, default);
+    }
+
+    [Fact]
+    public async Task ReparentWorkspace_MakeTopLevel_RemovesParent()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var parent = await storage.CreateWorkspaceAsync("Parent WS TopLevel Test", cancellationToken: default);
+        var child = await storage.CreateWorkspaceAsync("Child WS Make TopLevel", parentId: parent.Id, cancellationToken: default);
+
+        Assert.Equal(parent.Id, child.ParentId);
+
+        var updated = await storage.UpdateWorkspaceAsync(child.Id, makeTopLevel: true, cancellationToken: default);
+
+        Assert.Null(updated.ParentId);
+
+        // Cleanup
+        await storage.DeleteWorkspaceAsync(child.Id, default);
+        await storage.DeleteWorkspaceAsync(parent.Id, default);
+    }
+
+    [Fact]
+    public async Task ReparentWorkspace_SelfReference_ThrowsInvalidOperation()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var ws = await storage.CreateWorkspaceAsync("Self Ref WS", cancellationToken: default);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            storage.UpdateWorkspaceAsync(ws.Id, newParentId: ws.Id, cancellationToken: default));
+
+        // Cleanup
+        await storage.DeleteWorkspaceAsync(ws.Id, default);
+    }
+
+    [Fact]
+    public async Task ReparentWorkspace_CircularReference_ThrowsInvalidOperation()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var grandparent = await storage.CreateWorkspaceAsync("GP WS Circular", cancellationToken: default);
+        var parent = await storage.CreateWorkspaceAsync("Parent WS Circular", parentId: grandparent.Id, cancellationToken: default);
+        var child = await storage.CreateWorkspaceAsync("Child WS Circular", parentId: parent.Id, cancellationToken: default);
+
+        // Trying to move grandparent under child (circular)
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            storage.UpdateWorkspaceAsync(grandparent.Id, newParentId: child.Id, cancellationToken: default));
+
+        // Cleanup
+        await storage.DeleteWorkspaceAsync(child.Id, default);
+        await storage.DeleteWorkspaceAsync(parent.Id, default);
+        await storage.DeleteWorkspaceAsync(grandparent.Id, default);
+    }
+
+    [Fact]
+    public async Task ReparentWorkspace_BothFlagsSet_ThrowsInvalidOperation()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var parent = await storage.CreateWorkspaceAsync("Parent WS Both Flags", cancellationToken: default);
+        var child = await storage.CreateWorkspaceAsync("Child WS Both Flags", parentId: parent.Id, cancellationToken: default);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            storage.UpdateWorkspaceAsync(child.Id, newParentId: parent.Id, makeTopLevel: true, cancellationToken: default));
+
+        // Cleanup
+        await storage.DeleteWorkspaceAsync(child.Id, default);
+        await storage.DeleteWorkspaceAsync(parent.Id, default);
+    }
+
+    [Fact]
+    public async Task ReparentWorkspace_TargetIsSystemWorkspace_ThrowsInvalidOperation()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var ws = await storage.CreateWorkspaceAsync("WS Move To System", cancellationToken: default);
+
+        // Get system workspaces
+        var allWs = await storage.GetWorkspacesAsync(parentId: null, includeSystem: true, cancellationToken: default);
+        var systemWs = allWs.FirstOrDefault(w => w.IsSystem);
+
+        if (systemWs != null)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                storage.UpdateWorkspaceAsync(ws.Id, newParentId: systemWs.Id, cancellationToken: default));
+        }
+
+        // Cleanup
+        await storage.DeleteWorkspaceAsync(ws.Id, default);
+    }
+}

--- a/src/Memorizer.IntegrationTests/TitleGenerationActorTests.cs
+++ b/src/Memorizer.IntegrationTests/TitleGenerationActorTests.cs
@@ -262,7 +262,10 @@ public class TitleGenerationActorTests : TestKit
         public Task<IReadOnlyList<Workspace>> GetWorkspacesAsync(WorkspaceId? parentId = null, bool includeSystem = false, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<Workspace>>(new List<Workspace>());
 
-        public Task<Workspace> UpdateWorkspaceAsync(WorkspaceId id, string? name = null, string? description = null, CancellationToken cancellationToken = default)
+        public Task<Workspace> UpdateWorkspaceAsync(WorkspaceId id, string? name = null, string? description = null, WorkspaceId? newParentId = null, bool makeTopLevel = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException("Test mock");
+
+        public Task<Project> MoveProjectToWorkspaceAsync(ProjectId id, WorkspaceId newWorkspaceId, ProjectId? newParentId = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException("Test mock");
 
         public Task DeleteWorkspaceAsync(WorkspaceId id, CancellationToken cancellationToken = default)

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -308,7 +308,9 @@ public class MemoryToolsCanonicalUrlTests
             => throw new NotImplementedException();
         public Task<IReadOnlyList<Workspace>> GetWorkspacesAsync(WorkspaceId? parentId = null, bool includeSystem = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
-        public Task<Workspace> UpdateWorkspaceAsync(WorkspaceId id, string? name = null, string? description = null, CancellationToken cancellationToken = default)
+        public Task<Workspace> UpdateWorkspaceAsync(WorkspaceId id, string? name = null, string? description = null, WorkspaceId? newParentId = null, bool makeTopLevel = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<Project> MoveProjectToWorkspaceAsync(ProjectId id, WorkspaceId newWorkspaceId, ProjectId? newParentId = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
         public Task DeleteWorkspaceAsync(WorkspaceId id, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();

--- a/src/Memorizer.UnitTests/Tools/WorkspaceToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/WorkspaceToolsCanonicalUrlTests.cs
@@ -228,7 +228,10 @@ public class WorkspaceToolsCanonicalUrlTests
         public Task<IReadOnlyList<WorkspacePathSegment>> GetWorkspacePathAsync(WorkspaceId id, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<WorkspacePathSegment>>(new List<WorkspacePathSegment>());
 
-        public Task<Workspace> UpdateWorkspaceAsync(WorkspaceId id, string? name = null, string? description = null, CancellationToken cancellationToken = default)
+        public Task<Workspace> UpdateWorkspaceAsync(WorkspaceId id, string? name = null, string? description = null, WorkspaceId? newParentId = null, bool makeTopLevel = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<Project> MoveProjectToWorkspaceAsync(ProjectId id, WorkspaceId newWorkspaceId, ProjectId? newParentId = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task DeleteWorkspaceAsync(WorkspaceId id, CancellationToken cancellationToken = default)

--- a/src/Memorizer/Controllers/ProjectController.cs
+++ b/src/Memorizer/Controllers/ProjectController.cs
@@ -282,9 +282,23 @@ public class ProjectController : ControllerBase
             return NotFound(new { message = $"Workspace with ID {request.WorkspaceId} not found" });
         }
 
-        // Note: This requires adding a MoveProjectAsync method to IStorage
-        // For now, we'll return an error indicating this needs implementation
-        return StatusCode(501, new { message = "Move project functionality not yet implemented in storage layer" });
+        ProjectId? newParentId = request.NewParentId.HasValue
+            ? new ProjectId(request.NewParentId.Value)
+            : null;
+
+        try
+        {
+            var moved = await _storage.MoveProjectToWorkspaceAsync(projectId, newWorkspaceId, newParentId, cancellationToken);
+            return Ok(await ToProjectDto(moved, newWorkspace.Name, cancellationToken));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (Exception ex) when (ex.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase))
+        {
+            return Conflict(new { message = "A project with this name already exists in the target workspace. Rename the project before moving." });
+        }
     }
 
     /// <summary>
@@ -394,4 +408,5 @@ public class UpdateStatusRequest
 public class MoveProjectRequest
 {
     public Guid WorkspaceId { get; set; }
+    public Guid? NewParentId { get; set; }
 }

--- a/src/Memorizer/Controllers/WorkspaceController.cs
+++ b/src/Memorizer/Controllers/WorkspaceController.cs
@@ -211,10 +211,16 @@ public class WorkspaceController : ControllerBase
 
         try
         {
+            WorkspaceId? newParentId = request.NewParentId.HasValue
+                ? new WorkspaceId(request.NewParentId.Value)
+                : null;
+
             var updated = await _storage.UpdateWorkspaceAsync(
                 workspaceId,
                 request.Name,
                 request.Description,
+                newParentId,
+                request.MakeTopLevel,
                 cancellationToken);
 
             var memoryCount = await _storage.GetMemoryCountByOwnerAsync(
@@ -234,9 +240,13 @@ public class WorkspaceController : ControllerBase
                 UpdatedAt = updated.UpdatedAt
             });
         }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
         catch (Exception ex) when (ex.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase))
         {
-            return Conflict(new { message = $"A workspace with the name '{request.Name}' already exists" });
+            return Conflict(new { message = $"A workspace with this name already exists at the target level. Rename the workspace before moving." });
         }
     }
 
@@ -376,4 +386,6 @@ public class UpdateWorkspaceRequest
 {
     public string? Name { get; set; }
     public string? Description { get; set; }
+    public Guid? NewParentId { get; set; }
+    public bool MakeTopLevel { get; set; }
 }

--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -199,12 +199,27 @@ public interface IStorage
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Updates workspace properties.
+    /// Updates workspace properties. Can also reparent the workspace or promote it to top-level.
     /// </summary>
     Task<Workspace> UpdateWorkspaceAsync(
         WorkspaceId id,
         string? name = null,
         string? description = null,
+        WorkspaceId? newParentId = null,
+        bool makeTopLevel = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Moves a project (and all its descendants) to a different workspace.
+    /// </summary>
+    /// <param name="id">The root project to move.</param>
+    /// <param name="newWorkspaceId">The target workspace.</param>
+    /// <param name="newParentId">Optional new parent project in the target workspace. Must belong to the target workspace.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Project> MoveProjectToWorkspaceAsync(
+        ProjectId id,
+        WorkspaceId newWorkspaceId,
+        ProjectId? newParentId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -2434,24 +2449,54 @@ public class Storage : IStorage
         WorkspaceId id,
         string? name = null,
         string? description = null,
+        WorkspaceId? newParentId = null,
+        bool makeTopLevel = false,
         CancellationToken cancellationToken = default)
     {
+        if (newParentId != null && makeTopLevel)
+            throw new InvalidOperationException("Cannot specify both newParentId and makeTopLevel. Use one or the other.");
+
         await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
-        await using var cmd = new NpgsqlCommand(@"
+
+        if (newParentId != null)
+        {
+            // Self-reference check
+            if (newParentId.Value == id)
+                throw new InvalidOperationException("A workspace cannot be its own parent.");
+
+            // Target must exist and not be a system workspace
+            var targetParent = await GetWorkspaceAsync(newParentId.Value, cancellationToken);
+            if (targetParent == null)
+                throw new InvalidOperationException($"Target parent workspace {newParentId.Value.Value} not found.");
+            if (targetParent.IsSystem)
+                throw new InvalidOperationException("Cannot move a workspace under a system workspace.");
+
+            // Circular reference check: newParentId must not be a descendant of id
+            if (await IsWorkspaceDescendantOfAsync(newParentId.Value, id, conn, cancellationToken))
+                throw new InvalidOperationException("Cannot move a workspace under its own descendant. This would create a circular reference.");
+        }
+
+        bool updateParent = newParentId != null || makeTopLevel;
+        var slug = name != null ? GenerateSlug(name) : null;
+
+        var sql = @"
             UPDATE workspaces SET
                 name = COALESCE(@name, name),
                 slug = CASE WHEN @name IS NOT NULL THEN @slug ELSE slug END,
-                description = COALESCE(@description, description),
+                description = COALESCE(@description, description)," +
+            (updateParent ? @"
+                parent_id = @newParentId," : "") + @"
                 updated_at = NOW()
             WHERE id = @id AND is_system = false
-            RETURNING id, parent_id, name, slug, description, is_system, settings, created_at, updated_at", conn);
+            RETURNING id, parent_id, name, slug, description, is_system, settings, created_at, updated_at";
 
-        var slug = name != null ? GenerateSlug(name) : null;
-
+        await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("id", id.Value);
         cmd.Parameters.AddWithValue("name", name ?? (object)DBNull.Value);
         cmd.Parameters.AddWithValue("slug", slug ?? (object)DBNull.Value);
         cmd.Parameters.AddWithValue("description", description ?? (object)DBNull.Value);
+        if (updateParent)
+            cmd.Parameters.AddWithValue("newParentId", makeTopLevel ? DBNull.Value : newParentId!.Value.Value);
 
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
         if (!await reader.ReadAsync(cancellationToken))
@@ -2466,6 +2511,101 @@ public class Storage : IStorage
         }
 
         return workspace;
+    }
+
+    /// <summary>
+    /// Checks if workspaceId is a descendant of potentialAncestorId.
+    /// Used to prevent circular references when reparenting workspaces.
+    /// </summary>
+    private async Task<bool> IsWorkspaceDescendantOfAsync(WorkspaceId workspaceId, WorkspaceId potentialAncestorId, NpgsqlConnection conn, CancellationToken cancellationToken)
+    {
+        await using var cmd = new NpgsqlCommand(@"
+            WITH RECURSIVE descendants AS (
+                SELECT id FROM workspaces WHERE parent_id = @ancestorId
+                UNION ALL
+                SELECT w.id FROM workspaces w
+                INNER JOIN descendants d ON w.parent_id = d.id
+            )
+            SELECT EXISTS (SELECT 1 FROM descendants WHERE id = @workspaceId)", conn);
+
+        cmd.Parameters.AddWithValue("ancestorId", potentialAncestorId.Value);
+        cmd.Parameters.AddWithValue("workspaceId", workspaceId.Value);
+
+        var result = await cmd.ExecuteScalarAsync(cancellationToken);
+        return result is true;
+    }
+
+    public async Task<Project> MoveProjectToWorkspaceAsync(
+        ProjectId id,
+        WorkspaceId newWorkspaceId,
+        ProjectId? newParentId = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Load existing project
+        var existing = await GetProjectAsync(id, cancellationToken);
+        if (existing == null)
+            throw new InvalidOperationException($"Project {id.Value} not found.");
+
+        // Target workspace must exist and not be system
+        var targetWorkspace = await GetWorkspaceAsync(newWorkspaceId, cancellationToken);
+        if (targetWorkspace == null)
+            throw new InvalidOperationException($"Target workspace {newWorkspaceId.Value} not found.");
+        if (targetWorkspace.IsSystem)
+            throw new InvalidOperationException("Cannot move a project into a system workspace.");
+
+        // Already in target workspace
+        if (existing.WorkspaceId == newWorkspaceId)
+            throw new InvalidOperationException("Project is already in the specified workspace.");
+
+        // Validate optional new parent
+        if (newParentId != null)
+        {
+            var newParent = await GetProjectAsync(newParentId.Value, cancellationToken);
+            if (newParent == null)
+                throw new InvalidOperationException($"Target parent project {newParentId.Value.Value} not found.");
+            if (newParent.WorkspaceId != newWorkspaceId)
+                throw new InvalidOperationException("The new parent project must belong to the target workspace.");
+        }
+
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
+
+        // Step 1: Recursively move all descendants (including the root) to the new workspace
+        await using (var updateCmd = new NpgsqlCommand(@"
+            WITH RECURSIVE subtree AS (
+                SELECT id FROM projects WHERE id = @rootId
+                UNION ALL
+                SELECT p.id FROM projects p
+                INNER JOIN subtree s ON p.parent_id = s.id
+            )
+            UPDATE projects SET workspace_id = @newWorkspaceId
+            WHERE id IN (SELECT id FROM subtree)", conn))
+        {
+            updateCmd.Parameters.AddWithValue("rootId", id.Value);
+            updateCmd.Parameters.AddWithValue("newWorkspaceId", newWorkspaceId.Value);
+            await updateCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        // Step 2: Update the root project's parent_id and return it
+        await using var returnCmd = new NpgsqlCommand(@"
+            UPDATE projects SET
+                parent_id = @newParentId,
+                updated_at = NOW()
+            WHERE id = @id
+            RETURNING id, workspace_id, parent_id, name, slug, description, status, victory_conditions, settings, created_at, updated_at, completed_at", conn);
+
+        returnCmd.Parameters.AddWithValue("id", id.Value);
+        returnCmd.Parameters.AddWithValue("newParentId", newParentId.HasValue ? newParentId.Value.Value : DBNull.Value);
+
+        await using var reader = await returnCmd.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+            throw new InvalidOperationException($"Project {id} not found after move.");
+
+        var project = ReadProjectFromReader(reader);
+
+        // Update system memory to reflect new workspace
+        await CreateOrUpdateProjectSystemMemoryAsync(project, cancellationToken);
+
+        return project;
     }
 
     public async Task DeleteWorkspaceAsync(WorkspaceId id, CancellationToken cancellationToken = default)

--- a/src/Memorizer/Tools/WorkspaceTools.cs
+++ b/src/Memorizer/Tools/WorkspaceTools.cs
@@ -241,14 +241,21 @@ public class WorkspaceTools
         }
     }
 
-    [McpServerTool, Description("Update a workspace's properties (name or description).")]
+    [McpServerTool, Description("Update a workspace's properties (name or description). Can also move a workspace under a different parent or promote it to top-level.")]
     public async Task<string> UpdateWorkspace(
         [Description("The workspace ID to update. Use GetWorkspace() to find workspace IDs.")] Guid workspaceId,
         [Description("New name for the workspace. Leave null to keep current.")] string? name = null,
         [Description("New description. Leave null to keep current.")] string? description = null,
+        [Description("New parent workspace ID to move this workspace under. Use GetWorkspace() to find IDs. Cannot be used with makeTopLevel.")] Guid? newParentWorkspaceId = null,
+        [Description("Set to true to remove the workspace from its current parent and make it a top-level workspace. Cannot be used with newParentWorkspaceId.")] bool makeTopLevel = false,
         CancellationToken cancellationToken = default
     )
     {
+        if (newParentWorkspaceId.HasValue && makeTopLevel)
+        {
+            return "Cannot specify both newParentWorkspaceId and makeTopLevel. Use one or the other.";
+        }
+
         var typedWorkspaceId = new WorkspaceId(workspaceId);
 
         // Verify workspace exists
@@ -263,26 +270,38 @@ public class WorkspaceTools
             return "Cannot modify system workspaces.";
         }
 
+        WorkspaceId? typedNewParentId = newParentWorkspaceId.HasValue
+            ? new WorkspaceId(newParentWorkspaceId.Value)
+            : null;
+
         try
         {
             var workspace = await _storage.UpdateWorkspaceAsync(
                 typedWorkspaceId,
                 name,
                 description,
+                typedNewParentId,
+                makeTopLevel,
                 cancellationToken
             );
 
             var changes = new List<string>();
             if (name != null) changes.Add($"name='{name}'");
             if (description != null) changes.Add("description updated");
+            if (newParentWorkspaceId.HasValue) changes.Add($"moved under workspace {newParentWorkspaceId.Value}");
+            if (makeTopLevel) changes.Add("promoted to top-level");
 
             _logger.LogInformation("Updated workspace {WorkspaceId}: {Changes}", workspaceId, string.Join(", ", changes));
 
             return $"Workspace updated successfully. Changes: {string.Join(", ", changes)}";
         }
+        catch (InvalidOperationException ex)
+        {
+            return $"Failed to update workspace: {ex.Message}";
+        }
         catch (Exception ex) when (ex.Message.Contains("duplicate"))
         {
-            return $"Failed to update workspace: A workspace with the name '{name}' already exists.";
+            return $"Failed to update workspace: A workspace with that name already exists at the target level. Rename before moving.";
         }
         catch (Exception ex)
         {
@@ -635,6 +654,7 @@ public class WorkspaceTools
         [Description("New victory conditions. Leave null to keep current.")] string? victoryConditions = null,
         [Description("New parent project ID to move this project under. The parent must be in the same workspace. Cannot be used with makeTopLevel.")] string? parentProjectId = null,
         [Description("Set to true to remove the project from its current parent and make it a top-level project in its workspace. Cannot be used with parentProjectId.")] bool makeTopLevel = false,
+        [Description("Move this project (and all subprojects) to a different workspace. Provide the target workspace ID. Use GetWorkspace() to find workspace IDs.")] Guid? newWorkspaceId = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -643,7 +663,45 @@ public class WorkspaceTools
         // Parse optional Guid defensively — MCP clients may send empty strings or "null"
         var parsedParentProjectId = ParseOptionalGuid(parentProjectId);
 
-        // Validate move parameters
+        // If moving to a different workspace, route to MoveProjectToWorkspaceAsync
+        if (newWorkspaceId.HasValue)
+        {
+            var existing = await _storage.GetProjectAsync(typedProjectId, cancellationToken);
+            if (existing == null)
+                return $"Project with ID {projectId} not found.";
+
+            if (existing.WorkspaceId.Value == newWorkspaceId.Value)
+                return "Project is already in the specified workspace.";
+
+            ProjectId? typedNewParentIdForMove = parsedParentProjectId.HasValue ? new ProjectId(parsedParentProjectId.Value) : null;
+
+            try
+            {
+                var moved = await _storage.MoveProjectToWorkspaceAsync(
+                    typedProjectId,
+                    new WorkspaceId(newWorkspaceId.Value),
+                    typedNewParentIdForMove,
+                    cancellationToken);
+
+                _logger.LogInformation("Moved project {ProjectId} to workspace {WorkspaceId}", projectId, newWorkspaceId.Value);
+                return $"Project moved successfully to workspace {newWorkspaceId.Value}. Project ID: {moved.Id.Value}";
+            }
+            catch (InvalidOperationException ex)
+            {
+                return $"Failed to move project: {ex.Message}";
+            }
+            catch (Exception ex) when (ex.Message.Contains("duplicate"))
+            {
+                return $"Failed to move project: A project with this name already exists in the target workspace. Rename before moving.";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to move project {ProjectId}", projectId);
+                return $"Failed to move project: {ex.Message}";
+            }
+        }
+
+        // Validate same-workspace move parameters
         if (parsedParentProjectId.HasValue && makeTopLevel)
         {
             return "Cannot specify both parentProjectId and makeTopLevel. Use one or the other to move the project.";

--- a/src/Memorizer/Views/Home/ProjectDetail.cshtml
+++ b/src/Memorizer/Views/Home/ProjectDetail.cshtml
@@ -34,9 +34,14 @@
                 </small>
             </div>
         </div>
-        <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editProjectModal">
-            <i class="fas fa-edit me-2"></i>Edit
-        </button>
+        <div class="d-flex gap-2">
+            <button type="button" class="btn btn-outline-secondary" id="moveProjectBtn" data-bs-toggle="modal" data-bs-target="#moveProjectModal" onclick="openMoveProjectModal()">
+                <i class="fas fa-exchange-alt me-2"></i>Move to Workspace
+            </button>
+            <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editProjectModal">
+                <i class="fas fa-edit me-2"></i>Edit
+            </button>
+        </div>
     </div>
 
     <hr>
@@ -219,6 +224,37 @@
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-danger" onclick="deleteProject()">
                     <i class="fas fa-trash me-2"></i>Delete Project
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Move to Workspace Modal -->
+<div class="modal fade" id="moveProjectModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="fas fa-exchange-alt me-2"></i>Move to Workspace</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="move-info-banner mb-3">
+                    <i class="fas fa-info-circle me-2"></i>
+                    All subprojects will be moved along with this project.
+                </div>
+                <div class="mb-3">
+                    <label for="moveWorkspaceSelect" class="form-label">Target Workspace <span class="text-danger">*</span></label>
+                    <select class="form-select" id="moveWorkspaceSelect">
+                        <option value="">Loading workspaces...</option>
+                    </select>
+                </div>
+                <div id="moveProjectError" class="alert alert-danger" style="display: none;"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="confirmMoveProjectBtn" onclick="moveProject()">
+                    <i class="fas fa-exchange-alt me-2"></i>Move Project
                 </button>
             </div>
         </div>
@@ -576,6 +612,71 @@ function escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
+}
+
+async function openMoveProjectModal() {
+    const select = document.getElementById('moveWorkspaceSelect');
+    const errorEl = document.getElementById('moveProjectError');
+    errorEl.style.display = 'none';
+    select.innerHTML = '<option value="">Loading workspaces...</option>';
+
+    try {
+        const response = await fetch('/api/workspace?includeSystem=false');
+        if (!response.ok) throw new Error('Failed to load workspaces');
+        const data = await response.json();
+
+        const workspaces = (data.workspaces || []).filter(w => !w.isSystem && w.id !== project.workspaceId);
+        if (workspaces.length === 0) {
+            select.innerHTML = '<option value="">No other workspaces available</option>';
+            return;
+        }
+
+        select.innerHTML = '<option value="">Select a workspace...</option>' +
+            workspaces.map(w => `<option value="${w.id}">${escapeHtml(w.name)}</option>`).join('');
+    } catch (error) {
+        select.innerHTML = '<option value="">Error loading workspaces</option>';
+    }
+}
+
+async function moveProject() {
+    const workspaceId = document.getElementById('moveWorkspaceSelect').value;
+    const errorEl = document.getElementById('moveProjectError');
+
+    if (!workspaceId) {
+        errorEl.textContent = 'Please select a target workspace.';
+        errorEl.style.display = 'block';
+        return;
+    }
+
+    const btn = document.getElementById('confirmMoveProjectBtn');
+    const originalText = btn.innerHTML;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Moving...';
+    btn.disabled = true;
+    errorEl.style.display = 'none';
+
+    try {
+        const response = await fetch(`/api/project/${projectId}/move`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaceId })
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to move project');
+        }
+
+        const moved = await response.json();
+        bootstrap.Modal.getInstance(document.getElementById('moveProjectModal')).hide();
+        window.location.href = `/projects/${moved.id}`;
+
+    } catch (error) {
+        errorEl.textContent = error.message;
+        errorEl.style.display = 'block';
+    } finally {
+        btn.innerHTML = originalText;
+        btn.disabled = false;
+    }
 }
 </script>
 }

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -28,7 +28,10 @@
                 <span id="workspaceMeta"></span>
             </small>
         </div>
-        <div id="editButton">
+        <div id="editButton" class="d-flex gap-2">
+            <button type="button" class="btn btn-outline-secondary" id="reparentWorkspaceBtn" data-bs-toggle="modal" data-bs-target="#reparentWorkspaceModal" onclick="openReparentModal()">
+                <i class="fas fa-sitemap me-2"></i>Move/Reparent
+            </button>
             <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editWorkspaceModal">
                 <i class="fas fa-edit me-2"></i>Edit
             </button>
@@ -211,6 +214,34 @@
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-primary" id="createChildWorkspaceBtn2" onclick="createChildWorkspace()">
                     <i class="fas fa-plus me-2"></i>Create Workspace
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Move/Reparent Workspace Modal -->
+<div class="modal fade" id="reparentWorkspaceModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="fas fa-sitemap me-2"></i>Move / Reparent Workspace</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label for="reparentSelect" class="form-label">New Parent Workspace</label>
+                    <select class="form-select" id="reparentSelect">
+                        <option value="">Loading workspaces...</option>
+                    </select>
+                    <div class="form-text">Select "None (top-level)" to promote this workspace to a root workspace.</div>
+                </div>
+                <div id="reparentError" class="alert alert-danger" style="display: none;"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="confirmReparentBtn" onclick="reparentWorkspace()">
+                    <i class="fas fa-sitemap me-2"></i>Move Workspace
                 </button>
             </div>
         </div>
@@ -576,6 +607,72 @@ function escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
+}
+
+async function openReparentModal() {
+    const select = document.getElementById('reparentSelect');
+    const errorEl = document.getElementById('reparentError');
+    errorEl.style.display = 'none';
+    select.innerHTML = '<option value="">Loading workspaces...</option>';
+
+    try {
+        const response = await fetch('/api/workspace?includeSystem=false');
+        if (!response.ok) throw new Error('Failed to load workspaces');
+        const data = await response.json();
+
+        // Exclude current workspace and system workspaces
+        const otherWorkspaces = (data.workspaces || []).filter(w => !w.isSystem && w.id !== workspaceId);
+
+        select.innerHTML = '<option value="__toplevel__">None (top-level)</option>' +
+            otherWorkspaces.map(w => `<option value="${w.id}">${escapeHtml(w.name)}</option>`).join('');
+    } catch (error) {
+        select.innerHTML = '<option value="">Error loading workspaces</option>';
+    }
+}
+
+async function reparentWorkspace() {
+    const selectedValue = document.getElementById('reparentSelect').value;
+    const errorEl = document.getElementById('reparentError');
+
+    if (!selectedValue) {
+        errorEl.textContent = 'Please select a target.';
+        errorEl.style.display = 'block';
+        return;
+    }
+
+    const btn = document.getElementById('confirmReparentBtn');
+    const originalText = btn.innerHTML;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Moving...';
+    btn.disabled = true;
+    errorEl.style.display = 'none';
+
+    const isTopLevel = selectedValue === '__toplevel__';
+    const body = isTopLevel
+        ? { makeTopLevel: true }
+        : { newParentId: selectedValue };
+
+    try {
+        const response = await fetch(`/api/workspace/${workspaceId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to move workspace');
+        }
+
+        bootstrap.Modal.getInstance(document.getElementById('reparentWorkspaceModal')).hide();
+        loadWorkspace();
+
+    } catch (error) {
+        errorEl.textContent = error.message;
+        errorEl.style.display = 'block';
+    } finally {
+        btn.innerHTML = originalText;
+        btn.disabled = false;
+    }
 }
 </script>
 }

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -578,3 +578,18 @@ footer a:hover {
     background-color: #495057;
     color: #adb5bd;
 }
+
+/* Move info banner for project/workspace move modals */
+.move-info-banner {
+    background-color: #cce5ff;
+    color: #004085;
+    border: 1px solid #b8daff;
+    border-radius: 0.375rem;
+    padding: 0.75rem 1rem;
+}
+
+[data-theme="dark"] .move-info-banner {
+    background-color: #1a3a5c;
+    color: #93c5fd;
+    border-color: #2d5a8e;
+}


### PR DESCRIPTION
## Summary

- **Move project to a different workspace** — `MoveProjectToWorkspaceAsync` atomically moves a project and all its descendants (recursive CTE) to a target workspace, with an optional new parent project in that workspace
- **Reparent a workspace** — `UpdateWorkspaceAsync` extended with `newParentId`/`makeTopLevel` params; circular-reference guard via `IsWorkspaceDescendantOfAsync`
- Both operations are fully wired through REST API, MCP tools, and UI modals

## Changes

| Layer | What changed |
|-------|-------------|
| Storage (`Memory.cs`) | `IsWorkspaceDescendantOfAsync` helper; extended `UpdateWorkspaceAsync`; new `MoveProjectToWorkspaceAsync` |
| REST (`WorkspaceController`, `ProjectController`) | Extended DTOs; implemented 501-stub `PUT /api/project/{id}/move`; 400/409 error mapping |
| MCP (`WorkspaceTools.cs`) | `newParentWorkspaceId`/`makeTopLevel` on `UpdateWorkspace`; `newWorkspaceId` on `UpdateProject` |
| UI (`ProjectDetail.cshtml`) | "Move to Workspace" button + Bootstrap modal with subproject info banner |
| UI (`WorkspaceDetail.cshtml`) | "Move/Reparent" button + Bootstrap modal with top-level promotion option |
| CSS (`site.css`) | `.move-info-banner` with light + dark mode variants |
| Tests | `MoveOperationsIntegrationTests.cs` — 9 integration test cases |

## Test plan

- [ ] `dotnet test src/Memorizer.IntegrationTests` passes (including new `MoveOperationsIntegrationTests`)
- [ ] ProjectDetail page shows "Move to Workspace" button; modal lists other workspaces; moving a project with subprojects redirects to project in new workspace
- [ ] WorkspaceDetail page shows "Move/Reparent" button (hidden on system workspaces); modal allows selecting parent or "None (top-level)"
- [ ] Circular reference attempt returns a clear error message in both UI and MCP
- [ ] MCP: `update_project` with `newWorkspaceId` moves project; `update_workspace` with `newParentWorkspaceId` reparents workspace