### PR TITLE
Fix racy SearchWithMetadataEmbedding test caused by IVFFlat probe count and threshold sensitivity

### DIFF
--- a/src/Memorizer.IntegrationTests/McpToolsProjectScopingTests.cs
+++ b/src/Memorizer.IntegrationTests/McpToolsProjectScopingTests.cs
@@ -325,11 +325,13 @@ public class McpToolsProjectScopingTests : IDisposable
                 cancellationToken: default
             );
 
-            // Search without projectId (should search all)
+            // Search without projectId (should search all).
+            // Use minSimilarity=0.0 (accept any distance) so this test verifies owner-filter
+            // bypass behavior rather than embedding quality, which is nondeterministic in CI.
             var globalResults = await storage.SearchWithMetadataEmbedding(
                 query: "global search testing",
                 limit: 10,
-                minSimilarity: new SimilarityScore(0.3),
+                minSimilarity: new SimilarityScore(0.0),
                 filterTags: null,
                 projectId: null, // No project filter
                 includeUnassigned: false, // Ignored when projectId is null
@@ -338,8 +340,10 @@ public class McpToolsProjectScopingTests : IDisposable
 
             _output.WriteLine($"Global search returned {globalResults.Count} results");
 
-            // Should find memories regardless of owner
-            Assert.True(globalResults.Count >= 2, "Should find at least the 2 test memories");
+            // Both specific memories must appear regardless of embedding similarity score
+            var resultIds = globalResults.Select(m => m.Id).ToHashSet();
+            Assert.Contains(memoryInProject!.Id, resultIds);
+            Assert.Contains(memoryUnfiled!.Id, resultIds);
         }
         finally
         {

--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -1307,6 +1307,12 @@ public class Storage : IStorage
 
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
 
+        // IVFFlat uses approximate nearest-neighbor search. The default probes=1 with lists=100
+        // means only 1% of the index is scanned, which causes missed results on small datasets.
+        // Setting probes to sqrt(lists)=10 gives good recall without meaningful overhead.
+        await using (var probeCmd = new NpgsqlCommand("SET LOCAL ivfflat.probes = 10", connection))
+            await probeCmd.ExecuteNonQueryAsync(cancellationToken);
+
         // Always fetch up to 2x the requested limit for post-filtering/boosting
         int fetchLimit = limit * 2;
 


### PR DESCRIPTION
## Summary
- `SearchWithMetadataEmbedding_WithNoProjectId_SearchesAll` was intermittently failing in CI with `Global search returned 1 results` — only one of the two inserted memories was returned
- Root cause: the `embedding_metadata` index uses `ivfflat` with `lists = 100` and the default `probes = 1`, meaning only 1% of the index is scanned per query; on the small CI test database this causes rows to be missed entirely
- Secondary factor: `minSimilarity: 0.3` threshold combined with Ollama embedding nondeterminism could push one memory below the distance cutoff

## Changes
- **`Memory.cs`**: Set `ivfflat.probes = 10` (`sqrt(lists)`) via `SET LOCAL` before every `SearchWithMetadataEmbedding` query, improving recall on small datasets without meaningful overhead
- **`McpToolsProjectScopingTests.cs`**: Use `minSimilarity: 0.0` (accept any distance) and assert both specific memory IDs appear in results, decoupling owner-filter correctness from embedding quality

## Test plan
- [ ] CI integration tests pass consistently (no more flaky `Global search returned 1 results`)
- [ ] Owner-filter behavior is still correctly verified by ID assertions