### PR TITLE
Release 2.2.0-beta2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,28 +3,15 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/petabridge/memorizer-v1</PackageProjectUrl>
-    <VersionPrefix>2.2.0-beta1</VersionPrefix>
+    <VersionPrefix>2.2.0-beta2</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
     <PackageReleaseNotes>**Features**
-- [Add cross-project tag filtering with multi-tag selection and dynamic filter panel](https://github.com/petabridge/memorizer/pull/168) - Filter memories across projects and workspaces by tags, type, and location from a persistent filter panel
-  - Multi-tag selection with searchable suggestions and removable filter badges
-  - Tag suggestions and location filters update dynamically based on the current filter context
-  - Memory cards show owner badges when filtering across locations, and tag badges link directly to filtered results
-  - MCP `GetByFilter` supports filtering by type, location, and tags
-- [Harden OpenAI-compatible embedding provider support](https://github.com/petabridge/memorizer/pull/194) - Improves OpenAI-compatible embedding provider configuration, migration behavior, and credential safety
-  - Embedding API keys are read from runtime configuration instead of persisted provider settings
-  - Sensitive provider configuration values are stripped before API display or database storage
-  - Adds a database migration to remove previously persisted provider API keys from `provider_settings.config`
-  - Makes fallback embedding dimensions safer during dimension migrations
-
-**Bug Fixes**
-- [Self-heal stale dimension configuration after migration](https://github.com/petabridge/memorizer/pull/177) - Automatically reconciles `embedding_config` when the live provider probe and database schema already match, avoiding unnecessary reruns of embedding dimension migration
-
-**Updates**
-- [Bump Akka.Streams from 1.5.60 to 1.5.62](https://github.com/petabridge/memorizer/pull/172)
-- [Bump Dapper from 2.1.66 to 2.1.72](https://github.com/petabridge/memorizer/pull/180)</PackageReleaseNotes>
+- [Add workspace scope to memory tools](https://github.com/petabridge/memorizer/pull/197) - Memory search and storage now support workspace-level scoping
+  - `SearchMemories` can filter by workspace ID to query all memories in a workspace in a single call
+  - `Store` supports assigning memories directly to workspaces (not just projects)
+  - Closes scoping gaps for agents operating at the workspace level</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 2.2.0-beta2 July 1st 2026 ####
+
+**Features**
+- [Add workspace scope to memory tools](https://github.com/petabridge/memorizer/pull/197) - Memory search and storage now support workspace-level scoping
+  - `SearchMemories` can filter by workspace ID to query all memories in a workspace in a single call
+  - `Store` supports assigning memories directly to workspaces (not just projects)
+  - Closes scoping gaps for agents operating at the workspace level
+
 #### 2.2.0-beta1 June 26th 2026 ####
 
 **Features**


### PR DESCRIPTION
## Changes

**Features**
- [Add workspace scope to memory tools](https://github.com/petabridge/memorizer/pull/197) - Memory search and storage now support workspace-level scoping
  - SearchMemories can filter by workspace ID to query all memories in a workspace in a single call
  - Store supports assigning memories directly to workspaces (not just projects)
  - Closes scoping gaps for agents operating at the workspace level

## Files changed
- RELEASE_NOTES.md - Added 2.2.0-beta2 entry
- Directory.Build.props - Bumped version to 2.2.0-beta2, updated PackageReleaseNotes