### PR TITLE
Release 2.2.0: update release notes and version metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,15 +3,19 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/petabridge/memorizer-v1</PackageProjectUrl>
-    <VersionPrefix>2.2.0-beta2</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
     <PackageReleaseNotes>**Features**
-- [Add workspace scope to memory tools](https://github.com/petabridge/memorizer/pull/197) - Memory search and storage now support workspace-level scoping
-  - `SearchMemories` can filter by workspace ID to query all memories in a workspace in a single call
-  - `Store` supports assigning memories directly to workspaces (not just projects)
-  - Closes scoping gaps for agents operating at the workspace level</PackageReleaseNotes>
+- [Support get_workspace by slug](https://github.com/petabridge/memorizer/pull/199) - The `GetWorkspace` MCP tool now accepts workspace slugs in addition to IDs
+  - Enables workspace lookup without needing to know the workspace ID in advance
+  - Slug matching is case-insensitive
+
+**Bug Fixes**
+- [Make MCP tools resilient to missing required parameters](https://github.com/petabridge/memorizer/pull/184) - MCP tools now return descriptive error messages when required parameters are missing or malformed, instead of throwing unhandled exceptions
+  - Fixes compatibility with MCP clients (Claude Code, opencode) that may omit required parameters
+  - Affected tools: `Store`, `Edit`, `CreateReference`, `MoveMemory`</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 2.2.0 July 3rd 2026 ####
+
+**Features**
+- [Support get_workspace by slug](https://github.com/petabridge/memorizer/pull/199) - The `GetWorkspace` MCP tool now accepts workspace slugs in addition to IDs
+  - Enables workspace lookup without needing to know the workspace ID in advance
+  - Slug matching is case-insensitive
+
+**Bug Fixes**
+- [Make MCP tools resilient to missing required parameters](https://github.com/petabridge/memorizer/pull/184) - MCP tools now return descriptive error messages when required parameters are missing or malformed, instead of throwing unhandled exceptions
+  - Fixes compatibility with MCP clients (Claude Code, opencode) that may omit required parameters
+  - Affected tools: `Store`, `Edit`, `CreateReference`, `MoveMemory`
+
 #### 2.2.0-beta2 July 1st 2026 ####
 
 **Features**


### PR DESCRIPTION
## Summary

- Updates `RELEASE_NOTES.md` with the 2.2.0 release entry (dated July 3rd 2026)
- Updates `Directory.Build.props` version to `2.2.0` and injects release notes via build script

## Changes in this release

**Features**
- [Support get_workspace by slug](https://github.com/petabridge/memorizer/pull/199) - The `GetWorkspace` MCP tool now accepts workspace slugs in addition to IDs; slug matching is case-insensitive
  
**Bug Fixes**
- [Make MCP tools resilient to missing required parameters](https://github.com/petabridge/memorizer/pull/184) - MCP tools now return descriptive error messages when required parameters are missing or malformed; affected tools: `Store`, `Edit`, `CreateReference`, `MoveMemory`

## Test plan
- [ ] Verify `RELEASE_NOTES.md` has correct version header `#### 2.2.0 July 3rd 2026 ####`
- [ ] Verify `Directory.Build.props` `VersionPrefix` is `2.2.0`
- [ ] Verify `PackageReleaseNotes` in `Directory.Build.props` matches the 2.2.0 release notes block
- [ ] CI checks pass