### PR TITLE
 Add cross-project tag filtering with multi-tag selection and dynamic filter panel and MCP tool

### DIFF
--- a/src/Memorizer.IntegrationTests/TitleGenerationActorTests.cs
+++ b/src/Memorizer.IntegrationTests/TitleGenerationActorTests.cs
@@ -166,7 +166,7 @@ public class TitleGenerationActorTests : TestKit
         public Task<List<Memory>> Search(string query, int limit = 10, SimilarityScore? minSimilarity = null, string[]? filterTags = null, bool includeArchived = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException("Test mock");
 
-        public Task<(List<Memory> Memories, int TotalCount)> GetMemoriesPaginated(int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
+        public Task<(List<Memory> Memories, int TotalCount)> GetMemoriesPaginated(int page = 1, int pageSize = 20, string? memoryType = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException("Test mock");
 
         public Task<Memory?> UpdateMemory(MemoryId id, string type, string content, string source, string[]? tags, Confidence confidence, string? title = null, CancellationToken cancellationToken = default)
@@ -189,6 +189,11 @@ public class TitleGenerationActorTests : TestKit
 
         public Task<List<string>> GetDistinctMemoryTypes(CancellationToken cancellationToken = default)
             => Task.FromResult(new List<string> { "test", "mock" });
+        public Task<List<string>> GetDistinctTagsAsync(MemoryOwner? owner = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<string>());
+
+        public Task<List<MemoryOwner>> GetDistinctOwnersAsync(string[]? tags = null, string? memoryType = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<MemoryOwner>());
 
         public Task<int> CountMemoriesWithoutMetadataEmbeddings(CancellationToken cancellationToken = default)
             => Task.FromResult(0);
@@ -294,17 +299,20 @@ public class TitleGenerationActorTests : TestKit
         public Task MoveMemoryToUnfiledAsync(MemoryId memoryId, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
 
-        public Task<IReadOnlyList<Memory>> GetMemoriesByOwnerAsync(MemoryOwner owner, int page = 1, int pageSize = 50, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Memory>> GetMemoriesByOwnerAsync(MemoryOwner owner, int page = 1, int pageSize = 50, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<Memory>>(new List<Memory>());
 
-        public Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, CancellationToken cancellationToken = default)
+        public Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult(0);
 
-        public Task<IReadOnlyList<Memory>> GetUnfiledMemoriesAsync(int page = 1, int pageSize = 50, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Memory>> GetUnfiledMemoriesAsync(int page = 1, int pageSize = 50, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<Memory>>(new List<Memory>());
 
-        public Task<int> GetUnfiledMemoryCountAsync(CancellationToken cancellationToken = default)
+        public Task<int> GetUnfiledMemoryCountAsync(string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult(0);
+
+        public Task<(IReadOnlyList<Memory> Memories, int TotalCount)> GetMemoriesByTagAsync(string[] tags, int page = 1, int pageSize = 20, MemoryOwner? owner = null, string? memoryType = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<(IReadOnlyList<Memory>, int)>((new List<Memory>(), 0));
 
         // Archival operations
         public Task<Memory?> UpdateMemoryArchetypeAsync(MemoryId memoryId, ArchetypeEnum newArchetype, CancellationToken cancellationToken = default)

--- a/src/Memorizer.IntegrationTests/WebUIIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/WebUIIntegrationTests.cs
@@ -124,8 +124,8 @@ public class WebUIIntegrationTests : IDisposable
             }
 
             // Act - Test pagination
-            var (page1Memories, page1Total) = await storage.GetMemoriesPaginated(1, 10, CancellationToken.None);
-            var (page2Memories, page2Total) = await storage.GetMemoriesPaginated(2, 10, CancellationToken.None);
+            var (page1Memories, page1Total) = await storage.GetMemoriesPaginated(1, 10, cancellationToken: CancellationToken.None);
+            var (page2Memories, page2Total) = await storage.GetMemoriesPaginated(2, 10, cancellationToken: CancellationToken.None);
 
             // Assert
             Assert.Equal(10, page1Memories.Count);

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -254,10 +254,14 @@ public class MemoryToolsCanonicalUrlTests
             => throw new NotImplementedException();
 
         // Pagination and listing
-        public Task<(List<Memory> Memories, int TotalCount)> GetMemoriesPaginated(int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
+        public Task<(List<Memory> Memories, int TotalCount)> GetMemoriesPaginated(int page = 1, int pageSize = 20, string? memoryType = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
         public Task<List<string>> GetDistinctMemoryTypes(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
+        public Task<List<string>> GetDistinctTagsAsync(MemoryOwner? owner = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<List<MemoryOwner>> GetDistinctOwnersAsync(string[]? tags = null, string? memoryType = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<MemoryOwner>());
 
         // Title generation
         public Task<List<Memory>> GetMemoriesWithoutTitles(int limit = 50, CancellationToken cancellationToken = default)
@@ -290,14 +294,16 @@ public class MemoryToolsCanonicalUrlTests
             => Task.FromResult<(IReadOnlyList<Memory> Memories, int TotalCount)>((new List<Memory>(), 0));
 
         // Owner-based queries
-        public Task<IReadOnlyList<Memory>> GetMemoriesByOwnerAsync(MemoryOwner owner, int page = 1, int pageSize = 50, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Memory>> GetMemoriesByOwnerAsync(MemoryOwner owner, int page = 1, int pageSize = 50, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<Memory>>(new List<Memory>());
-        public Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, CancellationToken cancellationToken = default)
+        public Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult(0);
-        public Task<IReadOnlyList<Memory>> GetUnfiledMemoriesAsync(int page = 1, int pageSize = 50, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Memory>> GetUnfiledMemoriesAsync(int page = 1, int pageSize = 50, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<Memory>>(new List<Memory>());
-        public Task<int> GetUnfiledMemoryCountAsync(CancellationToken cancellationToken = default)
+        public Task<int> GetUnfiledMemoryCountAsync(string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult(0);
+        public Task<(IReadOnlyList<Memory> Memories, int TotalCount)> GetMemoriesByTagAsync(string[] tags, int page = 1, int pageSize = 20, MemoryOwner? owner = null, string? memoryType = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<(IReadOnlyList<Memory>, int)>((new List<Memory>(), 0));
 
         // Workspace operations
         public Task<Workspace> CreateWorkspaceAsync(string name, string? description = null, WorkspaceId? parentId = null, CancellationToken cancellationToken = default)

--- a/src/Memorizer.UnitTests/Tools/WorkspaceToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/WorkspaceToolsCanonicalUrlTests.cs
@@ -300,10 +300,14 @@ public class WorkspaceToolsCanonicalUrlTests
             => throw new NotImplementedException();
         public Task<List<Memory>> Search(string query, int limit = 10, SimilarityScore? minSimilarity = null, string[]? filterTags = null, bool includeArchived = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
-        public Task<(List<Memory> Memories, int TotalCount)> GetMemoriesPaginated(int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
+        public Task<(List<Memory> Memories, int TotalCount)> GetMemoriesPaginated(int page = 1, int pageSize = 20, string? memoryType = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
         public Task<List<string>> GetDistinctMemoryTypes(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
+        public Task<List<string>> GetDistinctTagsAsync(MemoryOwner? owner = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<List<MemoryOwner>> GetDistinctOwnersAsync(string[]? tags = null, string? memoryType = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<MemoryOwner>());
         public Task<List<Memory>> GetMemoriesWithoutTitles(int limit = 50, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
         public Task UpdateMemoryTitle(MemoryId id, string title, CancellationToken cancellationToken = default)
@@ -334,14 +338,16 @@ public class WorkspaceToolsCanonicalUrlTests
             => throw new NotImplementedException();
         public Task<(IReadOnlyList<Memory> Memories, int TotalCount)> GetArchivedMemoriesAsync(int page = 1, int pageSize = 50, ProjectId? projectId = null, CancellationToken cancellationToken = default)
             => Task.FromResult<(IReadOnlyList<Memory> Memories, int TotalCount)>((new List<Memory>(), 0));
-        public Task<IReadOnlyList<Memory>> GetMemoriesByOwnerAsync(MemoryOwner owner, int page = 1, int pageSize = 50, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Memory>> GetMemoriesByOwnerAsync(MemoryOwner owner, int page = 1, int pageSize = 50, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<Memory>>(new List<Memory>());
-        public Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, CancellationToken cancellationToken = default)
+        public Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult(0);
-        public Task<IReadOnlyList<Memory>> GetUnfiledMemoriesAsync(int page = 1, int pageSize = 50, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Memory>> GetUnfiledMemoriesAsync(int page = 1, int pageSize = 50, string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<Memory>>(new List<Memory>());
-        public Task<int> GetUnfiledMemoryCountAsync(CancellationToken cancellationToken = default)
+        public Task<int> GetUnfiledMemoryCountAsync(string? memoryType = null, CancellationToken cancellationToken = default)
             => Task.FromResult(0);
+        public Task<(IReadOnlyList<Memory> Memories, int TotalCount)> GetMemoriesByTagAsync(string[] tags, int page = 1, int pageSize = 20, MemoryOwner? owner = null, string? memoryType = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<(IReadOnlyList<Memory>, int)>((new List<Memory>(), 0));
 
         // Provider settings
         public Task<ProviderSettings?> GetActiveProviderAsync(string providerType, CancellationToken cancellationToken = default)

--- a/src/Memorizer/Actors/EmbeddingRegenerationActor.cs
+++ b/src/Memorizer/Actors/EmbeddingRegenerationActor.cs
@@ -123,7 +123,7 @@ public sealed class EmbeddingRegenerationActor : ReceiveActor
             var storage = _currentScope.ServiceProvider.GetRequiredService<IStorage>();
 
             // Get total count first to size the job
-            var (_, totalCount) = await storage.GetMemoriesPaginated(1, 1);
+            var (_, totalCount) = await storage.GetMemoriesPaginated(1, 1, cancellationToken: default);
 
             // Create job manager and start job
             _jobManager = new ProgressJobManager(_logger, _materializer);
@@ -187,7 +187,7 @@ public sealed class EmbeddingRegenerationActor : ReceiveActor
         try
         {
             var storage = _currentScope.ServiceProvider.GetRequiredService<IStorage>();
-            var (memories, _) = await storage.GetMemoriesPaginated(_currentPage, _pageSize);
+            var (memories, _) = await storage.GetMemoriesPaginated(_currentPage, _pageSize, cancellationToken: default);
 
             if (memories.Count == 0)
             {

--- a/src/Memorizer/Controllers/HomeController.cs
+++ b/src/Memorizer/Controllers/HomeController.cs
@@ -204,7 +204,7 @@ public class HomeController : Controller
         }
 
         // Get unfiled memory count
-        var unfiledCount = await _storage.GetUnfiledMemoryCountAsync(cancellationToken);
+        var unfiledCount = await _storage.GetUnfiledMemoryCountAsync(cancellationToken: cancellationToken);
 
         var result = new
         {
@@ -219,7 +219,7 @@ public class HomeController : Controller
     {
         // Get memory count directly in this workspace (not in projects)
         var directMemoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForWorkspace(workspace.Id), cancellationToken);
+            MemoryOwner.ForWorkspace(workspace.Id), cancellationToken: cancellationToken);
 
         // Get projects in this workspace and build nodes, also aggregate project memory counts
         var projects = await _storage.GetProjectsAsync(workspace.Id, parentId: null, statusFilter: null, cancellationToken);
@@ -266,7 +266,7 @@ public class HomeController : Controller
     {
         // Get memory count for this project
         var memoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForProject(project.Id), cancellationToken);
+            MemoryOwner.ForProject(project.Id), cancellationToken: cancellationToken);
 
         // Get child projects (nested)
         var childProjects = await _storage.GetProjectsAsync(project.WorkspaceId, parentId: project.Id, statusFilter: null, cancellationToken);

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -33,7 +33,9 @@ public class MemoryController : ControllerBase
         int pageSize = 20,
         [FromQuery] Guid? workspaceId = null,
         [FromQuery] Guid? projectId = null,
-        [FromQuery] bool unfiled = false)
+        [FromQuery] bool unfiled = false,
+        [FromQuery] string[]? tag = null,
+        [FromQuery] string? type = null)
     {
         if (page < 1) page = 1;
         if (pageSize < 1 || pageSize > 100) pageSize = 20;
@@ -41,27 +43,45 @@ public class MemoryController : ControllerBase
         List<Memory> memories;
         int totalCount;
 
-        // Priority: projectId > workspaceId > unfiled > all
-        if (projectId.HasValue)
+        // Filter out empty tags
+        var validTags = tag?.Where(t => !string.IsNullOrWhiteSpace(t)).ToArray() ?? [];
+
+        // Priority: tags > projectId > workspaceId > unfiled > all
+        if (validTags.Length > 0)
+        {
+            // Tag filter can be combined with project/workspace/unfiled scope
+            MemoryOwner? owner = null;
+            if (projectId.HasValue)
+                owner = MemoryOwner.ForProject(new ProjectId(projectId.Value));
+            else if (workspaceId.HasValue)
+                owner = MemoryOwner.ForWorkspace(new WorkspaceId(workspaceId.Value));
+            else if (unfiled)
+                owner = MemoryOwner.Unfiled;
+
+            var (tagMemories, tagCount) = await _storage.GetMemoriesByTagAsync(validTags, page, pageSize, owner, type);
+            memories = tagMemories.ToList();
+            totalCount = tagCount;
+        }
+        else if (projectId.HasValue)
         {
             var owner = MemoryOwner.ForProject(new ProjectId(projectId.Value));
-            memories = (await _storage.GetMemoriesByOwnerAsync(owner, page, pageSize)).ToList();
-            totalCount = await _storage.GetMemoryCountByOwnerAsync(owner);
+            memories = (await _storage.GetMemoriesByOwnerAsync(owner, page, pageSize, type)).ToList();
+            totalCount = await _storage.GetMemoryCountByOwnerAsync(owner, type);
         }
         else if (workspaceId.HasValue)
         {
             var owner = MemoryOwner.ForWorkspace(new WorkspaceId(workspaceId.Value));
-            memories = (await _storage.GetMemoriesByOwnerAsync(owner, page, pageSize)).ToList();
-            totalCount = await _storage.GetMemoryCountByOwnerAsync(owner);
+            memories = (await _storage.GetMemoriesByOwnerAsync(owner, page, pageSize, type)).ToList();
+            totalCount = await _storage.GetMemoryCountByOwnerAsync(owner, type);
         }
         else if (unfiled)
         {
-            memories = (await _storage.GetUnfiledMemoriesAsync(page, pageSize)).ToList();
-            totalCount = await _storage.GetUnfiledMemoryCountAsync();
+            memories = (await _storage.GetUnfiledMemoriesAsync(page, pageSize, type)).ToList();
+            totalCount = await _storage.GetUnfiledMemoryCountAsync(type);
         }
         else
         {
-            (memories, totalCount) = await _storage.GetMemoriesPaginated(page, pageSize);
+            (memories, totalCount) = await _storage.GetMemoriesPaginated(page, pageSize, type);
         }
 
         return Ok(new MemoryListResponse
@@ -96,6 +116,41 @@ public class MemoryController : ControllerBase
     {
         var types = await _storage.GetDistinctMemoryTypes();
         return Ok(types);
+    }
+
+    /// <summary>
+    /// Get all distinct tags across non-archived memories, optionally scoped by workspace/project
+    /// </summary>
+    [HttpGet("tags")]
+    public async Task<ActionResult<List<string>>> GetDistinctTags(
+        [FromQuery] Guid? workspaceId = null,
+        [FromQuery] Guid? projectId = null)
+    {
+        MemoryOwner? owner = null;
+        if (projectId.HasValue)
+            owner = MemoryOwner.ForProject(new ProjectId(projectId.Value));
+        else if (workspaceId.HasValue)
+            owner = MemoryOwner.ForWorkspace(new WorkspaceId(workspaceId.Value));
+
+        var tags = await _storage.GetDistinctTagsAsync(owner);
+        return Ok(tags);
+    }
+
+    /// <summary>
+    /// Get distinct owner (type, id) pairs for memories matching the given filters
+    /// </summary>
+    [HttpGet("owners")]
+    public async Task<ActionResult<List<OwnerDto>>> GetDistinctOwners(
+        [FromQuery] string[]? tag = null,
+        [FromQuery] string? type = null)
+    {
+        var validTags = tag?.Where(t => !string.IsNullOrWhiteSpace(t)).ToArray();
+        var owners = await _storage.GetDistinctOwnersAsync(validTags, type);
+        return Ok(owners.Select(o => new OwnerDto
+        {
+            Type = o.Type.ToString(),
+            Id = o.Id
+        }).ToList());
     }
 
     /// <summary>
@@ -906,4 +961,10 @@ public class ArchivedMemoryListResponse
     public int Page { get; set; }
     public int PageSize { get; set; }
     public int TotalPages { get; set; }
+}
+
+public class OwnerDto
+{
+    public string Type { get; set; } = string.Empty;
+    public Guid Id { get; set; }
 } 

--- a/src/Memorizer/Controllers/ProjectController.cs
+++ b/src/Memorizer/Controllers/ProjectController.cs
@@ -88,11 +88,11 @@ public class ProjectController : ControllerBase
 
         var workspace = await _storage.GetWorkspaceAsync(project.WorkspaceId, cancellationToken);
         var memoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForProject(projectId), cancellationToken);
+            MemoryOwner.ForProject(projectId), cancellationToken: cancellationToken);
 
         // Get recent memories in this project
         var recentMemories = await _storage.GetMemoriesByOwnerAsync(
-            MemoryOwner.ForProject(projectId), 1, 10, cancellationToken);
+            MemoryOwner.ForProject(projectId), 1, 10, cancellationToken: cancellationToken);
 
         // Get child projects
         var childProjects = await _storage.GetProjectsAsync(
@@ -319,7 +319,7 @@ public class ProjectController : ControllerBase
 
         // Get memory count for info
         var memoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForProject(projectId), cancellationToken);
+            MemoryOwner.ForProject(projectId), cancellationToken: cancellationToken);
 
         await _storage.DeleteProjectAsync(projectId, cancellationToken);
 
@@ -332,7 +332,7 @@ public class ProjectController : ControllerBase
     private async Task<ProjectDto> ToProjectDto(Project project, string workspaceName, CancellationToken cancellationToken)
     {
         var memoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForProject(project.Id), cancellationToken);
+            MemoryOwner.ForProject(project.Id), cancellationToken: cancellationToken);
 
         return new ProjectDto
         {

--- a/src/Memorizer/Controllers/SearchEvalController.cs
+++ b/src/Memorizer/Controllers/SearchEvalController.cs
@@ -467,7 +467,7 @@ public class SearchEvalController : ControllerBase
             const int pageSize = 50;
             while (true)
             {
-                var memories = await _storage.GetMemoriesByOwnerAsync(owner, page, pageSize, cancellationToken);
+                var memories = await _storage.GetMemoriesByOwnerAsync(owner, page, pageSize, cancellationToken: cancellationToken);
                 if (memories.Count == 0) break;
 
                 foreach (var memory in memories)

--- a/src/Memorizer/Controllers/WorkspaceController.cs
+++ b/src/Memorizer/Controllers/WorkspaceController.cs
@@ -77,7 +77,7 @@ public class WorkspaceController : ControllerBase
         foreach (var proj in projects)
         {
             var projMemoryCount = await _storage.GetMemoryCountByOwnerAsync(
-                MemoryOwner.ForProject(proj.Id), cancellationToken);
+                MemoryOwner.ForProject(proj.Id), cancellationToken: cancellationToken);
             totalProjectMemories += projMemoryCount;
             projectDtos.Add(new ProjectSummaryDto
             {
@@ -92,14 +92,14 @@ public class WorkspaceController : ControllerBase
 
         // Get memories directly in this workspace (not in projects)
         var directMemoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForWorkspace(workspaceId), cancellationToken);
+            MemoryOwner.ForWorkspace(workspaceId), cancellationToken: cancellationToken);
 
         // Total includes workspace memories + all project memories
         var totalMemoryCount = directMemoryCount + totalProjectMemories;
 
         // Get recent memories directly in this workspace
         var recentMemories = await _storage.GetMemoriesByOwnerAsync(
-            MemoryOwner.ForWorkspace(workspaceId), 1, 5, cancellationToken);
+            MemoryOwner.ForWorkspace(workspaceId), 1, 5, cancellationToken: cancellationToken);
 
         // Get child workspaces (nested workspaces)
         var childWorkspaces = await _storage.GetWorkspacesAsync(parentId: workspaceId, includeSystem: false, cancellationToken);
@@ -224,7 +224,7 @@ public class WorkspaceController : ControllerBase
                 cancellationToken);
 
             var memoryCount = await _storage.GetMemoryCountByOwnerAsync(
-                MemoryOwner.ForWorkspace(workspaceId), cancellationToken);
+                MemoryOwner.ForWorkspace(workspaceId), cancellationToken: cancellationToken);
             var projects = await _storage.GetProjectsAsync(workspaceId, parentId: null, statusFilter: null, cancellationToken);
 
             return Ok(new WorkspaceDto
@@ -273,7 +273,7 @@ public class WorkspaceController : ControllerBase
 
         // Get counts for warning
         var memoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForWorkspace(workspaceId), cancellationToken);
+            MemoryOwner.ForWorkspace(workspaceId), cancellationToken: cancellationToken);
         var projects = await _storage.GetProjectsAsync(workspaceId, parentId: null, statusFilter: null, cancellationToken);
 
         await _storage.DeleteWorkspaceAsync(workspaceId, cancellationToken);
@@ -294,7 +294,7 @@ public class WorkspaceController : ControllerBase
     {
         // Get memories directly in the workspace
         var directMemoryCount = await _storage.GetMemoryCountByOwnerAsync(
-            MemoryOwner.ForWorkspace(workspaceId), cancellationToken);
+            MemoryOwner.ForWorkspace(workspaceId), cancellationToken: cancellationToken);
 
         // Get all projects in the workspace
         var projects = await _storage.GetProjectsAsync(workspaceId, parentId: null, statusFilter: null, cancellationToken);
@@ -304,7 +304,7 @@ public class WorkspaceController : ControllerBase
         foreach (var project in projects)
         {
             var projMemCount = await _storage.GetMemoryCountByOwnerAsync(
-                MemoryOwner.ForProject(project.Id), cancellationToken);
+                MemoryOwner.ForProject(project.Id), cancellationToken: cancellationToken);
             projectMemoryCount += projMemCount;
         }
 

--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -63,6 +63,7 @@ public interface IStorage
     Task<(List<Memorizer.Models.Memory> Memories, int TotalCount)> GetMemoriesPaginated(
         int page = 1,
         int pageSize = 20,
+        string? memoryType = null,
         CancellationToken cancellationToken = default
     );
 
@@ -80,6 +81,16 @@ public interface IStorage
 
     // Get distinct memory types
     Task<List<string>> GetDistinctMemoryTypes(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all distinct tags across all non-archived memories, sorted alphabetically.
+    /// </summary>
+    Task<List<string>> GetDistinctTagsAsync(MemoryOwner? owner = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets distinct owner (type, id) pairs for memories matching the given filters.
+    /// </summary>
+    Task<List<MemoryOwner>> GetDistinctOwnersAsync(string[]? tags = null, string? memoryType = null, CancellationToken cancellationToken = default);
 
     // Title generation support
     Task<List<Memorizer.Models.Memory>> GetMemoriesWithoutTitles(
@@ -355,12 +366,13 @@ public interface IStorage
         MemoryOwner owner,
         int page = 1,
         int pageSize = 50,
+        string? memoryType = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the count of memories for an owner.
     /// </summary>
-    Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, CancellationToken cancellationToken = default);
+    Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, string? memoryType = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets unfiled memories (convenience method).
@@ -368,12 +380,25 @@ public interface IStorage
     Task<IReadOnlyList<Memorizer.Models.Memory>> GetUnfiledMemoriesAsync(
         int page = 1,
         int pageSize = 50,
+        string? memoryType = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the count of unfiled memories.
     /// </summary>
-    Task<int> GetUnfiledMemoryCountAsync(CancellationToken cancellationToken = default);
+    Task<int> GetUnfiledMemoryCountAsync(string? memoryType = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets memories matching one or more tags (case-insensitive, AND logic) with pagination.
+    /// Optionally scoped to a specific owner (workspace/project).
+    /// </summary>
+    Task<(IReadOnlyList<Memorizer.Models.Memory> Memories, int TotalCount)> GetMemoriesByTagAsync(
+        string[] tags,
+        int page = 1,
+        int pageSize = 20,
+        MemoryOwner? owner = null,
+        string? memoryType = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Seeds system memories for all projects and workspaces that don't have them.
@@ -900,27 +925,32 @@ public class Storage : IStorage
     public async Task<(List<Memorizer.Models.Memory> Memories, int TotalCount)> GetMemoriesPaginated(
         int page = 1,
         int pageSize = 20,
+        string? memoryType = null,
         CancellationToken cancellationToken = default
     )
     {
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
-        
+
+        var typeClause = !string.IsNullOrWhiteSpace(memoryType) ? " AND type_legacy = @memoryType" : "";
+
         // Get total count first
         // Exclude System (3) and Archived (2) memories from user-facing lists
-        const string countSql = "SELECT COUNT(*) FROM memories WHERE archetype IN (0, 1)";
+        var countSql = $"SELECT COUNT(*) FROM memories WHERE archetype IN (0, 1){typeClause}";
         await using NpgsqlCommand countCmd = new(countSql, connection);
+        if (!string.IsNullOrWhiteSpace(memoryType)) countCmd.Parameters.AddWithValue("memoryType", memoryType);
         var countResult = await countCmd.ExecuteScalarAsync(cancellationToken);
         var totalCount = countResult is null ? 0L : Convert.ToInt64(countResult);
-        
+
         // Get paginated results
-        const string sql = @"
+        var sql = $@"
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence, created_at, updated_at, title, current_version, owner_type, owner_id, archetype
             FROM memories
-            WHERE archetype IN (0, 1)
+            WHERE archetype IN (0, 1){typeClause}
             ORDER BY created_at DESC
             LIMIT @limit OFFSET @offset";
 
         await using NpgsqlCommand cmd = new(sql, connection);
+        if (!string.IsNullOrWhiteSpace(memoryType)) cmd.Parameters.AddWithValue("memoryType", memoryType);
         cmd.Parameters.AddWithValue("limit", pageSize);
         cmd.Parameters.AddWithValue("offset", (page - 1) * pageSize);
 
@@ -1735,6 +1765,79 @@ public class Storage : IStorage
         while (await reader.ReadAsync(cancellationToken))
         {
             result.Add(reader.GetString(0));
+        }
+
+        return result;
+    }
+
+    public async Task<List<string>> GetDistinctTagsAsync(MemoryOwner? owner = null, CancellationToken cancellationToken = default)
+    {
+        var ownerClause = "";
+        if (owner.HasValue)
+        {
+            ownerClause = " AND owner_type = @ownerType AND owner_id = @ownerId";
+        }
+
+        var sql = $@"
+            SELECT DISTINCT tag
+            FROM memories, unnest(tags) AS tag
+            WHERE archetype IN (0, 1){ownerClause}
+            ORDER BY tag";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        if (owner.HasValue)
+        {
+            command.Parameters.AddWithValue("ownerType", (short)owner.Value.Type);
+            command.Parameters.AddWithValue("ownerId", owner.Value.Id);
+        }
+
+        var result = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(reader.GetString(0));
+        }
+
+        return result;
+    }
+
+    public async Task<List<MemoryOwner>> GetDistinctOwnersAsync(string[]? tags = null, string? memoryType = null, CancellationToken cancellationToken = default)
+    {
+        var clauses = new List<string> { "archetype IN (0, 1)" };
+
+        var validTags = tags?.Where(t => !string.IsNullOrWhiteSpace(t)).ToArray() ?? [];
+        for (var i = 0; i < validTags.Length; i++)
+        {
+            clauses.Add($"EXISTS (SELECT 1 FROM unnest(tags) t WHERE lower(t) = lower(@tag{i}))");
+        }
+
+        if (!string.IsNullOrWhiteSpace(memoryType))
+        {
+            clauses.Add("type_legacy = @memoryType");
+        }
+
+        var where = string.Join(" AND ", clauses);
+        var sql = $"SELECT DISTINCT owner_type, owner_id FROM memories WHERE {where}";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        for (var i = 0; i < validTags.Length; i++)
+            command.Parameters.AddWithValue($"tag{i}", validTags[i]);
+        if (!string.IsNullOrWhiteSpace(memoryType))
+            command.Parameters.AddWithValue("memoryType", memoryType);
+
+        var result = new List<MemoryOwner>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var ownerType = (OwnerTypeEnum)reader.GetInt16(0);
+            var ownerId = reader.GetGuid(1);
+            result.Add(new MemoryOwner { Type = ownerType, Id = ownerId });
         }
 
         return result;
@@ -3696,21 +3799,24 @@ public class Storage : IStorage
         MemoryOwner owner,
         int page = 1,
         int pageSize = 50,
+        string? memoryType = null,
         CancellationToken cancellationToken = default)
     {
         await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
+        var typeClause = !string.IsNullOrWhiteSpace(memoryType) ? " AND type_legacy = @memoryType" : "";
         // Exclude System memories (archetype = 3) and Archived memories (archetype = 2) from normal queries
-        await using var cmd = new NpgsqlCommand(@"
+        await using var cmd = new NpgsqlCommand($@"
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence,
-                   created_at, updated_at, title, current_version
+                   created_at, updated_at, title, current_version, owner_type, owner_id, archetype
             FROM memories
             WHERE owner_type = @ownerType AND owner_id = @ownerId
-              AND archetype IN (0, 1)
+              AND archetype IN (0, 1){typeClause}
             ORDER BY updated_at DESC
             LIMIT @limit OFFSET @offset", conn);
 
         cmd.Parameters.AddWithValue("ownerType", (short)owner.Type);
         cmd.Parameters.AddWithValue("ownerId", owner.Id);
+        if (!string.IsNullOrWhiteSpace(memoryType)) cmd.Parameters.AddWithValue("memoryType", memoryType);
         cmd.Parameters.AddWithValue("limit", pageSize);
         cmd.Parameters.AddWithValue("offset", (page - 1) * pageSize);
 
@@ -3718,22 +3824,24 @@ public class Storage : IStorage
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
-            results.Add(ReadMemoryFromReaderLegacy(reader));
+            results.Add(ReadMemoryFromReader(reader, withSimilarity: false));
         }
         return results;
     }
 
-    public async Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, CancellationToken cancellationToken = default)
+    public async Task<int> GetMemoryCountByOwnerAsync(MemoryOwner owner, string? memoryType = null, CancellationToken cancellationToken = default)
     {
         await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
+        var typeClause = !string.IsNullOrWhiteSpace(memoryType) ? " AND type_legacy = @memoryType" : "";
         // Exclude System memories (archetype = 3) and Archived memories (archetype = 2) from normal queries
-        await using var cmd = new NpgsqlCommand(@"
+        await using var cmd = new NpgsqlCommand($@"
             SELECT COUNT(*) FROM memories
             WHERE owner_type = @ownerType AND owner_id = @ownerId
-              AND archetype IN (0, 1)", conn);
+              AND archetype IN (0, 1){typeClause}", conn);
 
         cmd.Parameters.AddWithValue("ownerType", (short)owner.Type);
         cmd.Parameters.AddWithValue("ownerId", owner.Id);
+        if (!string.IsNullOrWhiteSpace(memoryType)) cmd.Parameters.AddWithValue("memoryType", memoryType);
 
         var result = await cmd.ExecuteScalarAsync(cancellationToken);
         return Convert.ToInt32(result);
@@ -3742,14 +3850,102 @@ public class Storage : IStorage
     public Task<IReadOnlyList<Memorizer.Models.Memory>> GetUnfiledMemoriesAsync(
         int page = 1,
         int pageSize = 50,
+        string? memoryType = null,
         CancellationToken cancellationToken = default)
     {
-        return GetMemoriesByOwnerAsync(MemoryOwner.Unfiled, page, pageSize, cancellationToken);
+        return GetMemoriesByOwnerAsync(MemoryOwner.Unfiled, page, pageSize, memoryType, cancellationToken);
     }
 
-    public Task<int> GetUnfiledMemoryCountAsync(CancellationToken cancellationToken = default)
+    public Task<int> GetUnfiledMemoryCountAsync(string? memoryType = null, CancellationToken cancellationToken = default)
     {
-        return GetMemoryCountByOwnerAsync(MemoryOwner.Unfiled, cancellationToken);
+        return GetMemoryCountByOwnerAsync(MemoryOwner.Unfiled, memoryType, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<Memorizer.Models.Memory> Memories, int TotalCount)> GetMemoriesByTagAsync(
+        string[] tags,
+        int page = 1,
+        int pageSize = 20,
+        MemoryOwner? owner = null,
+        string? memoryType = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var conn = await _dataSource.OpenConnectionAsync(cancellationToken);
+
+        // Build tag filter: each tag must match at least one element (AND logic)
+        var tagClauses = new List<string>();
+        for (var i = 0; i < tags.Length; i++)
+        {
+            tagClauses.Add($"EXISTS (SELECT 1 FROM unnest(tags) t WHERE lower(t) = lower(@tag{i}))");
+        }
+        var tagFilter = string.Join(" AND ", tagClauses);
+
+        // Build optional owner filter clause
+        var ownerClause = "";
+        if (owner.HasValue)
+        {
+            ownerClause = " AND owner_type = @ownerType AND owner_id = @ownerId";
+        }
+
+        // Build optional type filter clause
+        var typeClause = "";
+        if (!string.IsNullOrWhiteSpace(memoryType))
+        {
+            typeClause = " AND type_legacy = @memoryType";
+        }
+
+        void AddTagParams(NpgsqlCommand c)
+        {
+            for (var i = 0; i < tags.Length; i++)
+                c.Parameters.AddWithValue($"tag{i}", tags[i]);
+        }
+
+        void AddOwnerParams(NpgsqlCommand c)
+        {
+            if (!owner.HasValue) return;
+            c.Parameters.AddWithValue("ownerType", (short)owner.Value.Type);
+            c.Parameters.AddWithValue("ownerId", owner.Value.Id);
+        }
+
+        void AddTypeParam(NpgsqlCommand c)
+        {
+            if (!string.IsNullOrWhiteSpace(memoryType))
+                c.Parameters.AddWithValue("memoryType", memoryType);
+        }
+
+        // Count query
+        await using var countCmd = new NpgsqlCommand($@"
+            SELECT COUNT(*) FROM memories
+            WHERE archetype IN (0, 1)
+              AND {tagFilter}{ownerClause}{typeClause}", conn);
+        AddTagParams(countCmd);
+        AddOwnerParams(countCmd);
+        AddTypeParam(countCmd);
+        var countResult = await countCmd.ExecuteScalarAsync(cancellationToken);
+        var totalCount = Convert.ToInt32(countResult);
+
+        // Paginated results
+        await using var cmd = new NpgsqlCommand($@"
+            SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence,
+                   created_at, updated_at, title, current_version, owner_type, owner_id, archetype
+            FROM memories
+            WHERE archetype IN (0, 1)
+              AND {tagFilter}{ownerClause}{typeClause}
+            ORDER BY updated_at DESC
+            LIMIT @limit OFFSET @offset", conn);
+        AddTagParams(cmd);
+        AddOwnerParams(cmd);
+        AddTypeParam(cmd);
+        cmd.Parameters.AddWithValue("limit", pageSize);
+        cmd.Parameters.AddWithValue("offset", (page - 1) * pageSize);
+
+        var results = new List<Memorizer.Models.Memory>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            results.Add(ReadMemoryFromReader(reader, withSimilarity: false));
+        }
+
+        return (results, totalCount);
     }
 
     // ===== Reader Helpers for New Entities =====

--- a/src/Memorizer/Tools/MemoryTools.cs
+++ b/src/Memorizer/Tools/MemoryTools.cs
@@ -987,6 +987,138 @@ public class MemoryTools
         return result.ToString();
     }
 
+    [McpServerTool, Description("Filter memories by tags, type, project, or workspace. At least one filter (tags or type) is required. Tags use AND logic — all specified tags must be present. Results can be scoped to a specific project or workspace.")]
+    public async Task<string> GetByFilter(
+        [Description("One or more tags to filter by (case-insensitive, AND logic). Optional if type is provided.")] string[]? tags = null,
+        [Description("Memory type to filter by (e.g. 'reference', 'how-to'). Optional if tags are provided.")] string? type = null,
+        [Description("Page number (1-based). Default is 1.")] int page = 1,
+        [Description("Number of results per page. Default is 20, max is 100.")] int pageSize = 20,
+        [Description("Optional project ID to scope results to a specific project.")] string? projectId = null,
+        [Description("Optional workspace ID to scope results to a specific workspace. Ignored if projectId is set.")] string? workspaceId = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using var activity = TelemetryConfig.ActivitySource.StartActivity("MemoryTools.GetByFilter");
+
+        // Filter out empty/whitespace tags
+        var validTags = tags?.Where(t => !string.IsNullOrWhiteSpace(t)).ToArray() ?? [];
+
+        if (validTags.Length == 0 && string.IsNullOrWhiteSpace(type))
+        {
+            return "At least one filter is required: provide tags and/or type.";
+        }
+
+        // Validate pagination
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
+
+        // Determine optional owner scope
+        MemoryOwner? owner = null;
+        var parsedProjectId = ParseOptionalGuid(projectId);
+        var parsedWorkspaceId = ParseOptionalGuid(workspaceId);
+
+        if (parsedProjectId.HasValue)
+        {
+            owner = MemoryOwner.ForProject(new ProjectId(parsedProjectId.Value));
+        }
+        else if (parsedWorkspaceId.HasValue)
+        {
+            owner = MemoryOwner.ForWorkspace(new WorkspaceId(parsedWorkspaceId.Value));
+        }
+
+        List<Memorizer.Models.Memory> memories;
+        int totalCount;
+
+        if (validTags.Length > 0)
+        {
+            // Tag-based filtering (supports all additional filters)
+            var result2 = await _storage.GetMemoriesByTagAsync(validTags, page, pageSize, owner, type, cancellationToken);
+            memories = result2.Memories.ToList();
+            totalCount = result2.TotalCount;
+        }
+        else if (owner.HasValue)
+        {
+            // Type + owner filtering (no tags)
+            memories = (await _storage.GetMemoriesByOwnerAsync(owner.Value, page, pageSize, type, cancellationToken)).ToList();
+            totalCount = await _storage.GetMemoryCountByOwnerAsync(owner.Value, type, cancellationToken);
+        }
+        else
+        {
+            // Type-only filtering
+            var result2 = await _storage.GetMemoriesPaginated(page, pageSize, type, cancellationToken);
+            memories = result2.Memories;
+            totalCount = result2.TotalCount;
+        }
+
+        // Build filter description
+        var filterParts = new List<string>();
+        if (validTags.Length > 0) filterParts.Add($"tags: {string.Join(", ", validTags.Select(t => $"\"{t}\""))}");
+        if (!string.IsNullOrWhiteSpace(type)) filterParts.Add($"type: \"{type}\"");
+        var filterLabel = string.Join(", ", filterParts);
+
+        _logger.LogInformation("GetByFilter completed. Filter: {Filter}, Page: {Page}, PageSize: {PageSize}, ResultCount: {ResultCount}, TotalCount: {TotalCount}",
+            filterLabel, page, pageSize, memories.Count, totalCount);
+
+        if (memories.Count == 0)
+        {
+            activity?.SetStatus(ActivityStatusCode.Ok, "No memories found for filter");
+            var scopeInfo = owner.HasValue ? $" in {FormatOwner(owner.Value)}" : "";
+            return $"No memories found with {filterLabel}{scopeInfo}.";
+        }
+
+        StringBuilder result = new();
+        var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
+
+        result.AppendLine($"Filtered memories ({filterLabel}) — Page {page} of {totalPages}, {totalCount} total:");
+        if (owner.HasValue)
+        {
+            result.AppendLine($"Scoped to: {FormatOwner(owner.Value)}");
+        }
+        result.AppendLine();
+
+        var memoryIds = new List<Guid>();
+
+        foreach (var memory in memories)
+        {
+            memoryIds.Add(memory.Id.Value);
+
+            result.AppendLine($"ID: {memory.Id}");
+            result.AppendLine($"  Title: {memory.Title ?? "Untitled"}");
+            result.AppendLine($"  Type: {memory.Type}");
+            result.AppendLine($"  Owner: {FormatOwner(memory.Owner)}");
+            result.AppendLine($"  Tags: {(memory.Tags != null ? string.Join(", ", memory.Tags) : "none")}");
+            result.AppendLine($"  Updated: {memory.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
+
+            if (_canonicalUrlService.IsConfigured)
+            {
+                result.AppendLine($"  URL: {_canonicalUrlService.GetMemoryUrl(memory.Id)}");
+            }
+
+            result.AppendLine();
+        }
+
+        if (totalPages > 1)
+        {
+            result.AppendLine("---");
+            if (page < totalPages)
+            {
+                result.AppendLine($"Use GetByFilter with page={page + 1} to see more results.");
+            }
+            if (page > 1)
+            {
+                result.AppendLine($"Use GetByFilter with page={page - 1} to see previous results.");
+            }
+        }
+
+        result.AppendLine();
+        result.AppendLine($"Use Get with a memory ID to view full content.");
+        result.AppendLine($"Use GetMany with IDs: [{string.Join(", ", memoryIds)}] to fetch all at once.");
+
+        activity?.SetStatus(ActivityStatusCode.Ok, $"Listed {memories.Count} memories for filter {filterLabel}");
+        return result.ToString();
+    }
+
     [McpServerTool, Description("List archived memories with pagination. Use this to browse obsolete content for reference, audit, or potential restoration.")]
     public async Task<string> ListArchived(
         [Description("Page number (1-based). Default is 1.")] int page = 1,

--- a/src/Memorizer/Tools/WorkspaceTools.cs
+++ b/src/Memorizer/Tools/WorkspaceTools.cs
@@ -101,7 +101,7 @@ public class WorkspaceTools
             // Get child counts for hints
             var childWorkspaces = await _storage.GetWorkspacesAsync(parentId: ws.Id, includeSystem: false, cancellationToken);
             var projects = await _storage.GetProjectsAsync(ws.Id, parentId: null, statusFilter: null, cancellationToken);
-            var memoryCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForWorkspace(ws.Id), cancellationToken);
+            var memoryCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForWorkspace(ws.Id), cancellationToken: cancellationToken);
 
             result.AppendLine($"ID: {ws.Id.Value}");
             result.AppendLine($"Name: {ws.Name}");
@@ -154,7 +154,7 @@ public class WorkspaceTools
 
         // Get memory count for this workspace
         var workspaceOwner = MemoryOwner.ForWorkspace(workspaceId);
-        var memoryCount = await _storage.GetMemoryCountByOwnerAsync(workspaceOwner, cancellationToken);
+        var memoryCount = await _storage.GetMemoryCountByOwnerAsync(workspaceOwner, cancellationToken: cancellationToken);
 
         var result = new StringBuilder();
         result.AppendLine($"Workspace: {workspace.Name}");
@@ -183,7 +183,7 @@ public class WorkspaceTools
             foreach (var proj in projects.Take(10))
             {
                 // Get project memory count for hints
-                var projMemCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForProject(proj.Id), cancellationToken);
+                var projMemCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForProject(proj.Id), cancellationToken: cancellationToken);
                 result.AppendLine($"  - {proj.Name} ({proj.Status.ToStringValue()}) [{projMemCount} memories] [ID: {proj.Id.Value}]");
             }
             if (projects.Count > 10)
@@ -199,7 +199,7 @@ public class WorkspaceTools
             foreach (var child in childWorkspaces.Take(10))
             {
                 // Get child workspace memory count for hints
-                var childMemCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForWorkspace(child.Id), cancellationToken);
+                var childMemCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForWorkspace(child.Id), cancellationToken: cancellationToken);
                 var childProjects = await _storage.GetProjectsAsync(child.Id, parentId: null, statusFilter: null, cancellationToken);
                 var projectHint = childProjects.Count > 0 ? $", {childProjects.Count} projects" : "";
                 result.AppendLine($"  - {child.Name} [{childMemCount} memories{projectHint}] [ID: {child.Id.Value}]");
@@ -346,7 +346,7 @@ public class WorkspaceTools
 
         // Get memory count for context
         var workspaceOwner = MemoryOwner.ForWorkspace(typedWorkspaceId);
-        var memoryCount = await _storage.GetMemoryCountByOwnerAsync(workspaceOwner, cancellationToken);
+        var memoryCount = await _storage.GetMemoryCountByOwnerAsync(workspaceOwner, cancellationToken: cancellationToken);
 
         try
         {
@@ -469,7 +469,7 @@ public class WorkspaceTools
         foreach (var proj in projects)
         {
             // Get memory count and subproject count for hints
-            var memCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForProject(proj.Id), cancellationToken);
+            var memCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForProject(proj.Id), cancellationToken: cancellationToken);
             var subprojects = await _storage.GetProjectsAsync(workspaceId, parentId: proj.Id, statusFilter: null, cancellationToken);
 
             result.AppendLine($"ID: {proj.Id.Value}");
@@ -520,12 +520,12 @@ public class WorkspaceTools
         if (includeMemories)
         {
             // Fetch actual memories (limit to reasonable amount for display)
-            memories = await _storage.GetMemoriesByOwnerAsync(memoryOwner, page: 1, pageSize: 100, cancellationToken);
+            memories = await _storage.GetMemoriesByOwnerAsync(memoryOwner, page: 1, pageSize: 100, cancellationToken: cancellationToken);
             memoryCount = memories.Count;
         }
         else
         {
-            memoryCount = await _storage.GetMemoryCountByOwnerAsync(memoryOwner, cancellationToken);
+            memoryCount = await _storage.GetMemoryCountByOwnerAsync(memoryOwner, cancellationToken: cancellationToken);
         }
 
         var result = new StringBuilder();
@@ -570,7 +570,7 @@ public class WorkspaceTools
             result.AppendLine($"Subprojects ({childProjects.Count}):");
             foreach (var child in childProjects)
             {
-                var childMemCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForProject(child.Id), cancellationToken);
+                var childMemCount = await _storage.GetMemoryCountByOwnerAsync(MemoryOwner.ForProject(child.Id), cancellationToken: cancellationToken);
                 result.AppendLine($"  - {child.Name} ({child.Status.ToStringValue()}) [{childMemCount} memories]");
                 result.AppendLine($"    ID: {child.Id.Value}");
             }
@@ -779,7 +779,7 @@ public class WorkspaceTools
 
         // Get memory count for context
         var projectOwner = MemoryOwner.ForProject(typedProjectId);
-        var memoryCount = await _storage.GetMemoryCountByOwnerAsync(projectOwner, cancellationToken);
+        var memoryCount = await _storage.GetMemoryCountByOwnerAsync(projectOwner, cancellationToken: cancellationToken);
 
         try
         {

--- a/src/Memorizer/Views/Home/Index.cshtml
+++ b/src/Memorizer/Views/Home/Index.cshtml
@@ -26,6 +26,38 @@
     </div>
 </div>
 
+<!-- Filter Dropdowns (always visible) -->
+<div class="card mb-4" style="overflow: visible; position: relative; z-index: 100;">
+    <div class="card-body py-2" style="overflow: visible;">
+        <div class="row g-2 align-items-center">
+            <div class="col-auto">
+                <i class="fas fa-sliders-h text-muted me-1"></i>
+                <span class="text-muted small fw-semibold">Filter:</span>
+            </div>
+            <div class="col-md-4">
+                <select class="form-select form-select-sm" id="locationSelect" onchange="onLocationChange()">
+                    <option value="">All locations</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <select class="form-select form-select-sm" id="typeSelect" onchange="onTypeChange()">
+                    <option value="">All types</option>
+                </select>
+            </div>
+            <div class="col-md-3 position-relative">
+                <input type="text" class="form-control form-control-sm" id="tagSearchInput"
+                       placeholder="Search tags..." autocomplete="off"
+                       oninput="onTagSearchInput()" onfocus="onTagSearchInput()" />
+                <div id="tagSearchDropdown" class="list-group position-absolute w-100 shadow-sm" style="display: none; z-index: 1050; max-height: 250px; overflow-y: auto;"></div>
+            </div>
+        </div>
+        <div id="selectedTagsContainer" class="mt-2" style="display: none;">
+            <span class="text-muted small me-2">Tags:</span>
+            <span id="selectedTags"></span>
+        </div>
+    </div>
+</div>
+
 <!-- Vector Search Bar - Moved to top -->
 <div class="card mb-4">
     <div class="card-body">
@@ -106,7 +138,9 @@ let showArchived = false;
 let currentFilter = {
     workspaceId: null,
     projectId: null,
-    unfiled: false
+    unfiled: false,
+    tags: [],
+    type: null
 };
 
 // Toggle archived memories display
@@ -162,6 +196,8 @@ function parseUrlParams() {
     currentFilter.workspaceId = params.get('workspaceId');
     currentFilter.projectId = params.get('projectId');
     currentFilter.unfiled = params.get('unfiled') === 'true';
+    currentFilter.tags = params.getAll('tag').filter(t => t.trim());
+    currentFilter.type = params.get('type');
 
     // Check for search query from sidebar
     const searchQuery = params.get('q');
@@ -177,12 +213,18 @@ function parseUrlParams() {
 // Build query string for API calls
 function buildFilterQueryString() {
     const parts = [`page=${currentPage}`, `pageSize=${currentPageSize}`];
+    for (const t of currentFilter.tags) {
+        parts.push(`tag=${encodeURIComponent(t)}`);
+    }
     if (currentFilter.projectId) {
         parts.push(`projectId=${currentFilter.projectId}`);
     } else if (currentFilter.workspaceId) {
         parts.push(`workspaceId=${currentFilter.workspaceId}`);
     } else if (currentFilter.unfiled) {
         parts.push(`unfiled=true`);
+    }
+    if (currentFilter.type) {
+        parts.push(`type=${encodeURIComponent(currentFilter.type)}`);
     }
     return parts.join('&');
 }
@@ -192,7 +234,14 @@ async function updateFilterContext() {
     const contextDiv = document.getElementById('filterContext');
     const contextText = document.getElementById('filterContextText');
 
-    if (currentFilter.projectId) {
+    const hasActiveFilter = currentFilter.tags.length > 0 || currentFilter.type || currentFilter.projectId || currentFilter.workspaceId || currentFilter.unfiled;
+
+    if (currentFilter.tags.length > 0 && !currentFilter.projectId && !currentFilter.workspaceId && !currentFilter.unfiled) {
+        // Tags-only filter — show in banner
+        const tagBadges = currentFilter.tags.map(t => `<span class="badge bg-secondary">${escapeHtml(t)}</span>`).join(' ');
+        contextText.innerHTML = `<strong>Tags:</strong> ${tagBadges}`;
+        contextDiv.style.display = 'block';
+    } else if (currentFilter.projectId) {
         // Fetch project name from workspace tree API
         try {
             const treeResponse = await fetch('/api/workspace-tree');
@@ -272,10 +321,362 @@ function findProjectInChildProjects(projects, id) {
     return null;
 }
 
+// Workspace tree cache for resolving owner names on cards
+let workspaceTreeCache = null;
+
+async function getWorkspaceTree() {
+    if (workspaceTreeCache) return workspaceTreeCache;
+    try {
+        const response = await fetch('/api/workspace-tree');
+        if (response.ok) {
+            workspaceTreeCache = await response.json();
+        }
+    } catch (e) {
+        console.warn('Could not load workspace tree:', e);
+    }
+    return workspaceTreeCache;
+}
+
+function resolveOwnerName(owner, tree) {
+    if (!owner || !tree) return null;
+    const emptyGuid = '00000000-0000-0000-0000-000000000000';
+    if (owner.id === emptyGuid) return 'Unfiled';
+    const ownerType = owner.type?.toLowerCase();
+    if (ownerType === 'project') {
+        const project = findProjectInTree(tree.workspaces, owner.id);
+        return project ? project.name : null;
+    } else if (ownerType === 'workspace') {
+        const workspace = findWorkspaceInTree(tree.workspaces, owner.id);
+        return workspace ? workspace.name : null;
+    }
+    return null;
+}
+
+function createOwnerBadge(owner, tree) {
+    if (!owner) return '';
+    const name = resolveOwnerName(owner, tree);
+    if (!name) return '';
+    const ownerType = owner.type?.toLowerCase();
+    const icon = ownerType === 'project' ? 'fa-project-diagram' : 'fa-folder';
+    const href = ownerType === 'project'
+        ? `/memories?projectId=${owner.id}`
+        : `/memories?workspaceId=${owner.id}`;
+    return `<a href="${href}" class="badge bg-info text-decoration-none"><i class="fas ${icon} me-1"></i>${escapeHtml(name)}</a>`;
+}
+
+// All available tags (loaded once)
+let allAvailableTags = [];
+
+async function loadTagDropdown() {
+    try {
+        let url = '/api/memory/tags';
+        const params = new URLSearchParams();
+        if (currentFilter.projectId) params.set('projectId', currentFilter.projectId);
+        else if (currentFilter.workspaceId) params.set('workspaceId', currentFilter.workspaceId);
+        const qs = params.toString();
+        if (qs) url += '?' + qs;
+
+        const response = await fetch(url);
+        if (!response.ok) return;
+        allAvailableTags = await response.json();
+    } catch (e) {
+        console.warn('Could not load tags:', e);
+    }
+}
+
+// Show filtered tag suggestions as user types
+function onTagSearchInput() {
+    const input = document.getElementById('tagSearchInput');
+    const dropdown = document.getElementById('tagSearchDropdown');
+    const query = input.value.toLowerCase().trim();
+
+    // Filter: exclude already-selected tags, match query
+    const matches = allAvailableTags
+        .filter(t => !currentFilter.tags.includes(t))
+        .filter(t => !query || t.toLowerCase().includes(query))
+        .slice(0, 20);
+
+    if (matches.length === 0) {
+        dropdown.style.display = 'none';
+        return;
+    }
+
+    dropdown.innerHTML = matches.map(t => {
+        // Highlight the matching portion
+        const escaped = escapeHtml(t);
+        let display = escaped;
+        if (query) {
+            const idx = t.toLowerCase().indexOf(query);
+            if (idx >= 0) {
+                display = escapeHtml(t.substring(0, idx))
+                    + '<strong>' + escapeHtml(t.substring(idx, idx + query.length)) + '</strong>'
+                    + escapeHtml(t.substring(idx + query.length));
+            }
+        }
+        return `<button type="button" class="list-group-item list-group-item-action py-1 px-2 small" onmousedown="selectTag('${t.replace(/'/g, "\\'")}')">${display}</button>`;
+    }).join('');
+    dropdown.style.display = 'block';
+}
+
+// Close dropdown when clicking outside
+document.addEventListener('click', function(e) {
+    const input = document.getElementById('tagSearchInput');
+    const dropdown = document.getElementById('tagSearchDropdown');
+    if (input && dropdown && !input.contains(e.target) && !dropdown.contains(e.target)) {
+        dropdown.style.display = 'none';
+    }
+});
+
+// Select a tag from suggestions
+async function selectTag(tag) {
+    if (currentFilter.tags.includes(tag)) return;
+    currentFilter.tags.push(tag);
+
+    const input = document.getElementById('tagSearchInput');
+    const dropdown = document.getElementById('tagSearchDropdown');
+    input.value = '';
+    dropdown.style.display = 'none';
+
+    renderSelectedTags();
+    updateFilterUrl();
+    currentPage = 1;
+    await loadLocationDropdown();
+    updateFilterUrl();
+    updateFilterContext();
+    loadMemories();
+}
+
+// Remove a tag from the selection
+async function removeTag(tag) {
+    currentFilter.tags = currentFilter.tags.filter(t => t !== tag);
+    renderSelectedTags();
+    updateFilterUrl();
+    currentPage = 1;
+    await loadLocationDropdown();
+    updateFilterUrl();
+    updateFilterContext();
+    loadMemories();
+}
+
+// Render selected tags as removable badges
+function renderSelectedTags() {
+    const container = document.getElementById('selectedTagsContainer');
+    const tagsSpan = document.getElementById('selectedTags');
+
+    if (currentFilter.tags.length === 0) {
+        container.style.display = 'none';
+        return;
+    }
+
+    tagsSpan.innerHTML = currentFilter.tags.map(t =>
+        `<span class="badge bg-secondary me-1">${escapeHtml(t)} <a href="#" class="text-white text-decoration-none ms-1" onclick="removeTag('${t.replace(/'/g, "\\'")}'); return false;"><i class="fas fa-times fa-xs"></i></a></span>`
+    ).join('');
+    container.style.display = 'block';
+}
+
+// Populate the location dropdown (filtered by active tags/type)
+async function loadLocationDropdown() {
+    const select = document.getElementById('locationSelect');
+    const previousValue = select.value;
+
+    const tree = await getWorkspaceTree();
+    if (!tree || !tree.workspaces) return;
+
+    // Fetch allowed owners based on current tag/type filters
+    let allowedOwners = null;
+    if (currentFilter.tags.length > 0 || currentFilter.type) {
+        try {
+            const params = new URLSearchParams();
+            for (const t of currentFilter.tags) params.append('tag', t);
+            if (currentFilter.type) params.set('type', currentFilter.type);
+            const resp = await fetch(`/api/memory/owners?${params.toString()}`);
+            if (resp.ok) {
+                const owners = await resp.json();
+                allowedOwners = new Set(owners.map(o => `${o.type}:${o.id}`));
+            }
+        } catch (e) {
+            console.warn('Could not load owners:', e);
+        }
+    }
+
+    // Clear existing options (keep first "All locations")
+    while (select.options.length > 1) select.remove(1);
+
+    // Add "Unfiled" option
+    const unfiledOpt = document.createElement('option');
+    unfiledOpt.value = 'unfiled';
+    unfiledOpt.textContent = '\u{1F4E5} Unfiled';
+    select.appendChild(unfiledOpt);
+
+    function isOwnerAllowed(type, id) {
+        if (!allowedOwners) return true;
+        return allowedOwners.has(`${type}:${id}`);
+    }
+
+    function hasAllowedDescendants(node, type) {
+        if (type === 'workspace') {
+            if (isOwnerAllowed('Workspace', node.id)) return true;
+            if (node.projects) {
+                for (const p of node.projects) {
+                    if (hasAllowedDescendants(p, 'project')) return true;
+                }
+            }
+            if (node.children) {
+                for (const c of node.children) {
+                    if (hasAllowedDescendants(c, 'workspace')) return true;
+                }
+            }
+        } else if (type === 'project') {
+            if (isOwnerAllowed('Project', node.id)) return true;
+            if (node.children) {
+                for (const c of node.children) {
+                    if (hasAllowedDescendants(c, 'project')) return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    function addWorkspaceOptions(workspaces, prefix) {
+        for (const ws of workspaces) {
+            if (allowedOwners && !hasAllowedDescendants(ws, 'workspace')) continue;
+            const indent = prefix ? prefix + ' ' : '';
+            const opt = document.createElement('option');
+            opt.value = `workspace:${ws.id}`;
+            opt.textContent = indent + '\u{1F4C1} ' + ws.name;
+            if (!prefix) opt.style.fontWeight = 'bold';
+            if (allowedOwners && !isOwnerAllowed('Workspace', ws.id)) opt.disabled = true;
+            select.appendChild(opt);
+
+            if (ws.projects && ws.projects.length > 0) {
+                addProjectOptions(ws.projects, prefix + '\u2500\u2500');
+            }
+            if (ws.children && ws.children.length > 0) {
+                addWorkspaceOptions(ws.children, prefix + '\u2500\u2500');
+            }
+        }
+    }
+
+    function addProjectOptions(projects, prefix) {
+        for (const proj of projects) {
+            if (allowedOwners && !hasAllowedDescendants(proj, 'project')) continue;
+            const opt = document.createElement('option');
+            opt.value = `project:${proj.id}`;
+            opt.textContent = prefix + ' \u{1F4CB} ' + proj.name;
+            if (allowedOwners && !isOwnerAllowed('Project', proj.id)) opt.disabled = true;
+            select.appendChild(opt);
+            if (proj.children && proj.children.length > 0) {
+                addProjectOptions(proj.children, prefix + '\u2500\u2500');
+            }
+        }
+    }
+
+    addWorkspaceOptions(tree.workspaces, '');
+
+    // Restore previous selection if still available, otherwise use filter state
+    const targetValue = previousValue || (currentFilter.unfiled ? 'unfiled' : currentFilter.projectId ? `project:${currentFilter.projectId}` : currentFilter.workspaceId ? `workspace:${currentFilter.workspaceId}` : '');
+    const optionExists = Array.from(select.options).some(o => o.value === targetValue && !o.disabled);
+    if (optionExists) {
+        select.value = targetValue;
+    } else {
+        // If previously selected location is no longer available, reset to "All"
+        select.value = '';
+        if (currentFilter.projectId || currentFilter.workspaceId || currentFilter.unfiled) {
+            currentFilter.projectId = null;
+            currentFilter.workspaceId = null;
+            currentFilter.unfiled = false;
+            updateFilterUrl();
+        }
+    }
+}
+
+// Handle location change
+function onLocationChange() {
+    const select = document.getElementById('locationSelect');
+    const val = select.value;
+
+    currentFilter.projectId = null;
+    currentFilter.workspaceId = null;
+    currentFilter.unfiled = false;
+
+    if (val === 'unfiled') {
+        currentFilter.unfiled = true;
+    } else if (val) {
+        const [type, id] = val.split(':');
+        if (type === 'project') {
+            currentFilter.projectId = id;
+        } else if (type === 'workspace') {
+            currentFilter.workspaceId = id;
+        }
+    }
+
+    updateFilterUrl();
+    currentPage = 1;
+    updateFilterContext();
+    loadTagDropdown();
+    loadMemories();
+}
+
+// Populate the type dropdown
+async function loadTypeDropdown() {
+    const select = document.getElementById('typeSelect');
+
+    try {
+        const response = await fetch('/api/memory/types');
+        if (!response.ok) return;
+        const types = await response.json();
+
+        // Clear existing options (keep first "All types")
+        while (select.options.length > 1) select.remove(1);
+
+        for (const t of types) {
+            const opt = document.createElement('option');
+            opt.value = t;
+            opt.textContent = t;
+            select.appendChild(opt);
+        }
+
+        // Set current value from filter state
+        if (currentFilter.type) {
+            select.value = currentFilter.type;
+        }
+    } catch (e) {
+        console.warn('Could not load memory types:', e);
+    }
+}
+
+// Handle type change
+async function onTypeChange() {
+    const select = document.getElementById('typeSelect');
+    currentFilter.type = select.value || null;
+    updateFilterUrl();
+    currentPage = 1;
+    await loadLocationDropdown();
+    updateFilterUrl();
+    updateFilterContext();
+    loadMemories();
+}
+
+// Update browser URL to reflect current filter state
+function updateFilterUrl() {
+    const params = new URLSearchParams();
+    for (const t of currentFilter.tags) params.append('tag', t);
+    if (currentFilter.projectId) params.set('projectId', currentFilter.projectId);
+    else if (currentFilter.workspaceId) params.set('workspaceId', currentFilter.workspaceId);
+    else if (currentFilter.unfiled) params.set('unfiled', 'true');
+    if (currentFilter.type) params.set('type', currentFilter.type);
+    const qs = params.toString();
+    window.history.replaceState({}, '', qs ? `/memories?${qs}` : '/memories');
+}
+
 // Load memories on page load
 document.addEventListener('DOMContentLoaded', function() {
     parseUrlParams();
     updateFilterContext();
+    loadLocationDropdown();
+    loadTypeDropdown();
+    loadTagDropdown();
+    renderSelectedTags();
     loadMemories();
 });
 
@@ -312,7 +713,7 @@ async function loadMemories() {
     }
 }
 
-function displayMemories(memories, isArchivedView = false) {
+async function displayMemories(memories, isArchivedView = false) {
     const listElement = document.getElementById('memoryList');
 
     if (memories.length === 0) {
@@ -332,10 +733,17 @@ function displayMemories(memories, isArchivedView = false) {
         return;
     }
 
+    // Load workspace tree for owner badges when tag filter is active
+    let tree = null;
+    const showOwnerBadges = currentFilter.tags.length > 0 || currentFilter.type;
+    if (showOwnerBadges) {
+        tree = await getWorkspaceTree();
+    }
+
     let html = '<div class="row">';
 
     memories.forEach(memory => {
-        const tags = createTagBadges(memory.tags);
+        const tags = createClickableTagBadges(memory.tags);
         const title = memory.title || 'Untitled Memory';
         const preview = truncateText(memory.text, 100) || 'No content';
         const isArchived = memory.archetype === 'archived';
@@ -343,6 +751,7 @@ function displayMemories(memories, isArchivedView = false) {
         const archivedBadge = isArchived
             ? '<span class="badge badge-archived-indicator ms-1"><i class="fas fa-archive me-1"></i>ARCHIVED</span>'
             : '';
+        const ownerBadge = showOwnerBadges ? createOwnerBadge(memory.owner, tree) : '';
 
         html += `
             <div class="col-md-6 col-lg-4 mb-4">
@@ -355,6 +764,8 @@ function displayMemories(memories, isArchivedView = false) {
                                 ${archivedBadge}
                             </div>
                         </div>
+
+                        ${ownerBadge ? `<div class="mb-2">${ownerBadge}</div>` : ''}
 
                         <p class="card-text text-muted small mb-2">${escapeHtml(preview)}</p>
 
@@ -524,7 +935,7 @@ function displayVectorSearchResults(results) {
     }
     let html = `<div class='card mb-4'><div class='card-body'><h5 class='mb-3'><i class='fas fa-search me-2 text-success'></i>Vector Search Results</h5><div class='row'>`;
     results.forEach(memory => {
-        const tags = createTagBadges(memory.tags);
+        const tags = createClickableTagBadges(memory.tags);
         const title = memory.title || 'Untitled Memory';
         const preview = truncateText(memory.text, 100) || 'No content';
         const similarity = memory.similarity !== null && memory.similarity !== undefined ? (100 * memory.similarity).toFixed(1) : 'N/A';

--- a/src/Memorizer/Views/Home/View.cshtml
+++ b/src/Memorizer/Views/Home/View.cshtml
@@ -662,10 +662,10 @@ function populateMemoryView(memory) {
         document.getElementById('memoryConfidence').innerHTML = createConfidenceBadge(memory.confidence || 1.0);
         document.getElementById('memoryCreated').textContent = formatDateTime(memory.createdAt);
 
-        // Set tags
+        // Set tags (clickable - link to tag filter)
         const tagsContainer = document.getElementById('memoryTags');
         if (memory.tags && memory.tags.length > 0) {
-            tagsContainer.innerHTML = createTagBadges(memory.tags);
+            tagsContainer.innerHTML = createClickableTagBadges(memory.tags);
         } else {
             tagsContainer.innerHTML = '<span class="text-muted">No tags</span>';
         }

--- a/src/Memorizer/migrations/021_add_tags_gin_index.sql
+++ b/src/Memorizer/migrations/021_add_tags_gin_index.sql
@@ -1,0 +1,2 @@
+-- GIN index on tags array for efficient tag-based filtering queries
+CREATE INDEX IF NOT EXISTS idx_memories_tags_gin ON memories USING GIN (tags);

--- a/src/Memorizer/wwwroot/js/memory-utils.js
+++ b/src/Memorizer/wwwroot/js/memory-utils.js
@@ -58,6 +58,28 @@ function createTagBadges(tags, badgeClass = 'bg-secondary') {
 }
 
 /**
+ * Creates a clickable tag badge that links to the tag filter page
+ * @param {string} tag - The tag text
+ * @param {string} badgeClass - Bootstrap badge class (default: 'bg-secondary')
+ * @returns {string} HTML for the clickable tag badge
+ */
+function createClickableTagBadge(tag, badgeClass = 'bg-secondary') {
+    const href = `/memories?tag=${encodeURIComponent(tag)}`;
+    return `<a href="${href}" class="badge ${badgeClass} me-1 text-decoration-none">${escapeHtml(tag)}</a>`;
+}
+
+/**
+ * Creates multiple clickable tag badges from an array
+ * @param {string[]} tags - Array of tag strings
+ * @param {string} badgeClass - Bootstrap badge class (default: 'bg-secondary')
+ * @returns {string} HTML for all clickable tag badges
+ */
+function createClickableTagBadges(tags, badgeClass = 'bg-secondary') {
+    if (!tags || !Array.isArray(tags)) return '';
+    return tags.map(tag => createClickableTagBadge(tag, badgeClass)).join('');
+}
+
+/**
  * Truncates text to a specified length with ellipsis
  * @param {string} text - Text to truncate
  * @param {number} maxLength - Maximum length before truncation


### PR DESCRIPTION
- Add tag-based memory filtering across all projects/workspaces
- Multi-tag selection with searchable typeahead and removable badges
- Always-visible filter panel with location, type, and tag filters
- Unfiled option in location dropdown
- Dynamic filtering: location dropdown scoped by active type/tags,
      tag suggestions scoped by selected location
- Owner badges on memory cards when filtering by tags or type
- Add /api/memory/tags, /api/memory/owners endpoints
- Add GetMemoriesByTagAsync, GetDistinctTagsAsync, GetDistinctOwnersAsync to IStorage with PostgreSQL GIN index for tag queries
- MCP tool GetByFilter with type, location and tags parameter
- Clickable tag badges on memory detail view linking to filtered list
