### PR TITLE
Self-heal stale dimension configuration after migration

### DIFF
--- a/src/Memorizer.IntegrationTests/EmbeddingDimensionServiceTests.cs
+++ b/src/Memorizer.IntegrationTests/EmbeddingDimensionServiceTests.cs
@@ -117,7 +117,7 @@ public class EmbeddingDimensionServiceTests
     }
 
     [Fact]
-    public async Task Validate_WhenStoredConfigHasDifferentDimensions_ReturnsMismatch()
+    public async Task Validate_WhenStoredConfigHasDifferentDimensionsButSchemaMatches_SelfHeals()
     {
         // Arrange - Create a stored config with different dimensions than the model outputs
         // This simulates switching to a model with different output dimensions
@@ -143,12 +143,15 @@ public class EmbeddingDimensionServiceTests
             // Act
             var result = await dimensionService.ValidateAsync();
 
-            // Assert - Model outputs 384, but stored config says 768
-            Assert.True(result.HasMismatch, $"Expected mismatch. Result: detected={result.DetectedModelDimensions}, stored={result.StoredDimensions}");
-            Assert.True(result.RequiresMigration);
-            Assert.Contains("384", result.MismatchDescription!);
-            Assert.Contains("768", result.MismatchDescription!);
-            _output.WriteLine($"✅ Detected mismatch: {result.MismatchDescription}");
+            // Assert - Model and schema are both 384, so stale stored config should be auto-reconciled
+            Assert.False(result.HasMismatch, $"Unexpected mismatch. Result: detected={result.DetectedModelDimensions}, stored={result.StoredDimensions}, schema={result.DatabaseSchemaDimensions}");
+            Assert.False(result.RequiresMigration);
+
+            var activeConfig = await dimensionService.GetActiveConfigAsync();
+            Assert.NotNull(activeConfig);
+            Assert.Equal("all-minilm", activeConfig.ModelName);
+            Assert.Equal(384, activeConfig.Dimensions);
+            _output.WriteLine("✅ Stale stored config auto-reconciled to live model/schema");
         }
         finally
         {
@@ -160,7 +163,7 @@ public class EmbeddingDimensionServiceTests
     }
 
     [Fact]
-    public async Task Validate_WhenStoredConfigDiffersFromSchema_DetectsIncompleteMigration()
+    public async Task Validate_WhenStoredConfigDiffersFromSchemaButProbeMatches_SelfHeals()
     {
         // Arrange
         using var services = CreateServices("all-minilm");
@@ -186,11 +189,15 @@ public class EmbeddingDimensionServiceTests
             // Act
             var result = await dimensionService.ValidateAsync();
 
-            // Assert - Stored says 1024, but schema is 384
-            Assert.True(result.HasMismatch, "Should detect schema/config mismatch");
-            Assert.True(result.RequiresMigration);
-            Assert.NotNull(result.MismatchDescription);
-            _output.WriteLine($"✅ Detected incomplete migration: {result.MismatchDescription}");
+            // Assert - Probe and schema are both 384, so stale stored config should be auto-reconciled
+            Assert.False(result.HasMismatch, $"Unexpected mismatch. Description: {result.MismatchDescription}");
+            Assert.False(result.RequiresMigration);
+
+            var activeConfig = await dimensionService.GetActiveConfigAsync();
+            Assert.NotNull(activeConfig);
+            Assert.Equal("all-minilm", activeConfig.ModelName);
+            Assert.Equal(384, activeConfig.Dimensions);
+            _output.WriteLine("✅ Incomplete-metadata state auto-reconciled when schema and probe align");
         }
         finally
         {

--- a/src/Memorizer/Actors/DimensionMigrationActor.cs
+++ b/src/Memorizer/Actors/DimensionMigrationActor.cs
@@ -487,6 +487,10 @@ public sealed class DimensionMigrationActor : ReceiveActor
             {
                 var dimensionService = _currentScope.ServiceProvider.GetRequiredService<IEmbeddingDimensionService>();
                 await dimensionService.UpdateActiveConfigAsync(_newModel!, _newDimensions);
+
+                var validation = await dimensionService.ValidateAsync();
+                var mismatchState = _currentScope.ServiceProvider.GetRequiredService<IDimensionMismatchState>();
+                mismatchState.Update(validation);
             }
 
             // Complete the migration record

--- a/src/Memorizer/Services/EmbeddingDimensionService.cs
+++ b/src/Memorizer/Services/EmbeddingDimensionService.cs
@@ -190,24 +190,38 @@ public class EmbeddingDimensionService : IEmbeddingDimensionService
                 embeddingApiAvailable: embeddingApiAvailable);
         }
 
-        // Scenario 3: Stored config doesn't match schema (could happen after failed migration)
+        // Scenario 3: Stored config doesn't match schema.
+        // If live probe matches schema, this is stale metadata and we can self-heal.
         if (storedConfig != null && schemaDimensions.HasValue &&
             storedConfig.Dimensions != schemaDimensions.Value)
         {
-            var description = $"Stored config shows {storedConfig.Dimensions} dimensions, " +
-                              $"but database schema has VECTOR({schemaDimensions}). " +
-                              "This may indicate an incomplete migration.";
+            if (detectedDimensions.HasValue && detectedDimensions.Value == schemaDimensions.Value)
+            {
+                _logger.LogInformation(
+                    "Stored config is stale (stored={StoredDimensions}, schema={SchemaDimensions}, model={StoredModel}). " +
+                    "Live probe matches schema ({DetectedDimensions}), updating stored config.",
+                    storedConfig.Dimensions, schemaDimensions, storedConfig.ModelName, detectedDimensions);
 
-            _logger.LogWarning("Dimension mismatch: {Description}", description);
+                await UpdateActiveConfigAsync(Settings.Model, detectedDimensions.Value, ct);
+                storedConfig = await GetActiveConfigAsync(ct);
+            }
+            else
+            {
+                var description = $"Stored config shows {storedConfig.Dimensions} dimensions, " +
+                                  $"but database schema has VECTOR({schemaDimensions}). " +
+                                  "This may indicate an incomplete migration.";
 
-            return DimensionValidationResult.Mismatch(
-                configuredModel: Settings.Model,
-                detectedDimensions: detectedDimensions,
-                storedDimensions: storedConfig.Dimensions,
-                storedModel: storedConfig.ModelName,
-                schemaDimensions: schemaDimensions,
-                description: description,
-                embeddingApiAvailable: embeddingApiAvailable);
+                _logger.LogWarning("Dimension mismatch: {Description}", description);
+
+                return DimensionValidationResult.Mismatch(
+                    configuredModel: Settings.Model,
+                    detectedDimensions: detectedDimensions,
+                    storedDimensions: storedConfig.Dimensions,
+                    storedModel: storedConfig.ModelName,
+                    schemaDimensions: schemaDimensions,
+                    description: description,
+                    embeddingApiAvailable: embeddingApiAvailable);
+            }
         }
 
         // Scenario 2: Model name changed but dimensions match schema - update stored config

--- a/src/Memorizer/Views/Tools/DimensionMigration.cshtml
+++ b/src/Memorizer/Views/Tools/DimensionMigration.cshtml
@@ -235,7 +235,8 @@
             resultsContentId: 'resultsContent',
             startButtonId: 'startButton',
             formId: 'dimensionMigrationForm',
-            jobName: 'Dimension migration'
+            jobName: 'Dimension migration',
+            onComplete: () => loadDimensionStatus()
         });
 
         document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- auto-reconcile `embedding_config` when live probe and schema already match, so users are not forced to rerun migration
- refresh mismatch state after migration completion and refresh the migration tool status card when the job completes
- update integration tests to validate stale configuration self-healing behavior

## Validation
- dotnet test src/Memorizer.IntegrationTests --filter \"FullyQualifiedName~EmbeddingDimensionServiceTests\"