### PR TITLE
Harden OpenAI-compatible embedding provider support

### DIFF
--- a/src/Memorizer.UnitTests/EmbeddingApiClientTests.cs
+++ b/src/Memorizer.UnitTests/EmbeddingApiClientTests.cs
@@ -96,6 +96,27 @@ public class EmbeddingApiClientTests
     }
 
     [Fact]
+    public async Task GenerateAsync_OllamaProvider_WithApiKey_DoesNotSendAuthHeader()
+    {
+        var handler = new RecordingHandler(JsonSerializer.Serialize(new
+        {
+            embedding = new float[] { 0.1f, 0.2f, 0.3f }
+        }));
+
+        var client = CreateClient(handler, new EmbeddingSettings
+        {
+            Provider = ProviderNames.Ollama,
+            ApiUrl = new Uri("http://embed.local"),
+            Model = "all-minilm",
+            ApiKey = "sk-should-not-leak"
+        });
+
+        await client.GenerateAsync("all-minilm", "probe");
+
+        Assert.Null(handler.LastRequest!.Headers.Authorization);
+    }
+
+    [Fact]
     public async Task GenerateAsync_ProviderMatchIsCaseInsensitive()
     {
         var handler = new RecordingHandler(JsonSerializer.Serialize(new

--- a/src/Memorizer.UnitTests/EmbeddingApiClientTests.cs
+++ b/src/Memorizer.UnitTests/EmbeddingApiClientTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Memorizer.Models;
+using Memorizer.Services;
+using Memorizer.Settings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Memorizer.UnitTests;
+
+public class EmbeddingApiClientTests
+{
+    [Fact]
+    public async Task GenerateAsync_OllamaProvider_PostsToApiEmbeddings_WithModelAndPrompt()
+    {
+        var handler = new RecordingHandler(JsonSerializer.Serialize(new
+        {
+            embedding = new float[] { 0.1f, 0.2f, 0.3f }
+        }));
+
+        var client = CreateClient(handler, new EmbeddingSettings
+        {
+            Provider = ProviderNames.Ollama,
+            ApiUrl = new Uri("http://embed.local"),
+            Model = "all-minilm"
+        });
+
+        var result = await client.GenerateAsync("all-minilm", "hello world");
+
+        Assert.Equal([0.1f, 0.2f, 0.3f], result);
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal("/api/embeddings", handler.LastRequest!.RequestUri!.AbsolutePath);
+
+        var body = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.Equal("all-minilm", body.RootElement.GetProperty("model").GetString());
+        Assert.Equal("hello world", body.RootElement.GetProperty("prompt").GetString());
+        Assert.False(body.RootElement.TryGetProperty("input", out _));
+        Assert.Null(handler.LastRequest.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_OpenAIProvider_PostsToV1Embeddings_WithModelAndInput_AndBearerAuth()
+    {
+        var handler = new RecordingHandler(JsonSerializer.Serialize(new
+        {
+            data = new[]
+            {
+                new { embedding = new float[] { 0.4f, 0.5f, 0.6f }, index = 0 }
+            }
+        }));
+
+        var client = CreateClient(handler, new EmbeddingSettings
+        {
+            Provider = ProviderNames.OpenAI,
+            ApiUrl = new Uri("https://api.openai.com"),
+            Model = "text-embedding-3-small",
+            ApiKey = "sk-test-key"
+        });
+
+        var result = await client.GenerateAsync("text-embedding-3-small", "hello world");
+
+        Assert.Equal([0.4f, 0.5f, 0.6f], result);
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal("/v1/embeddings", handler.LastRequest!.RequestUri!.AbsolutePath);
+
+        var body = JsonDocument.Parse(handler.LastRequestBody!);
+        Assert.Equal("text-embedding-3-small", body.RootElement.GetProperty("model").GetString());
+        Assert.Equal("hello world", body.RootElement.GetProperty("input").GetString());
+        Assert.False(body.RootElement.TryGetProperty("prompt", out _));
+
+        Assert.NotNull(handler.LastRequest.Headers.Authorization);
+        Assert.Equal("Bearer", handler.LastRequest.Headers.Authorization!.Scheme);
+        Assert.Equal("sk-test-key", handler.LastRequest.Headers.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_OpenAIProvider_WithoutApiKey_DoesNotSendAuthHeader()
+    {
+        var handler = new RecordingHandler(JsonSerializer.Serialize(new
+        {
+            data = new[] { new { embedding = new float[] { 1f }, index = 0 } }
+        }));
+
+        var client = CreateClient(handler, new EmbeddingSettings
+        {
+            Provider = ProviderNames.OpenAI,
+            ApiUrl = new Uri("http://localhost:8000"),
+            Model = "local-model",
+            ApiKey = null
+        });
+
+        await client.GenerateAsync("local-model", "probe");
+
+        Assert.Null(handler.LastRequest!.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ProviderMatchIsCaseInsensitive()
+    {
+        var handler = new RecordingHandler(JsonSerializer.Serialize(new
+        {
+            data = new[] { new { embedding = new float[] { 1f }, index = 0 } }
+        }));
+
+        var client = CreateClient(handler, new EmbeddingSettings
+        {
+            Provider = "OpenAI",
+            ApiUrl = new Uri("https://api.openai.com"),
+            Model = "text-embedding-3-small"
+        });
+
+        await client.GenerateAsync("text-embedding-3-small", "x");
+
+        Assert.Equal("/v1/embeddings", handler.LastRequest!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_OllamaProvider_EmptyResponse_Throws()
+    {
+        var handler = new RecordingHandler(JsonSerializer.Serialize(new { embedding = Array.Empty<float>() }));
+
+        var client = CreateClient(handler, new EmbeddingSettings
+        {
+            Provider = ProviderNames.Ollama,
+            ApiUrl = new Uri("http://embed.local"),
+            Model = "m"
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.GenerateAsync("m", "t"));
+    }
+
+    [Fact]
+    public async Task GenerateAsync_OpenAIProvider_NoData_Throws()
+    {
+        var handler = new RecordingHandler(JsonSerializer.Serialize(new { data = Array.Empty<object>() }));
+
+        var client = CreateClient(handler, new EmbeddingSettings
+        {
+            Provider = ProviderNames.OpenAI,
+            ApiUrl = new Uri("https://api.openai.com"),
+            Model = "m"
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.GenerateAsync("m", "t"));
+    }
+
+    private static EmbeddingApiClient CreateClient(HttpMessageHandler handler, EmbeddingSettings settings)
+    {
+        var httpClient = new HttpClient(handler);
+        var snapshot = new TestOptionsSnapshot<EmbeddingSettings>(settings);
+        return new EmbeddingApiClient(httpClient, snapshot, NullLogger<EmbeddingApiClient>.Instance);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly string _responseBody;
+
+        public RecordingHandler(string responseBody)
+        {
+            _responseBody = responseBody;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            LastRequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responseBody, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    private sealed class TestOptionsSnapshot<T> : IOptionsSnapshot<T> where T : class
+    {
+        public TestOptionsSnapshot(T value) { Value = value; }
+        public T Value { get; }
+        public T Get(string? name) => Value;
+    }
+}

--- a/src/Memorizer.UnitTests/ProviderConfigSanitizerTests.cs
+++ b/src/Memorizer.UnitTests/ProviderConfigSanitizerTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Memorizer.Services;
+
+namespace Memorizer.UnitTests;
+
+public class ProviderConfigSanitizerTests
+{
+    [Fact]
+    public void RedactForDisplay_ReplacesApiKeyWithConfiguredFlag()
+    {
+        using var config = JsonDocument.Parse("""
+        {
+            "apiUrl": "https://api.openai.com",
+            "model": "text-embedding-3-small",
+            "apiKey": "sk-secret"
+        }
+        """);
+
+        var redacted = ProviderConfigSanitizer.RedactForDisplay(config);
+
+        Assert.False(redacted.ContainsKey("apiKey"));
+        Assert.True(redacted["apiKeyConfigured"]!.GetValue<bool>());
+        Assert.Equal("https://api.openai.com", redacted["apiUrl"]!.GetValue<string>());
+        Assert.Equal("text-embedding-3-small", redacted["model"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void RedactForDisplay_EmptyApiKeyReportsNotConfigured()
+    {
+        using var config = JsonDocument.Parse("""
+        {
+            "apiUrl": "https://api.openai.com",
+            "model": "text-embedding-3-small",
+            "apiKey": ""
+        }
+        """);
+
+        var redacted = ProviderConfigSanitizer.RedactForDisplay(config);
+
+        Assert.False(redacted.ContainsKey("apiKey"));
+        Assert.False(redacted["apiKeyConfigured"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void CleanForStorage_DoesNotPreserveExistingApiKey()
+    {
+        var request = new Dictionary<string, object>
+        {
+            ["apiUrl"] = "https://gateway.local",
+            ["model"] = "new-model"
+        };
+
+        using var merged = ProviderConfigSanitizer.CleanForStorage(request);
+
+        Assert.Equal("https://gateway.local", merged.RootElement.GetProperty("apiUrl").GetString());
+        Assert.Equal("new-model", merged.RootElement.GetProperty("model").GetString());
+        Assert.False(merged.RootElement.TryGetProperty("apiKey", out _));
+    }
+
+    [Fact]
+    public void CleanForStorage_DropsRequestedApiKey()
+    {
+        var request = new Dictionary<string, object>
+        {
+            ["apiUrl"] = "https://gateway.local",
+            ["model"] = "new-model",
+            ["apiKey"] = "sk-new"
+        };
+
+        using var merged = ProviderConfigSanitizer.CleanForStorage(request);
+
+        Assert.Equal("https://gateway.local", merged.RootElement.GetProperty("apiUrl").GetString());
+        Assert.Equal("new-model", merged.RootElement.GetProperty("model").GetString());
+        Assert.False(merged.RootElement.TryGetProperty("apiKey", out _));
+    }
+
+    [Fact]
+    public void CleanForStorage_DropsConfiguredMarkersFromClientPayload()
+    {
+        var request = new Dictionary<string, object>
+        {
+            ["apiUrl"] = "https://gateway.local",
+            ["model"] = "new-model",
+            ["apiKeyConfigured"] = true
+        };
+
+        using var merged = ProviderConfigSanitizer.CleanForStorage(request);
+
+        Assert.False(merged.RootElement.TryGetProperty("apiKeyConfigured", out _));
+    }
+
+    [Fact]
+    public void CleanForStorage_DropsNestedSensitiveKeys()
+    {
+        var request = new Dictionary<string, object>
+        {
+            ["apiUrl"] = "https://gateway.local",
+            ["model"] = "new-model",
+            ["headers"] = new Dictionary<string, object>
+            {
+                ["Authorization"] = "Bearer secret",
+                ["X-Api-Key"] = "nested-secret",
+                ["X-Trace-Id"] = "trace-1"
+            }
+        };
+
+        using var merged = ProviderConfigSanitizer.CleanForStorage(request);
+        var headers = merged.RootElement.GetProperty("headers");
+
+        Assert.False(headers.TryGetProperty("Authorization", out _));
+        Assert.False(headers.TryGetProperty("X-Api-Key", out _));
+        Assert.Equal("trace-1", headers.GetProperty("X-Trace-Id").GetString());
+    }
+}

--- a/src/Memorizer/Controllers/ConfigurationController.cs
+++ b/src/Memorizer/Controllers/ConfigurationController.cs
@@ -42,7 +42,10 @@ public class ConfigurationController : ControllerBase
         {
             EmbeddingSettings = new EmbeddingConfigDto
             {
+                Provider = EmbeddingSettingsValue.Provider,
+                ApiUrl = EmbeddingSettingsValue.ApiUrl?.ToString(),
                 ApiConfigured = EmbeddingSettingsValue.ApiUrl != null,
+                ApiKeyConfigured = !string.IsNullOrWhiteSpace(EmbeddingSettingsValue.ApiKey),
                 Model = EmbeddingSettingsValue.Model,
                 Timeout = EmbeddingSettingsValue.Timeout.ToString()
             },
@@ -80,7 +83,10 @@ public class SystemConfiguration
 
 public class EmbeddingConfigDto
 {
+    public string Provider { get; set; } = string.Empty;
+    public string? ApiUrl { get; set; }
     public bool ApiConfigured { get; set; }
+    public bool ApiKeyConfigured { get; set; }
     public string Model { get; set; } = string.Empty;
     public string Timeout { get; set; } = string.Empty;
 }

--- a/src/Memorizer/Controllers/SettingsController.cs
+++ b/src/Memorizer/Controllers/SettingsController.cs
@@ -1,7 +1,9 @@
-using System.Text.Json;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using Memorizer.Models;
 using Memorizer.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using OllamaSharp;
 
 namespace Memorizer.Controllers;
@@ -14,21 +16,15 @@ public class SettingsController : Controller
 {
     private readonly IStorage _storage;
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly IEmbeddingDimensionService _dimensionService;
-    private readonly IDimensionMismatchState _mismatchState;
     private readonly ILogger<SettingsController> _logger;
 
     public SettingsController(
         IStorage storage,
         IHttpClientFactory httpClientFactory,
-        IEmbeddingDimensionService dimensionService,
-        IDimensionMismatchState mismatchState,
         ILogger<SettingsController> logger)
     {
         _storage = storage;
         _httpClientFactory = httpClientFactory;
-        _dimensionService = dimensionService;
-        _mismatchState = mismatchState;
         _logger = logger;
     }
 
@@ -59,7 +55,7 @@ public class SettingsController : Controller
                 p.ProviderName,
                 p.DisplayName,
                 p.IsActive,
-                config = JsonSerializer.Deserialize<object>(p.Config.RootElement.GetRawText()),
+                config = ProviderConfigSanitizer.RedactForDisplay(p.Config),
                 p.CreatedAt,
                 p.UpdatedAt
             }),
@@ -70,7 +66,7 @@ public class SettingsController : Controller
                 p.ProviderName,
                 p.DisplayName,
                 p.IsActive,
-                config = JsonSerializer.Deserialize<object>(p.Config.RootElement.GetRawText()),
+                config = ProviderConfigSanitizer.RedactForDisplay(p.Config),
                 p.CreatedAt,
                 p.UpdatedAt
             })
@@ -92,13 +88,13 @@ public class SettingsController : Controller
             {
                 embeddingProvider.ProviderName,
                 embeddingProvider.DisplayName,
-                config = JsonSerializer.Deserialize<object>(embeddingProvider.Config.RootElement.GetRawText())
+                config = ProviderConfigSanitizer.RedactForDisplay(embeddingProvider.Config)
             } : null,
             memorizerAgent = agentProvider != null ? new
             {
                 agentProvider.ProviderName,
                 agentProvider.DisplayName,
-                config = JsonSerializer.Deserialize<object>(agentProvider.Config.RootElement.GetRawText())
+                config = ProviderConfigSanitizer.RedactForDisplay(agentProvider.Config)
             } : null
         });
     }
@@ -111,13 +107,15 @@ public class SettingsController : Controller
     {
         try
         {
+            var existingProviders = await _storage.GetAllProvidersAsync(request.ProviderType, cancellationToken);
+
             // Check if embedding model is changing (to detect re-embedding need)
             string? previousModel = null;
             bool modelChanged = false;
 
             if (request.ProviderType == ProviderTypes.Embedding && request.IsActive)
             {
-                var previousProvider = await _storage.GetActiveProviderAsync(ProviderTypes.Embedding, cancellationToken);
+                var previousProvider = existingProviders.FirstOrDefault(p => p.IsActive);
                 if (previousProvider != null)
                 {
                     var prevConfig = previousProvider.Config.RootElement;
@@ -140,7 +138,7 @@ public class SettingsController : Controller
                 ProviderType = request.ProviderType,
                 ProviderName = request.ProviderName,
                 DisplayName = request.DisplayName,
-                Config = JsonDocument.Parse(JsonSerializer.Serialize(request.Config)),
+                Config = ProviderConfigSanitizer.CleanForStorage(request.Config),
                 IsActive = request.IsActive
             };
 
@@ -153,35 +151,27 @@ public class SettingsController : Controller
             DimensionValidationResult? dimensionValidation = null;
             if (request.ProviderType == ProviderTypes.Embedding && saved.IsActive)
             {
-                dimensionValidation = await ValidateEmbeddingDimensionsAsync(cancellationToken);
-
-                // Update the configuration with new values so IOptionsSnapshot picks them up
                 var config = HttpContext.RequestServices.GetRequiredService<IConfiguration>();
-                if (request.Config.TryGetValue("apiUrl", out var apiUrlObj))
-                {
-                    config["Embeddings:ApiUrl"] = apiUrlObj?.ToString();
-                }
-                if (request.Config.TryGetValue("model", out var modelObj))
-                {
-                    config["Embeddings:Model"] = modelObj?.ToString();
-                }
+                ApplyEmbeddingProviderConfiguration(config, saved);
+                dimensionValidation = await ValidateEmbeddingDimensionsAsync(cancellationToken);
             }
 
             // If this is an active Memorizer Agent provider, update configuration
             if (request.ProviderType == ProviderTypes.MemorizerAgent && saved.IsActive)
             {
                 var config = HttpContext.RequestServices.GetRequiredService<IConfiguration>();
-                if (request.Config.TryGetValue("apiUrl", out var apiUrlObj))
+                var savedConfig = saved.Config.RootElement;
+                if (savedConfig.TryGetProperty("apiUrl", out var apiUrlObj))
                 {
-                    config["LLM:ApiUrl"] = apiUrlObj?.ToString();
+                    config["LLM:ApiUrl"] = apiUrlObj.GetString();
                 }
-                if (request.Config.TryGetValue("model", out var modelObj))
+                if (savedConfig.TryGetProperty("model", out var modelObj))
                 {
-                    config["LLM:Model"] = modelObj?.ToString();
+                    config["LLM:Model"] = modelObj.GetString();
                 }
-                if (request.Config.TryGetValue("timeout", out var timeoutObj))
+                if (savedConfig.TryGetProperty("timeout", out var timeoutObj))
                 {
-                    config["LLM:Timeout"] = timeoutObj?.ToString();
+                    config["LLM:Timeout"] = timeoutObj.GetString();
                 }
             }
 
@@ -243,6 +233,13 @@ public class SettingsController : Controller
             DimensionValidationResult? dimensionValidation = null;
             if (request.ProviderType == ProviderTypes.Embedding)
             {
+                var activeProvider = await _storage.GetActiveProviderAsync(ProviderTypes.Embedding, cancellationToken);
+                if (activeProvider != null)
+                {
+                    var config = HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+                    ApplyEmbeddingProviderConfiguration(config, activeProvider);
+                }
+
                 dimensionValidation = await ValidateEmbeddingDimensionsAsync(cancellationToken);
             }
 
@@ -349,6 +346,59 @@ public class SettingsController : Controller
                 }
             }
 
+            if (request.ProviderName == ProviderNames.OpenAI && request.ProviderType == ProviderTypes.Embedding)
+            {
+                if (string.IsNullOrWhiteSpace(request.Model))
+                {
+                    return Json(new
+                    {
+                        success = false,
+                        error = "Model is required to test OpenAI-compatible embeddings",
+                        responseTimeMs = stopwatch.ElapsedMilliseconds
+                    });
+                }
+
+                var httpClient = _httpClientFactory.CreateClient();
+                httpClient.BaseAddress = new Uri(request.ApiUrl);
+                httpClient.Timeout = TimeSpan.FromSeconds(30);
+
+                var config = HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+                var apiKey = config["Embeddings:ApiKey"];
+
+                var testRequest = new OpenAIEmbeddingRequest
+                {
+                    Model = request.Model,
+                    Input = "test"
+                };
+                var httpRequest = new HttpRequestMessage(HttpMethod.Post, "v1/embeddings")
+                {
+                    Content = JsonContent.Create(testRequest)
+                };
+
+                if (!string.IsNullOrWhiteSpace(apiKey))
+                {
+                    httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                }
+
+                var response = await httpClient.SendAsync(httpRequest, cancellationToken);
+                response.EnsureSuccessStatusCode();
+
+                var embeddings = await response.Content.ReadFromJsonAsync<OpenAIEmbeddingResponse>(cancellationToken: cancellationToken);
+                var dimensions = embeddings?.Data.FirstOrDefault()?.Embedding.Length ?? 0;
+                if (dimensions == 0)
+                {
+                    throw new InvalidOperationException("Empty embedding response from OpenAI-compatible API");
+                }
+
+                stopwatch.Stop();
+                return Json(new
+                {
+                    success = true,
+                    message = $"Successfully connected to OpenAI-compatible embeddings API and verified model '{request.Model}' ({dimensions} dimensions)",
+                    responseTimeMs = stopwatch.ElapsedMilliseconds
+                });
+            }
+
             return BadRequest(new { success = false, error = $"Unknown provider: {request.ProviderName}" });
         }
         catch (HttpRequestException ex)
@@ -440,6 +490,20 @@ public class SettingsController : Controller
                 });
             }
 
+            if (request.ProviderName == ProviderNames.OpenAI)
+            {
+                return Json(new
+                {
+                    success = true,
+                    models = new[]
+                    {
+                        new { name = "text-embedding-3-small", size = 0L, modifiedAt = (DateTimeOffset?)null, sizeFormatted = "", isLikelyEmbedding = true },
+                        new { name = "text-embedding-3-large", size = 0L, modifiedAt = (DateTimeOffset?)null, sizeFormatted = "", isLikelyEmbedding = true },
+                        new { name = "text-embedding-ada-002", size = 0L, modifiedAt = (DateTimeOffset?)null, sizeFormatted = "", isLikelyEmbedding = true }
+                    }
+                });
+            }
+
             return BadRequest(new { success = false, error = $"Unknown provider: {request.ProviderName}" });
         }
         catch (HttpRequestException ex)
@@ -514,8 +578,12 @@ public class SettingsController : Controller
     {
         _logger.LogInformation("Validating embedding dimensions after provider change...");
 
-        var validation = await _dimensionService.ValidateAsync(cancellationToken);
-        _mismatchState.Update(validation);
+        using var scope = HttpContext.RequestServices.CreateScope();
+        var dimensionService = scope.ServiceProvider.GetRequiredService<IEmbeddingDimensionService>();
+        var mismatchState = scope.ServiceProvider.GetRequiredService<IDimensionMismatchState>();
+
+        var validation = await dimensionService.ValidateAsync(cancellationToken);
+        mismatchState.Update(validation);
 
         if (validation.HasMismatch)
         {
@@ -535,6 +603,19 @@ public class SettingsController : Controller
         }
 
         return validation;
+    }
+
+    private static void ApplyEmbeddingProviderConfiguration(IConfiguration config, ProviderSettings provider)
+    {
+        config["Embeddings:Provider"] = provider.ProviderName;
+
+        var providerConfig = provider.Config.RootElement;
+        config["Embeddings:ApiUrl"] = providerConfig.TryGetProperty("apiUrl", out var apiUrlProp)
+            ? apiUrlProp.GetString()
+            : null;
+        config["Embeddings:Model"] = providerConfig.TryGetProperty("model", out var modelProp)
+            ? modelProp.GetString()
+            : null;
     }
 }
 

--- a/src/Memorizer/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Memorizer/Extensions/ServiceCollectionExtensions.cs
@@ -38,12 +38,13 @@ public static class ServiceCollectionExtensions
             .BindConfiguration("Embeddings")
             .ValidateOnStart();
 
-        // Register EmbeddingService as Scoped so it gets fresh settings on each request
-        // Note: HttpClient is configured with base address in the service constructor
-        services.AddHttpClient<IEmbeddingService, EmbeddingService>();
+        // Single typed HttpClient that handles provider-specific request/response shapes
+        // (Ollama and OpenAI-compatible). EmbeddingService and EmbeddingDimensionService
+        // consume it instead of holding their own HttpClient.
+        services.AddHttpClient<IEmbeddingApiClient, EmbeddingApiClient>();
 
-        // Register EmbeddingDimensionService with its own HttpClient (singleton is fine here)
-        services.AddHttpClient<IEmbeddingDimensionService, EmbeddingDimensionService>();
+        services.AddScoped<IEmbeddingService, EmbeddingService>();
+        services.AddScoped<IEmbeddingDimensionService, EmbeddingDimensionService>();
 
         // Register dimension mismatch state holder for UI warnings
         services.AddSingleton<IDimensionMismatchState, DimensionMismatchState>();

--- a/src/Memorizer/Models/OpenAIEmbeddingRequest.cs
+++ b/src/Memorizer/Models/OpenAIEmbeddingRequest.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Memorizer.Models;
+
+public class OpenAIEmbeddingRequest
+{
+    [JsonPropertyName("model")]
+    public string Model { get; init; } = string.Empty;
+
+    [JsonPropertyName("input")]
+    public string Input { get; init; } = string.Empty;
+}
+
+public class OpenAIEmbeddingResponse
+{
+    [JsonPropertyName("data")]
+    public OpenAIEmbeddingData[] Data { get; init; } = [];
+}
+
+public class OpenAIEmbeddingData
+{
+    [JsonPropertyName("embedding")]
+    public float[] Embedding { get; init; } = [];
+
+    [JsonPropertyName("index")]
+    public int Index { get; init; }
+}

--- a/src/Memorizer/Services/EmbeddingApiClient.cs
+++ b/src/Memorizer/Services/EmbeddingApiClient.cs
@@ -1,0 +1,92 @@
+using System.Net.Http.Headers;
+using Memorizer.Models;
+using Memorizer.Settings;
+using Microsoft.Extensions.Options;
+
+namespace Memorizer.Services;
+
+/// <summary>
+/// Sends embedding requests to the configured provider and normalises the response
+/// to a <c>float[]</c>. Supports Ollama's native <c>/api/embeddings</c> shape and the
+/// OpenAI-compatible <c>/v1/embeddings</c> shape (also exposed by LiteLLM, vLLM, Azure
+/// OpenAI, LocalAI, etc.).
+/// </summary>
+public interface IEmbeddingApiClient
+{
+    Task<float[]> GenerateAsync(string model, string text, CancellationToken cancellationToken = default);
+}
+
+public sealed class EmbeddingApiClient : IEmbeddingApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IOptionsSnapshot<EmbeddingSettings> _settingsSnapshot;
+    private readonly ILogger<EmbeddingApiClient> _logger;
+
+    private EmbeddingSettings Settings => _settingsSnapshot.Value;
+
+    public EmbeddingApiClient(
+        HttpClient httpClient,
+        IOptionsSnapshot<EmbeddingSettings> settingsSnapshot,
+        ILogger<EmbeddingApiClient> logger)
+    {
+        _httpClient = httpClient;
+        _settingsSnapshot = settingsSnapshot;
+        _logger = logger;
+
+        _httpClient.BaseAddress = Settings.ApiUrl;
+        _httpClient.Timeout = Settings.Timeout;
+
+        if (!string.IsNullOrWhiteSpace(Settings.ApiKey))
+        {
+            _httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", Settings.ApiKey);
+        }
+    }
+
+    public async Task<float[]> GenerateAsync(string model, string text, CancellationToken cancellationToken = default)
+    {
+        var provider = Settings.Provider;
+
+        if (string.Equals(provider, ProviderNames.OpenAI, StringComparison.OrdinalIgnoreCase))
+        {
+            return await GenerateOpenAIAsync(model, text, cancellationToken);
+        }
+
+        return await GenerateOllamaAsync(model, text, cancellationToken);
+    }
+
+    private async Task<float[]> GenerateOllamaAsync(string model, string text, CancellationToken cancellationToken)
+    {
+        var request = new EmbeddingRequest { Model = model, Prompt = text };
+
+        _logger.LogDebug("Sending Ollama embedding request to {ApiUrl}", Settings.ApiUrl);
+        var response = await _httpClient.PostAsJsonAsync("api/embeddings", request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<EmbeddingResponse>(cancellationToken: cancellationToken);
+        if (result?.Embedding is null || result.Embedding.Length == 0)
+        {
+            throw new InvalidOperationException("Empty embedding response from Ollama API");
+        }
+
+        return result.Embedding;
+    }
+
+    private async Task<float[]> GenerateOpenAIAsync(string model, string text, CancellationToken cancellationToken)
+    {
+        var request = new OpenAIEmbeddingRequest { Model = model, Input = text };
+
+        _logger.LogDebug("Sending OpenAI-compatible embedding request to {ApiUrl}", Settings.ApiUrl);
+        var response = await _httpClient.PostAsJsonAsync("v1/embeddings", request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<OpenAIEmbeddingResponse>(cancellationToken: cancellationToken);
+        var first = result?.Data.FirstOrDefault();
+        if (first?.Embedding is null || first.Embedding.Length == 0)
+        {
+            throw new InvalidOperationException("Empty embedding response from OpenAI-compatible API");
+        }
+
+        return first.Embedding;
+    }
+}

--- a/src/Memorizer/Services/EmbeddingApiClient.cs
+++ b/src/Memorizer/Services/EmbeddingApiClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using Memorizer.Models;
 using Memorizer.Settings;
 using Microsoft.Extensions.Options;
@@ -35,12 +36,6 @@ public sealed class EmbeddingApiClient : IEmbeddingApiClient
 
         _httpClient.BaseAddress = Settings.ApiUrl;
         _httpClient.Timeout = Settings.Timeout;
-
-        if (!string.IsNullOrWhiteSpace(Settings.ApiKey))
-        {
-            _httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Bearer", Settings.ApiKey);
-        }
     }
 
     public async Task<float[]> GenerateAsync(string model, string text, CancellationToken cancellationToken = default)
@@ -75,9 +70,19 @@ public sealed class EmbeddingApiClient : IEmbeddingApiClient
     private async Task<float[]> GenerateOpenAIAsync(string model, string text, CancellationToken cancellationToken)
     {
         var request = new OpenAIEmbeddingRequest { Model = model, Input = text };
+        var httpRequest = new HttpRequestMessage(HttpMethod.Post, "v1/embeddings")
+        {
+            Content = JsonContent.Create(request)
+        };
+
+        if (!string.IsNullOrWhiteSpace(Settings.ApiKey))
+        {
+            httpRequest.Headers.Authorization =
+                new AuthenticationHeaderValue("Bearer", Settings.ApiKey);
+        }
 
         _logger.LogDebug("Sending OpenAI-compatible embedding request to {ApiUrl}", Settings.ApiUrl);
-        var response = await _httpClient.PostAsJsonAsync("v1/embeddings", request, cancellationToken);
+        var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
         response.EnsureSuccessStatusCode();
 
         var result = await response.Content.ReadFromJsonAsync<OpenAIEmbeddingResponse>(cancellationToken: cancellationToken);

--- a/src/Memorizer/Services/EmbeddingDimensionService.cs
+++ b/src/Memorizer/Services/EmbeddingDimensionService.cs
@@ -294,13 +294,19 @@ public class EmbeddingDimensionService : IEmbeddingDimensionService
         if (detected.HasValue)
             return detected.Value;
 
-        // Fall back to stored config
         var stored = await GetActiveConfigAsync(ct);
+        var schema = await GetDatabaseSchemaDimensionsAsync(ct);
+
+        // During dimension migration the schema changes before embedding_config is finalized.
+        // Fallback embeddings must satisfy the live VECTOR(n) columns to avoid failed writes.
+        if (schema.HasValue && stored != null && stored.Dimensions != schema.Value)
+            return schema.Value;
+
+        // Fall back to stored config
         if (stored != null)
             return stored.Dimensions;
 
         // Fall back to schema
-        var schema = await GetDatabaseSchemaDimensionsAsync(ct);
         if (schema.HasValue)
             return schema.Value;
 

--- a/src/Memorizer/Services/EmbeddingDimensionService.cs
+++ b/src/Memorizer/Services/EmbeddingDimensionService.cs
@@ -17,7 +17,7 @@ public class EmbeddingDimensionService : IEmbeddingDimensionService
 {
     private readonly NpgsqlDataSource _dataSource;
     private readonly IOptionsSnapshot<EmbeddingSettings> _settingsSnapshot;
-    private readonly HttpClient _httpClient;
+    private readonly IEmbeddingApiClient _apiClient;
     private readonly ILogger<EmbeddingDimensionService> _logger;
 
     // Convenience property to get current settings
@@ -30,20 +30,17 @@ public class EmbeddingDimensionService : IEmbeddingDimensionService
     public EmbeddingDimensionService(
         NpgsqlDataSource dataSource,
         IOptionsSnapshot<EmbeddingSettings> settingsSnapshot,
-        HttpClient httpClient,
+        IEmbeddingApiClient apiClient,
         ILogger<EmbeddingDimensionService> logger)
     {
         _dataSource = dataSource;
         _settingsSnapshot = settingsSnapshot;
-        _httpClient = httpClient;
-        _httpClient.BaseAddress = Settings.ApiUrl;
-        _httpClient.Timeout = Settings.Timeout;
+        _apiClient = apiClient;
         _logger = logger;
     }
 
     public async Task<int?> ProbeModelDimensionsAsync(CancellationToken ct = default)
     {
-        // Return cached value if we've already probed this model
         if (_cachedModelDimensions.HasValue && _cachedModelName == Settings.Model)
         {
             return _cachedModelDimensions;
@@ -53,24 +50,15 @@ public class EmbeddingDimensionService : IEmbeddingDimensionService
         {
             _logger.LogDebug("Probing embedding model {Model} for dimensions", Settings.Model);
 
-            var request = new EmbeddingRequest
-            {
-                Model = Settings.Model,
-                Prompt = "dimension probe"
-            };
+            var embedding = await _apiClient.GenerateAsync(Settings.Model, "dimension probe", ct);
 
-            var response = await _httpClient.PostAsJsonAsync("api/embeddings", request, ct);
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<EmbeddingResponse>(cancellationToken: ct);
-
-            if (result?.Embedding == null || result.Embedding.Length == 0)
+            if (embedding.Length == 0)
             {
                 _logger.LogWarning("Empty embedding response from model probe");
                 return null;
             }
 
-            _cachedModelDimensions = result.Embedding.Length;
+            _cachedModelDimensions = embedding.Length;
             _cachedModelName = Settings.Model;
 
             _logger.LogInformation("Detected {Dimensions} dimensions from model {Model}",

--- a/src/Memorizer/Services/EmbeddingService.cs
+++ b/src/Memorizer/Services/EmbeddingService.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Memorizer.Models;
 using Memorizer.Settings;
 using Microsoft.Extensions.Options;
 
@@ -24,28 +23,23 @@ public interface IEmbeddingService
 /// </summary>
 public class EmbeddingService : IEmbeddingService
 {
-    private readonly HttpClient _httpClient;
+    private readonly IEmbeddingApiClient _apiClient;
     private readonly IOptionsSnapshot<EmbeddingSettings> _settingsSnapshot;
     private readonly IEmbeddingDimensionService _dimensionService;
     private readonly ILogger<EmbeddingService> _logger;
 
-    // Convenience property to get current settings value
     private EmbeddingSettings Settings => _settingsSnapshot.Value;
 
     public EmbeddingService(
-        HttpClient httpClient,
+        IEmbeddingApiClient apiClient,
         IOptionsSnapshot<EmbeddingSettings> settingsSnapshot,
         IEmbeddingDimensionService dimensionService,
         ILogger<EmbeddingService> logger)
     {
-        _httpClient = httpClient;
+        _apiClient = apiClient;
         _settingsSnapshot = settingsSnapshot;
         _dimensionService = dimensionService;
         _logger = logger;
-
-        // Configure HttpClient with current settings
-        _httpClient.BaseAddress = Settings.ApiUrl;
-        _httpClient.Timeout = Settings.Timeout;
     }
 
     public async Task<float[]> Generate(
@@ -57,35 +51,16 @@ public class EmbeddingService : IEmbeddingService
         {
             _logger.LogDebug("Generating embedding for text of length {TextLength}", text.Length);
 
-            EmbeddingRequest request = new() { Model = Settings.Model, Prompt = text };
+            var embedding = await _apiClient.GenerateAsync(Settings.Model, text, cancellationToken);
 
-            _logger.LogDebug("Sending request to embedding API at {ApiUrl}", Settings.ApiUrl);
-            HttpResponseMessage response = await _httpClient.PostAsJsonAsync(
-                "api/embeddings",
-                request,
-                cancellationToken
-            );
-            response.EnsureSuccessStatusCode();
+            _logger.LogDebug("Successfully generated embedding with {Dimensions} dimensions", embedding.Length);
 
-            EmbeddingResponse? result =
-                await response.Content.ReadFromJsonAsync<EmbeddingResponse>(
-                    cancellationToken: cancellationToken
-                );
-            if (result?.Embedding == null || result.Embedding.Length == 0)
-            {
-                throw new Exception("Failed to generate embedding: Empty response from API");
-            }
-
-            _logger.LogDebug("Successfully generated embedding with {Dimensions} dimensions", result.Embedding.Length);
-
-            return result.Embedding;
+            return embedding;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error generating embedding: {ErrorMessage}", ex.Message);
 
-            // Fallback to a random embedding in case of error
-            // Use effective dimensions from the dimension service (detected > stored > schema > 384)
             _logger.LogWarning("Falling back to random embedding generation");
             var dimensions = await _dimensionService.GetEffectiveDimensionsAsync(cancellationToken);
 
@@ -96,7 +71,6 @@ public class EmbeddingService : IEmbeddingService
                 embedding[i] = (float)random.NextDouble();
             }
 
-            // Normalize the embedding
             float sum = 0;
             for (int i = 0; i < embedding.Length; i++)
             {

--- a/src/Memorizer/Services/IEmbeddingDimensionService.cs
+++ b/src/Memorizer/Services/IEmbeddingDimensionService.cs
@@ -43,7 +43,8 @@ public interface IEmbeddingDimensionService
 
     /// <summary>
     /// Get the effective dimensions to use for fallback/default scenarios.
-    /// Uses: detected > stored > schema > 384
+    /// Uses detected dimensions first. If stored config and schema disagree,
+    /// schema wins so fallback embeddings can still be written to VECTOR(n) columns.
     /// </summary>
     Task<int> GetEffectiveDimensionsAsync(CancellationToken ct = default);
 }

--- a/src/Memorizer/Services/InitializationService.cs
+++ b/src/Memorizer/Services/InitializationService.cs
@@ -136,6 +136,10 @@ public sealed class InitializationService : BackgroundService
             {
                 var providerConfig = embeddingProvider.Config.RootElement;
 
+                if (!string.IsNullOrWhiteSpace(embeddingProvider.ProviderName))
+                {
+                    config["Embeddings:Provider"] = embeddingProvider.ProviderName;
+                }
                 if (providerConfig.TryGetProperty("apiUrl", out var apiUrlProp))
                 {
                     config["Embeddings:ApiUrl"] = apiUrlProp.GetString();
@@ -144,10 +148,14 @@ public sealed class InitializationService : BackgroundService
                 {
                     config["Embeddings:Model"] = modelProp.GetString();
                 }
+                if (providerConfig.TryGetProperty("apiKey", out var apiKeyProp))
+                {
+                    config["Embeddings:ApiKey"] = apiKeyProp.GetString();
+                }
 
                 _logger.LogInformation(
-                    "Loaded embedding settings from database: ApiUrl={ApiUrl}, Model={Model}",
-                    config["Embeddings:ApiUrl"], config["Embeddings:Model"]);
+                    "Loaded embedding settings from database: Provider={Provider}, ApiUrl={ApiUrl}, Model={Model}",
+                    config["Embeddings:Provider"], config["Embeddings:ApiUrl"], config["Embeddings:Model"]);
             }
 
             // Load LLM/Agent provider settings from database
@@ -189,23 +197,30 @@ public sealed class InitializationService : BackgroundService
         var configApiUrl = settings.ApiUrl.ToString().TrimEnd('/');
         var configModel = settings.Model;
 
+        var configProvider = string.IsNullOrWhiteSpace(settings.Provider) ? ProviderNames.Ollama : settings.Provider;
+        var configApiKey = settings.ApiKey;
+        var configDisplayName = string.Equals(configProvider, ProviderNames.OpenAI, StringComparison.OrdinalIgnoreCase)
+            ? "OpenAI Embeddings"
+            : "Ollama Embeddings";
+
         if (activeProvider == null)
         {
             // No provider exists - create one from config
             _logger.LogInformation(
-                "No embedding provider configured - seeding from environment: ApiUrl={ApiUrl}, Model={Model}",
-                configApiUrl, configModel);
+                "No embedding provider configured - seeding from environment: Provider={Provider}, ApiUrl={ApiUrl}, Model={Model}",
+                configProvider, configApiUrl, configModel);
 
             var newProvider = new ProviderSettings
             {
                 Id = (ProviderSettingsId)Guid.NewGuid(),
                 ProviderType = ProviderTypes.Embedding,
-                ProviderName = ProviderNames.Ollama,
-                DisplayName = "Ollama Embeddings",
+                ProviderName = configProvider,
+                DisplayName = configDisplayName,
                 Config = JsonDocument.Parse(JsonSerializer.Serialize(new
                 {
                     apiUrl = configApiUrl,
-                    model = configModel
+                    model = configModel,
+                    apiKey = configApiKey
                 })),
                 IsActive = true,
                 CreatedAt = DateTime.UtcNow,
@@ -241,12 +256,13 @@ public sealed class InitializationService : BackgroundService
                 {
                     Id = activeProvider.Id,
                     ProviderType = ProviderTypes.Embedding,
-                    ProviderName = activeProvider.ProviderName,
-                    DisplayName = activeProvider.DisplayName,
+                    ProviderName = configProvider,
+                    DisplayName = configDisplayName,
                     Config = JsonDocument.Parse(JsonSerializer.Serialize(new
                     {
                         apiUrl = configApiUrl,
-                        model = configModel
+                        model = configModel,
+                        apiKey = configApiKey
                     })),
                     IsActive = true,
                     CreatedAt = activeProvider.CreatedAt,

--- a/src/Memorizer/Services/InitializationService.cs
+++ b/src/Memorizer/Services/InitializationService.cs
@@ -148,11 +148,6 @@ public sealed class InitializationService : BackgroundService
                 {
                     config["Embeddings:Model"] = modelProp.GetString();
                 }
-                if (providerConfig.TryGetProperty("apiKey", out var apiKeyProp))
-                {
-                    config["Embeddings:ApiKey"] = apiKeyProp.GetString();
-                }
-
                 _logger.LogInformation(
                     "Loaded embedding settings from database: Provider={Provider}, ApiUrl={ApiUrl}, Model={Model}",
                     config["Embeddings:Provider"], config["Embeddings:ApiUrl"], config["Embeddings:Model"]);
@@ -198,7 +193,6 @@ public sealed class InitializationService : BackgroundService
         var configModel = settings.Model;
 
         var configProvider = string.IsNullOrWhiteSpace(settings.Provider) ? ProviderNames.Ollama : settings.Provider;
-        var configApiKey = settings.ApiKey;
         var configDisplayName = string.Equals(configProvider, ProviderNames.OpenAI, StringComparison.OrdinalIgnoreCase)
             ? "OpenAI Embeddings"
             : "Ollama Embeddings";
@@ -219,8 +213,7 @@ public sealed class InitializationService : BackgroundService
                 Config = JsonDocument.Parse(JsonSerializer.Serialize(new
                 {
                     apiUrl = configApiUrl,
-                    model = configModel,
-                    apiKey = configApiKey
+                    model = configModel
                 })),
                 IsActive = true,
                 CreatedAt = DateTime.UtcNow,
@@ -249,27 +242,38 @@ public sealed class InitializationService : BackgroundService
             {
                 _logger.LogInformation(
                     "Updating embedding provider from localhost defaults to environment config: " +
-                    "ApiUrl={OldUrl}->{NewUrl}, Model={OldModel}->{NewModel}",
-                    existingApiUrl, configApiUrl, existingModel, configModel);
+                    "Provider={OldProvider}->{NewProvider}, ApiUrl={OldUrl}->{NewUrl}, Model={OldModel}->{NewModel}",
+                    activeProvider.ProviderName, configProvider, existingApiUrl, configApiUrl, existingModel, configModel);
+
+                var providerToUpdate = existingProviders.FirstOrDefault(p =>
+                    string.Equals(p.ProviderName, configProvider, StringComparison.OrdinalIgnoreCase));
+                var isSameProvider = string.Equals(
+                    activeProvider.ProviderName,
+                    configProvider,
+                    StringComparison.OrdinalIgnoreCase);
 
                 var updatedProvider = new ProviderSettings
                 {
-                    Id = activeProvider.Id,
+                    Id = providerToUpdate?.Id ?? (isSameProvider ? activeProvider.Id : ProviderSettingsId.New()),
                     ProviderType = ProviderTypes.Embedding,
                     ProviderName = configProvider,
                     DisplayName = configDisplayName,
                     Config = JsonDocument.Parse(JsonSerializer.Serialize(new
                     {
                         apiUrl = configApiUrl,
-                        model = configModel,
-                        apiKey = configApiKey
+                        model = configModel
                     })),
                     IsActive = true,
-                    CreatedAt = activeProvider.CreatedAt,
+                    CreatedAt = providerToUpdate?.CreatedAt ?? (isSameProvider ? activeProvider.CreatedAt : DateTime.UtcNow),
                     UpdatedAt = DateTime.UtcNow
                 };
 
                 await storage.SaveProviderSettingsAsync(updatedProvider, ct);
+                if (!isSameProvider)
+                {
+                    await storage.SetActiveProviderAsync(ProviderTypes.Embedding, configProvider, ct);
+                }
+
                 _logger.LogInformation("Embedding provider updated to use environment configuration");
             }
             else

--- a/src/Memorizer/Services/ProviderConfigSanitizer.cs
+++ b/src/Memorizer/Services/ProviderConfigSanitizer.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Memorizer.Services;
+
+public static class ProviderConfigSanitizer
+{
+    public static JsonObject RedactForDisplay(JsonDocument config)
+    {
+        var node = JsonNode.Parse(config.RootElement.GetRawText());
+        if (node is not JsonObject obj)
+        {
+            return new JsonObject();
+        }
+
+        RedactObject(obj);
+        return obj;
+    }
+
+    public static JsonDocument CleanForStorage(IReadOnlyDictionary<string, object> requestConfig)
+    {
+        var node = JsonSerializer.SerializeToNode(requestConfig) as JsonObject ?? new JsonObject();
+        CleanObjectForStorage(node);
+        return JsonDocument.Parse(node.ToJsonString());
+    }
+
+    private static void CleanObjectForStorage(JsonObject obj)
+    {
+        foreach (var (key, value) in obj.ToList())
+        {
+            if (IsConfiguredMarker(key) || IsSensitiveKey(key))
+            {
+                obj.Remove(key);
+                continue;
+            }
+
+            if (value is JsonObject childObject)
+            {
+                CleanObjectForStorage(childObject);
+            }
+            else if (value is JsonArray childArray)
+            {
+                CleanArrayForStorage(childArray);
+            }
+        }
+    }
+
+    private static void CleanArrayForStorage(JsonArray array)
+    {
+        foreach (var item in array)
+        {
+            if (item is JsonObject childObject)
+            {
+                CleanObjectForStorage(childObject);
+            }
+            else if (item is JsonArray childArray)
+            {
+                CleanArrayForStorage(childArray);
+            }
+        }
+    }
+
+    private static void RedactObject(JsonObject obj)
+    {
+        foreach (var (key, value) in obj.ToList())
+        {
+            if (IsSensitiveKey(key))
+            {
+                obj.Remove(key);
+                obj[$"{key}Configured"] = HasConfiguredValue(value);
+                continue;
+            }
+
+            if (value is JsonObject childObject)
+            {
+                RedactObject(childObject);
+            }
+            else if (value is JsonArray childArray)
+            {
+                RedactArray(childArray);
+            }
+        }
+    }
+
+    private static void RedactArray(JsonArray array)
+    {
+        foreach (var item in array)
+        {
+            if (item is JsonObject childObject)
+            {
+                RedactObject(childObject);
+            }
+            else if (item is JsonArray childArray)
+            {
+                RedactArray(childArray);
+            }
+        }
+    }
+
+    private static bool HasConfiguredValue(JsonNode? value)
+    {
+        if (value is null || value.GetValueKind() is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return false;
+        }
+
+        return value.GetValueKind() != JsonValueKind.String ||
+               !string.IsNullOrWhiteSpace(value.GetValue<string>());
+    }
+
+    private static bool IsConfiguredMarker(string key)
+    {
+        return key.EndsWith("Configured", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSensitiveKey(string key)
+    {
+        if (IsConfiguredMarker(key))
+        {
+            return false;
+        }
+
+        var normalized = key.Replace("_", "", StringComparison.Ordinal)
+            .Replace("-", "", StringComparison.Ordinal)
+            .ToLowerInvariant();
+
+        return normalized is "apikey" or "token" or "accesstoken" or "secret" or "password" or "authorization" ||
+               normalized.EndsWith("apikey", StringComparison.Ordinal) ||
+               normalized.EndsWith("token", StringComparison.Ordinal) ||
+               normalized.EndsWith("secret", StringComparison.Ordinal) ||
+               normalized.EndsWith("password", StringComparison.Ordinal);
+    }
+}

--- a/src/Memorizer/Settings/EmbeddingSettings.cs
+++ b/src/Memorizer/Settings/EmbeddingSettings.cs
@@ -1,3 +1,5 @@
+using Memorizer.Models;
+
 namespace Memorizer.Settings;
 
 /// <summary>
@@ -14,7 +16,20 @@ namespace Memorizer.Settings;
 /// </summary>
 public class EmbeddingSettings
 {
+    /// <summary>
+    /// Provider identifier. Supported values: <see cref="ProviderNames.Ollama"/>, <see cref="ProviderNames.OpenAI"/>.
+    /// OpenAI selects the OpenAI-compatible <c>POST /v1/embeddings</c> shape, which is also exposed by
+    /// LiteLLM, vLLM, Azure OpenAI, LocalAI, and similar gateways.
+    /// </summary>
+    public string Provider { get; set; } = ProviderNames.Ollama;
+
     public Uri ApiUrl { get; set; } = new("http://localhost:11434");
     public string Model { get; set; } = "all-minilm";
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Optional bearer token sent as <c>Authorization: Bearer &lt;ApiKey&gt;</c>.
+    /// Required for the hosted OpenAI API; usually omitted for self-hosted compatible servers.
+    /// </summary>
+    public string? ApiKey { get; set; }
 }

--- a/src/Memorizer/Views/Home/Config.cshtml
+++ b/src/Memorizer/Views/Home/Config.cshtml
@@ -43,17 +43,29 @@
                         <div class="col-md-6">
                             <table class="table table-sm">
                                 <tr>
-                                    <td><strong>API Configured:</strong></td>
-                                    <td><span id="embeddingApiConfigured" class="badge"></span></td>
+                                    <td><strong>Provider:</strong></td>
+                                    <td><code id="embeddingProvider"></code></td>
                                 </tr>
                                 <tr>
-                                    <td><strong>Model:</strong></td>
-                                    <td><code id="embeddingModel"></code></td>
+                                    <td><strong>API URL:</strong></td>
+                                    <td><code id="embeddingApiUrl"></code></td>
+                                </tr>
+                                <tr>
+                                    <td><strong>API Configured:</strong></td>
+                                    <td><span id="embeddingApiConfigured" class="badge"></span></td>
                                 </tr>
                             </table>
                         </div>
                         <div class="col-md-6">
                             <table class="table table-sm">
+                                <tr>
+                                    <td><strong>Model:</strong></td>
+                                    <td><code id="embeddingModel"></code></td>
+                                </tr>
+                                <tr>
+                                    <td><strong>API Key:</strong></td>
+                                    <td><span id="embeddingApiKeyConfigured" class="badge"></span></td>
+                                </tr>
                                 <tr>
                                     <td><strong>Timeout:</strong></td>
                                     <td><span id="embeddingTimeout"></span></td>
@@ -210,7 +222,10 @@ function displayConfiguration(config) {
     document.getElementById('configContent').style.display = 'block';
 
     // Embedding Configuration
+    setText('embeddingProvider', config.embeddingSettings.provider);
+    setText('embeddingApiUrl', config.embeddingSettings.apiUrl);
     setBadge('embeddingApiConfigured', config.embeddingSettings.apiConfigured, 'Configured', 'Not Configured');
+    setBadge('embeddingApiKeyConfigured', config.embeddingSettings.apiKeyConfigured, 'Configured', 'Not Configured');
     setText('embeddingModel', config.embeddingSettings.model);
     setText('embeddingTimeout', config.embeddingSettings.timeout);
 

--- a/src/Memorizer/appsettings.example.json
+++ b/src/Memorizer/appsettings.example.json
@@ -3,9 +3,17 @@
     "Storage": "Host=localhost;Port=5432;Database=postgmem;Username=postgres;Password=password"
   },
   "Embeddings": {
+    "Provider": "ollama",
     "ApiUrl": "http://localhost:11434",
     "Model": "all-minilm",
-    "Timeout": "00:01:00"
+    "Timeout": "00:01:00",
+    "ApiKey": null,
+    "_openai_example": {
+      "Provider": "openai",
+      "ApiUrl": "https://api.openai.com",
+      "Model": "text-embedding-3-small",
+      "ApiKey": "sk-..."
+    }
   },
   "LLM": {
     "ApiUrl": "http://localhost:11434",

--- a/src/Memorizer/migrations/022_strip_provider_apikey.sql
+++ b/src/Memorizer/migrations/022_strip_provider_apikey.sql
@@ -1,0 +1,56 @@
+-- 022_strip_provider_apikey.sql: Remove plaintext provider API keys from persisted provider settings.
+-- API keys are intentionally sourced from environment/application configuration instead.
+
+CREATE OR REPLACE FUNCTION memorizer_strip_provider_config_secrets(input_value jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    item RECORD;
+    normalized_key TEXT;
+    result JSONB;
+BEGIN
+    CASE jsonb_typeof(input_value)
+        WHEN 'object' THEN
+            result := '{}'::jsonb;
+
+            FOR item IN SELECT key, value FROM jsonb_each(input_value)
+            LOOP
+                normalized_key := lower(replace(replace(item.key, '_', ''), '-', ''));
+
+                IF normalized_key IN ('apikey', 'token', 'accesstoken', 'secret', 'password', 'authorization')
+                   OR normalized_key LIKE '%apikey'
+                   OR normalized_key LIKE '%token'
+                   OR normalized_key LIKE '%secret'
+                   OR normalized_key LIKE '%password'
+                THEN
+                    CONTINUE;
+                END IF;
+
+                result := result || jsonb_build_object(
+                    item.key,
+                    memorizer_strip_provider_config_secrets(item.value));
+            END LOOP;
+
+            RETURN result;
+
+        WHEN 'array' THEN
+            SELECT COALESCE(
+                jsonb_agg(memorizer_strip_provider_config_secrets(value)),
+                '[]'::jsonb)
+            INTO result
+            FROM jsonb_array_elements(input_value);
+
+            RETURN result;
+
+        ELSE
+            RETURN input_value;
+    END CASE;
+END;
+$$;
+
+UPDATE provider_settings
+SET config = memorizer_strip_provider_config_secrets(config)
+WHERE config <> memorizer_strip_provider_config_secrets(config);
+
+DROP FUNCTION memorizer_strip_provider_config_secrets(jsonb);


### PR DESCRIPTION
Builds on #193 and preserves the contributor's OpenAI-compatible embeddings work while addressing provider migration and credential handling concerns.\n\nCloses #193.\n\n## Summary\n- Add OpenAI-compatible embedding request/response support alongside Ollama.\n- Apply active embedding provider settings before dimension validation on save/activation.\n- Keep embedding API keys sourced from runtime configuration only, not provider_settings JSON.\n- Redact and recursively strip sensitive provider config keys before API display or database storage.\n- Add a migration to remove any previously persisted provider API keys from provider_settings.config.\n- Make fallback embedding dimensions schema-safe during dimension migrations.\n- Add focused unit tests for provider request auth and config sanitization.\n\n## Testing\n- git diff --check\n- dotnet test src/Memorizer.UnitTests/Memorizer.UnitTests.csproj --filter "EmbeddingApiClientTests|ProviderConfigSanitizerTests" --no-restore could not run locally because global.json requires .NET SDK 10.0.102, which is not installed in this environment.