### PR TITLE
Prepare release 2.2.0-beta1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,21 +3,28 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/petabridge/memorizer-v1</PackageProjectUrl>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0-beta1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
     <PackageReleaseNotes>**Features**
-- [Add move-project-to-workspace and workspace reparenting](https://github.com/petabridge/memorizer/pull/167) - Move projects between workspaces and reparent workspaces in the hierarchy
-  - `MoveProjectToWorkspaceAsync` atomically moves a project and all its descendants to a target workspace
-  - Workspace reparenting with circular-reference guard to prevent invalid hierarchies
-  - Full support across REST API, MCP tools, and Web UI with modal dialogs
-- [Add canonical URL support to MCP tool responses](https://github.com/petabridge/memorizer/pull/162) - MCP tool responses now include clickable URLs to the web UI for memories, workspaces, and projects
-  - Configure via `Server:CanonicalUrl` setting to enable links in MCP responses
-  - URLs included in `Store`, `Get`, `SearchMemories`, `GetMany`, `CreateWorkspace`, `CreateProject`, `GetWorkspace`, and `GetProjectContext` responses
+- [Add cross-project tag filtering with multi-tag selection and dynamic filter panel](https://github.com/petabridge/memorizer/pull/168) - Filter memories across projects and workspaces by tags, type, and location from a persistent filter panel
+  - Multi-tag selection with searchable suggestions and removable filter badges
+  - Tag suggestions and location filters update dynamically based on the current filter context
+  - Memory cards show owner badges when filtering across locations, and tag badges link directly to filtered results
+  - MCP `GetByFilter` supports filtering by type, location, and tags
+- [Harden OpenAI-compatible embedding provider support](https://github.com/petabridge/memorizer/pull/194) - Improves OpenAI-compatible embedding provider configuration, migration behavior, and credential safety
+  - Embedding API keys are read from runtime configuration instead of persisted provider settings
+  - Sensitive provider configuration values are stripped before API display or database storage
+  - Adds a database migration to remove previously persisted provider API keys from `provider_settings.config`
+  - Makes fallback embedding dimensions safer during dimension migrations
 
 **Bug Fixes**
-- [Make optional Guid MCP parameters resilient to client schema variations](https://github.com/petabridge/memorizer/pull/166) - Fixes compatibility with MCP clients (notably Cursor) that send empty strings or `"null"` for optional Guid parameters instead of proper JSON null</PackageReleaseNotes>
+- [Self-heal stale dimension configuration after migration](https://github.com/petabridge/memorizer/pull/177) - Automatically reconciles `embedding_config` when the live provider probe and database schema already match, avoiding unnecessary reruns of embedding dimension migration
+
+**Updates**
+- [Bump Akka.Streams from 1.5.60 to 1.5.62](https://github.com/petabridge/memorizer/pull/172)
+- [Bump Dapper from 2.1.66 to 2.1.72](https://github.com/petabridge/memorizer/pull/180)</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+#### 2.2.0-beta1 June 26th 2026 ####
+
+**Features**
+- [Add cross-project tag filtering with multi-tag selection and dynamic filter panel](https://github.com/petabridge/memorizer/pull/168) - Filter memories across projects and workspaces by tags, type, and location from a persistent filter panel
+  - Multi-tag selection with searchable suggestions and removable filter badges
+  - Tag suggestions and location filters update dynamically based on the current filter context
+  - Memory cards show owner badges when filtering across locations, and tag badges link directly to filtered results
+  - MCP `GetByFilter` supports filtering by type, location, and tags
+- [Harden OpenAI-compatible embedding provider support](https://github.com/petabridge/memorizer/pull/194) - Improves OpenAI-compatible embedding provider configuration, migration behavior, and credential safety
+  - Embedding API keys are read from runtime configuration instead of persisted provider settings
+  - Sensitive provider configuration values are stripped before API display or database storage
+  - Adds a database migration to remove previously persisted provider API keys from `provider_settings.config`
+  - Makes fallback embedding dimensions safer during dimension migrations
+
+**Bug Fixes**
+- [Self-heal stale dimension configuration after migration](https://github.com/petabridge/memorizer/pull/177) - Automatically reconciles `embedding_config` when the live provider probe and database schema already match, avoiding unnecessary reruns of embedding dimension migration
+
+**Updates**
+- [Bump Akka.Streams from 1.5.60 to 1.5.62](https://github.com/petabridge/memorizer/pull/172)
+- [Bump Dapper from 2.1.66 to 2.1.72](https://github.com/petabridge/memorizer/pull/180)
+
 #### 2.1.0 March 4th 2026 ####
 
 **Features**


### PR DESCRIPTION
## Summary
- Update release notes for 2.2.0-beta1
- Update package version metadata and package release notes

## Validation
- pwsh ./build.ps1
- dotnet test --no-restore could not run locally because global.json requires .NET SDK 10.0.102, which is not installed in this environment