### PR TITLE
Extract only latest release block for GitHub release body

### DIFF
--- a/.github/workflows/publish_containers.yml
+++ b/.github/workflows/publish_containers.yml
@@ -46,6 +46,17 @@ jobs:
       run: |
         dotnet publish -p:VersionPrefix=${{ github.ref_name }} -p:ContainerRegistry=docker.io -c Release /t:PublishContainer
 
+    - name: "Extract latest release notes"
+      shell: pwsh
+      run: |
+        $content = Get-Content RELEASE_NOTES.md -Raw
+        # Match from the first #### heading to just before the second one
+        if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+          $Matches[1].Trim() | Set-Content RELEASE_NOTES_LATEST.md
+        } else {
+          $content | Set-Content RELEASE_NOTES_LATEST.md
+        }
+
     - name: release
       uses: actions/create-release@v1
       id: create_release
@@ -54,6 +65,6 @@ jobs:
         prerelease: false
         release_name: 'Memorizer ${{ github.ref_name }}'
         tag_name: ${{ github.ref }}
-        body_path: RELEASE_NOTES.md
+        body_path: RELEASE_NOTES_LATEST.md
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- GitHub releases were previously using the entire `RELEASE_NOTES.md` as the release body, causing every release to contain the full changelog history
- Added a PowerShell step that extracts only the first `####` block (the latest release) into a temp file `RELEASE_NOTES_LATEST.md`
- Release action now uses `RELEASE_NOTES_LATEST.md` instead of the full file

## Test plan
- [ ] Verify the regex correctly extracts only the top release block from `RELEASE_NOTES.md`
- [ ] Confirm next tagged release on GitHub shows only the current version's notes