### PR TITLE
Release Memorizer 2.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,24 +3,21 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/petabridge/memorizer-v1</PackageProjectUrl>
-    <VersionPrefix>2.1.0-beta1</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
     <PackageReleaseNotes>**Features**
-- [Improve search quality with hybrid text + vector search](https://github.com/petabridge/memorizer/pull/157) - Combines PostgreSQL full-text search with vector similarity search using Reciprocal Rank Fusion (RRF) to dramatically improve search relevance
-  - Queries like "race condition", "phobos", and "dependency injection" that previously returned zero results now surface relevant matches
-  - AND-prefix FTS matching handles stemming mismatches (e.g., "postgres" matches "postgresql")
-  - Adaptive weighting favors text matching for short queries, both methods equally for longer queries
-  - Workspace and project search also use hybrid approach for better name matching
-  - New database migration adds `search_vector` tsvector column with GIN index
+- [Add move-project-to-workspace and workspace reparenting](https://github.com/petabridge/memorizer/pull/167) - Move projects between workspaces and reparent workspaces in the hierarchy
+  - `MoveProjectToWorkspaceAsync` atomically moves a project and all its descendants to a target workspace
+  - Workspace reparenting with circular-reference guard to prevent invalid hierarchies
+  - Full support across REST API, MCP tools, and Web UI with modal dialogs
+- [Add canonical URL support to MCP tool responses](https://github.com/petabridge/memorizer/pull/162) - MCP tool responses now include clickable URLs to the web UI for memories, workspaces, and projects
+  - Configure via `Server:CanonicalUrl` setting to enable links in MCP responses
+  - URLs included in `Store`, `Get`, `SearchMemories`, `GetMany`, `CreateWorkspace`, `CreateProject`, `GetWorkspace`, and `GetProjectContext` responses
 
 **Bug Fixes**
-- [Fix inconsistent memory counts by excluding system memories from user-facing queries](https://github.com/petabridge/memorizer/pull/154) - Memory list and stats no longer inflate counts with internal system index memories
-
-**Updates**
-- [Bump Microsoft.AspNetCore.Mvc.Testing from 10.0.2 to 10.0.3](https://github.com/petabridge/memorizer/pull/156)
-- [Bump Akka.Streams from 1.5.58 to 1.5.60](https://github.com/petabridge/memorizer/pull/152)</PackageReleaseNotes>
+- [Make optional Guid MCP parameters resilient to client schema variations](https://github.com/petabridge/memorizer/pull/166) - Fixes compatibility with MCP clients (notably Cursor) that send empty strings or `"null"` for optional Guid parameters instead of proper JSON null</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+#### 2.1.0 March 4th 2026 ####
+
+**Features**
+- [Add move-project-to-workspace and workspace reparenting](https://github.com/petabridge/memorizer/pull/167) - Move projects between workspaces and reparent workspaces in the hierarchy
+  - `MoveProjectToWorkspaceAsync` atomically moves a project and all its descendants to a target workspace
+  - Workspace reparenting with circular-reference guard to prevent invalid hierarchies
+  - Full support across REST API, MCP tools, and Web UI with modal dialogs
+- [Add canonical URL support to MCP tool responses](https://github.com/petabridge/memorizer/pull/162) - MCP tool responses now include clickable URLs to the web UI for memories, workspaces, and projects
+  - Configure via `Server:CanonicalUrl` setting to enable links in MCP responses
+  - URLs included in `Store`, `Get`, `SearchMemories`, `GetMany`, `CreateWorkspace`, `CreateProject`, `GetWorkspace`, and `GetProjectContext` responses
+
+**Bug Fixes**
+- [Make optional Guid MCP parameters resilient to client schema variations](https://github.com/petabridge/memorizer/pull/166) - Fixes compatibility with MCP clients (notably Cursor) that send empty strings or `"null"` for optional Guid parameters instead of proper JSON null
+
 #### 2.1.0-beta1 February 15th 2026 ####
 
 **Features**


### PR DESCRIPTION
## Summary

- Bump version from `2.1.0-beta1` to `2.1.0`
- Update `RELEASE_NOTES.md` with 2.1.0 release notes (March 4th 2026)
- Update `Directory.Build.props` with new version and release notes

## Changes since 2.1.0-beta1

**Features**
- Add move-project-to-workspace and workspace reparenting (#167)
- Add canonical URL support to MCP tool responses (#162)

**Bug Fixes**
- Make optional Guid MCP parameters resilient to client schema variations (#166)