### PR TITLE
feat(ui): tag clouds on workspace/project pages + hide empty sections

### DIFF
--- a/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
@@ -141,4 +141,35 @@ public class TagCloudIntegrationTests : IDisposable
             await storage.DeleteWorkspaceAsync(workspace.Id);
         }
     }
+
+    [Fact]
+    public async Task GlobalTagCounts_IncludeAllNonArchivedMemories()
+    {
+        // Arrange
+        var storage = _services.GetRequiredService<IStorage>();
+        var tagCloud = _services.GetRequiredService<ITagCloudService>();
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "global memory one", "test", new[] { "global-tag" },
+                new Confidence(1.0), "Global One")).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "global memory two", "test", new[] { "global-tag", "other-tag" },
+                new Confidence(1.0), "Global Two")).Id);
+
+            // Act
+            var globalCounts = await tagCloud.GetGlobalTagCountsAsync();
+
+            // Assert - counts aggregate across all memories
+            Assert.Contains(globalCounts, x => x.Tag == "global-tag" && x.Count == 2);
+            Assert.Contains(globalCounts, x => x.Tag == "other-tag" && x.Count == 1);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+        }
+    }
 }

--- a/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
@@ -1,0 +1,144 @@
+using Memorizer.Extensions;
+using Memorizer.Models;
+using Memorizer.Models.Enums;
+using Memorizer.Models.ValueTypes;
+using Memorizer.Services;
+using Memorizer.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Memorizer.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the tag cloud service (ITagCloudService).
+/// </summary>
+[Collection(nameof(IntegrationTestCollection))]
+public class TagCloudIntegrationTests : IDisposable
+{
+    private readonly IntegrationTestFixture _fixture;
+    private readonly IServiceProvider _services;
+
+    public void Dispose()
+    {
+        (_services as IDisposable)?.Dispose();
+    }
+
+    public TagCloudIntegrationTests(IntegrationTestFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _services = CreateServices();
+    }
+
+    private IServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:Storage"] = _fixture.PostgresConnectionString,
+                ["Embeddings:ApiUrl"] = _fixture.OllamaApiUrl,
+                ["Embeddings:Model"] = "all-minilm",
+                ["Embeddings:Timeout"] = TimeSpan.FromMinutes(1).ToString()
+            })
+            .Build());
+
+        services.AddHttpClient<IEmbeddingService, EmbeddingService>(client =>
+        {
+            client.BaseAddress = new Uri(_fixture.OllamaApiUrl);
+            client.Timeout = TimeSpan.FromMinutes(1);
+        });
+
+        services.AddSingleton(new EmbeddingSettings
+        {
+            ApiUrl = new Uri(_fixture.OllamaApiUrl),
+            Model = "all-minilm",
+            Timeout = TimeSpan.FromMinutes(1)
+        });
+
+        services.AddMemorizer();
+        services.AddLogging();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task WorkspaceSubtreeTagCounts_AggregateProjectsAndNestedWorkspaces()
+    {
+        // Arrange
+        var storage = _services.GetRequiredService<IStorage>();
+        var tagCloud = _services.GetRequiredService<ITagCloudService>();
+
+        var workspace = await storage.CreateWorkspaceAsync("TagCloud Root", "root");
+        var project = await storage.CreateProjectAsync(workspace.Id, "TagCloud Project", "p");
+        var nested = await storage.CreateWorkspaceAsync("TagCloud Nested", "n", parentId: workspace.Id);
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "workspace direct memory", "test", new[] { "alpha" },
+                new Confidence(1.0), "Workspace Memory", owner: MemoryOwner.ForWorkspace(workspace.Id))).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "project memory", "test", new[] { "beta" },
+                new Confidence(1.0), "Project Memory", owner: MemoryOwner.ForProject(project.Id))).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "nested workspace memory", "test", new[] { "alpha", "gamma" },
+                new Confidence(1.0), "Nested Memory", owner: MemoryOwner.ForWorkspace(nested.Id))).Id);
+
+            // Act - subtree covers direct + project + nested workspace tags
+            var subtreeCounts = await tagCloud.GetWorkspaceSubtreeTagCountsAsync(workspace.Id);
+
+            // Assert
+            Assert.Contains(subtreeCounts, x => x.Tag == "alpha" && x.Count == 2);
+            Assert.Contains(subtreeCounts, x => x.Tag == "beta" && x.Count == 1);
+            Assert.Contains(subtreeCounts, x => x.Tag == "gamma" && x.Count == 1);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+            await storage.DeleteProjectAsync(project.Id);
+            await storage.DeleteWorkspaceAsync(nested.Id);
+            await storage.DeleteWorkspaceAsync(workspace.Id);
+        }
+    }
+
+    [Fact]
+    public async Task ProjectTagCounts_OnlyIncludeProjectMemories()
+    {
+        // Arrange
+        var storage = _services.GetRequiredService<IStorage>();
+        var tagCloud = _services.GetRequiredService<ITagCloudService>();
+
+        var workspace = await storage.CreateWorkspaceAsync("TagCloud Root", "root");
+        var project = await storage.CreateProjectAsync(workspace.Id, "TagCloud Project", "p");
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "workspace memory", "test", new[] { "alpha" },
+                new Confidence(1.0), "Workspace Memory", owner: MemoryOwner.ForWorkspace(workspace.Id))).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "project memory", "test", new[] { "beta" },
+                new Confidence(1.0), "Project Memory", owner: MemoryOwner.ForProject(project.Id))).Id);
+
+            // Act
+            var projectCounts = await tagCloud.GetProjectTagCountsAsync(project.Id);
+
+            // Assert - only the project's own tag, not the workspace's
+            var beta = Assert.Single(projectCounts);
+            Assert.Equal("beta", beta.Tag);
+            Assert.Equal(1, beta.Count);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+            await storage.DeleteProjectAsync(project.Id);
+            await storage.DeleteWorkspaceAsync(workspace.Id);
+        }
+    }
+}

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -387,6 +387,9 @@ public class MemoryToolsCanonicalUrlTests
         public Task<List<TagCount>> GetProjectTagCountsAsync(
             ProjectId projectId, CancellationToken cancellationToken = default)
             => Task.FromResult(new List<TagCount>());
+
+        public Task<List<TagCount>> GetGlobalTagCountsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<TagCount>());
     }
 
     /// <summary>

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -234,7 +234,7 @@ public class MemoryToolsCanonicalUrlTests
                 CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Memory 1")
             }
         };
-        var controller = new MemoryController(fakeStorage, new SimilaritySettings());
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
         // Act
         var result = await controller.SearchMemories("test query", workspaceId: workspaceId);
@@ -260,7 +260,7 @@ public class MemoryToolsCanonicalUrlTests
                 CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Memory 1")
             }
         };
-        var controller = new MemoryController(fakeStorage, new SimilaritySettings());
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
         // Act
         var result = await controller.SearchWithMetadataEmbedding("test query", workspaceId: workspaceId);
@@ -279,7 +279,7 @@ public class MemoryToolsCanonicalUrlTests
     {
         // Arrange
         var fakeStorage = new FakeStorage();
-        var controller = new MemoryController(fakeStorage, new SimilaritySettings());
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
         // Act
         var result = await controller.SearchMemories(
@@ -373,6 +373,20 @@ public class MemoryToolsCanonicalUrlTests
             Archetype = ArchetypeEnum.Document,
             CurrentVersion = new VersionNumber(1)
         };
+    }
+
+    /// <summary>
+    /// Minimal ITagCloudService stub for controller constructor tests.
+    /// </summary>
+    private class FakeTagCloudService : ITagCloudService
+    {
+        public Task<List<TagCount>> GetWorkspaceSubtreeTagCountsAsync(
+            WorkspaceId workspaceId, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<TagCount>());
+
+        public Task<List<TagCount>> GetProjectTagCountsAsync(
+            ProjectId projectId, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<TagCount>());
     }
 
     /// <summary>

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -139,8 +139,9 @@ public class MemoryController : ControllerBase
     }
 
     /// <summary>
-    /// Get tag counts for a tag cloud, scoped to a workspace subtree or a single project.
-    /// Workspace scope aggregates across the entire subtree (nested workspaces + projects).
+    /// Get tag counts for a tag cloud. Scope to a workspace subtree or a single project
+    /// with the optional query parameters, or omit both for global counts across all
+    /// non-archived memories. Workspace scope aggregates across the entire subtree.
     /// </summary>
     [HttpGet("tags/cloud")]
     public async Task<ActionResult<List<TagCount>>> GetTagCloud(
@@ -163,7 +164,8 @@ public class MemoryController : ControllerBase
             return Ok(counts);
         }
 
-        return BadRequest("Either workspaceId or projectId is required.");
+        var globalCounts = await _tagCloudService.GetGlobalTagCountsAsync(cancellationToken);
+        return Ok(globalCounts);
     }
 
     /// <summary>

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -17,11 +17,13 @@ public class MemoryController : ControllerBase
 {
     private readonly IStorage _storage;
     private readonly SimilaritySettings _similaritySettings;
+    private readonly ITagCloudService _tagCloudService;
 
-    public MemoryController(IStorage storage, SimilaritySettings similaritySettings)
+    public MemoryController(IStorage storage, SimilaritySettings similaritySettings, ITagCloudService tagCloudService)
     {
         _storage = storage;
         _similaritySettings = similaritySettings;
+        _tagCloudService = tagCloudService;
     }
 
     /// <summary>
@@ -134,6 +136,34 @@ public class MemoryController : ControllerBase
 
         var tags = await _storage.GetDistinctTagsAsync(owner);
         return Ok(tags);
+    }
+
+    /// <summary>
+    /// Get tag counts for a tag cloud, scoped to a workspace subtree or a single project.
+    /// Workspace scope aggregates across the entire subtree (nested workspaces + projects).
+    /// </summary>
+    [HttpGet("tags/cloud")]
+    public async Task<ActionResult<List<TagCount>>> GetTagCloud(
+        [FromQuery] Guid? workspaceId = null,
+        [FromQuery] Guid? projectId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (projectId.HasValue && workspaceId.HasValue)
+            return BadRequest("projectId and workspaceId are mutually exclusive tag cloud scopes.");
+
+        if (projectId.HasValue)
+        {
+            var counts = await _tagCloudService.GetProjectTagCountsAsync(new ProjectId(projectId.Value), cancellationToken);
+            return Ok(counts);
+        }
+
+        if (workspaceId.HasValue)
+        {
+            var counts = await _tagCloudService.GetWorkspaceSubtreeTagCountsAsync(new WorkspaceId(workspaceId.Value), cancellationToken);
+            return Ok(counts);
+        }
+
+        return BadRequest("Either workspaceId or projectId is required.");
     }
 
     /// <summary>

--- a/src/Memorizer/Models/TagCount.cs
+++ b/src/Memorizer/Models/TagCount.cs
@@ -1,0 +1,10 @@
+namespace Memorizer.Models;
+
+/// <summary>
+/// A single tag and the number of non-archived memories using it.
+/// </summary>
+public class TagCount
+{
+    public string Tag { get; init; } = "";
+    public int Count { get; init; }
+}

--- a/src/Memorizer/Services/ITagCloudService.cs
+++ b/src/Memorizer/Services/ITagCloudService.cs
@@ -22,4 +22,9 @@ public interface ITagCloudService
     Task<List<TagCount>> GetProjectTagCountsAsync(
         ProjectId projectId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets tag counts across all non-archived memories (no owner scope).
+    /// </summary>
+    Task<List<TagCount>> GetGlobalTagCountsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Memorizer/Services/ITagCloudService.cs
+++ b/src/Memorizer/Services/ITagCloudService.cs
@@ -1,0 +1,25 @@
+using Memorizer.Models;
+using Memorizer.Models.ValueTypes;
+
+namespace Memorizer.Services;
+
+/// <summary>
+/// Computes tag clouds (tag → memory count) scoped to workspaces and projects.
+/// </summary>
+public interface ITagCloudService
+{
+    /// <summary>
+    /// Gets tag counts across the entire workspace subtree: direct workspace
+    /// memories, all projects, and all nested workspaces (recursive).
+    /// </summary>
+    Task<List<TagCount>> GetWorkspaceSubtreeTagCountsAsync(
+        WorkspaceId workspaceId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets tag counts for memories directly owned by a single project.
+    /// </summary>
+    Task<List<TagCount>> GetProjectTagCountsAsync(
+        ProjectId projectId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Memorizer/Services/TagCloudService.cs
+++ b/src/Memorizer/Services/TagCloudService.cs
@@ -1,0 +1,89 @@
+using Memorizer.Models;
+using Memorizer.Models.Enums;
+using Memorizer.Models.ValueTypes;
+using Npgsql;
+using Registrator.Net;
+
+namespace Memorizer.Services;
+
+/// <summary>
+/// Computes tag clouds (tag → memory count) scoped to workspaces and projects.
+/// </summary>
+[AutoRegisterInterfaces(ServiceLifetime.Scoped)]
+public class TagCloudService : ITagCloudService
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public TagCloudService(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task<List<TagCount>> GetWorkspaceSubtreeTagCountsAsync(
+        WorkspaceId workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = @"
+            WITH RECURSIVE ws_tree AS (
+                SELECT id FROM workspaces WHERE id = @root
+                UNION ALL
+                SELECT w.id FROM workspaces w JOIN ws_tree t ON w.parent_id = t.id
+            )
+            SELECT tag, COUNT(*) AS cnt
+            FROM memories, unnest(tags) AS tag
+            WHERE archetype IN (0, 1)
+              AND (
+                    (owner_type = @workspaceType AND owner_id IN (SELECT id FROM ws_tree))
+                 OR (owner_type = @projectType AND owner_id IN (
+                        SELECT id FROM projects WHERE workspace_id IN (SELECT id FROM ws_tree)))
+              )
+            GROUP BY tag
+            ORDER BY cnt DESC, tag";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("root", workspaceId.Value);
+        command.Parameters.AddWithValue("workspaceType", (short)OwnerTypeEnum.Workspace);
+        command.Parameters.AddWithValue("projectType", (short)OwnerTypeEnum.Project);
+
+        return await ReadTagCountsAsync(command, cancellationToken);
+    }
+
+    public async Task<List<TagCount>> GetProjectTagCountsAsync(
+        ProjectId projectId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = @"
+            SELECT tag, COUNT(*) AS cnt
+            FROM memories, unnest(tags) AS tag
+            WHERE archetype IN (0, 1)
+              AND owner_type = @projectType
+              AND owner_id = @projectId
+            GROUP BY tag
+            ORDER BY cnt DESC, tag";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("projectId", projectId.Value);
+        command.Parameters.AddWithValue("projectType", (short)OwnerTypeEnum.Project);
+
+        return await ReadTagCountsAsync(command, cancellationToken);
+    }
+
+    private static async Task<List<TagCount>> ReadTagCountsAsync(
+        NpgsqlCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<TagCount>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new TagCount
+            {
+                Tag = reader.GetString(0),
+                Count = reader.GetInt32(1)
+            });
+        }
+        return result;
+    }
+}

--- a/src/Memorizer/Services/TagCloudService.cs
+++ b/src/Memorizer/Services/TagCloudService.cs
@@ -70,6 +70,21 @@ public class TagCloudService : ITagCloudService
         return await ReadTagCountsAsync(command, cancellationToken);
     }
 
+    public async Task<List<TagCount>> GetGlobalTagCountsAsync(CancellationToken cancellationToken = default)
+    {
+        const string sql = @"
+            SELECT tag, COUNT(*) AS cnt
+            FROM memories, unnest(tags) AS tag
+            WHERE archetype IN (0, 1)
+            GROUP BY tag
+            ORDER BY cnt DESC, tag";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        return await ReadTagCountsAsync(command, cancellationToken);
+    }
+
     private static async Task<List<TagCount>> ReadTagCountsAsync(
         NpgsqlCommand command,
         CancellationToken cancellationToken)

--- a/src/Memorizer/Views/Home/ProjectDetail.cshtml
+++ b/src/Memorizer/Views/Home/ProjectDetail.cshtml
@@ -46,6 +46,23 @@
 
     <hr>
 
+    <!-- Tag Cloud Section -->
+    <div class="card mb-4" id="tagCloudSection" style="display: none;">
+        <div class="card-header">
+            <h5 class="mb-0">
+                <i class="fas fa-tags me-2"></i>
+                Tag Cloud
+            </h5>
+        </div>
+        <div class="card-body">
+            <div id="tagCloud" class="tag-cloud"></div>
+            <div id="noTagCloud" class="text-muted" style="display: none;">
+                <i class="fas fa-info-circle me-2"></i>
+                No tags yet.
+            </div>
+        </div>
+    </div>
+
     <!-- Status Section - Compact inline design -->
     <div class="d-flex align-items-center gap-3 mb-4 p-3 rounded" style="background-color: var(--surface-card-alt);">
         <span class="text-muted"><i class="fas fa-flag me-2"></i>Status:</span>
@@ -411,6 +428,39 @@ function renderProject() {
         archiveBtn.innerHTML = '<i class="fas fa-archive me-2"></i>Archive Project';
         archiveBtn.onclick = archiveProject;
     }
+
+    // Tag cloud
+    loadTagCloud();
+}
+
+async function loadTagCloud() {
+    const section = document.getElementById('tagCloudSection');
+    const container = document.getElementById('tagCloud');
+    const empty = document.getElementById('noTagCloud');
+
+    try {
+        const response = await fetch(`/api/memory/tags/cloud?projectId=${projectId}`);
+        if (!response.ok) throw new Error('Failed to load tag cloud');
+
+        const tags = await response.json();
+        if (!tags || tags.length === 0) {
+            section.style.display = 'none';
+            return;
+        }
+
+        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        empty.style.display = 'none';
+        section.style.display = 'block';
+    } catch (error) {
+        console.warn('Could not load tag cloud:', error);
+        section.style.display = 'none';
+    }
+}
+
+function renderTagCloudItem(tagCount) {
+    const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
+    const href = `/memories?projectId=${projectId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 
 function renderStatusDropdown() {

--- a/src/Memorizer/Views/Home/ProjectDetail.cshtml
+++ b/src/Memorizer/Views/Home/ProjectDetail.cshtml
@@ -433,9 +433,12 @@ function renderProject() {
     loadTagCloud();
 }
 
+const tagCloudMaxTags = 30;
+let allTagCounts = [];
+let tagCloudShowAll = false;
+
 async function loadTagCloud() {
     const section = document.getElementById('tagCloudSection');
-    const container = document.getElementById('tagCloud');
     const empty = document.getElementById('noTagCloud');
 
     try {
@@ -448,13 +451,30 @@ async function loadTagCloud() {
             return;
         }
 
-        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        allTagCounts = tags;
+        tagCloudShowAll = false;
+        renderTagCloud();
         empty.style.display = 'none';
         section.style.display = 'block';
     } catch (error) {
         console.warn('Could not load tag cloud:', error);
         section.style.display = 'none';
     }
+}
+
+function renderTagCloud() {
+    const container = document.getElementById('tagCloud');
+    const visible = tagCloudShowAll ? allTagCounts : allTagCounts.slice(0, tagCloudMaxTags);
+    let html = visible.map(renderTagCloudItem).join('');
+    if (allTagCounts.length > tagCloudMaxTags) {
+        html += `<a href="#" class="tag-cloud-toggle" onclick="toggleTagCloud(); return false;">${tagCloudShowAll ? 'Show fewer' : `Show all ${allTagCounts.length} tags`}</a>`;
+    }
+    container.innerHTML = html;
+}
+
+function toggleTagCloud() {
+    tagCloudShowAll = !tagCloudShowAll;
+    renderTagCloud();
 }
 
 function renderTagCloudItem(tagCount) {

--- a/src/Memorizer/Views/Home/ProjectDetail.cshtml
+++ b/src/Memorizer/Views/Home/ProjectDetail.cshtml
@@ -46,12 +46,12 @@
 
     <hr>
 
-    <!-- Tag Cloud Section -->
+    <!-- Tags Section -->
     <div class="card mb-4" id="tagCloudSection" style="display: none;">
         <div class="card-header">
             <h5 class="mb-0">
                 <i class="fas fa-tags me-2"></i>
-                Tag Cloud
+                Tags
             </h5>
         </div>
         <div class="card-body">
@@ -459,7 +459,7 @@ async function loadTagCloud() {
 
 function renderTagCloudItem(tagCount) {
     const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
-    const href = `/memories?projectId=${projectId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    const href = `/memories?tag=${encodeURIComponent(tagCount.tag)}`;
     return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -50,6 +50,23 @@
 
     <hr>
 
+    <!-- Tag Cloud Section -->
+    <div class="card mb-4" id="tagCloudSection" style="display: none;">
+        <div class="card-header">
+            <h5 class="mb-0">
+                <i class="fas fa-tags me-2"></i>
+                Tag Cloud
+            </h5>
+        </div>
+        <div class="card-body">
+            <div id="tagCloud" class="tag-cloud"></div>
+            <div id="noTagCloud" class="text-muted" style="display: none;">
+                <i class="fas fa-info-circle me-2"></i>
+                No tags yet.
+            </div>
+        </div>
+    </div>
+
     <!-- Child Workspaces Section -->
     <div class="mb-4" id="childWorkspacesSection">
         <div class="d-flex justify-content-between align-items-center mb-3">
@@ -340,6 +357,39 @@ function renderWorkspace() {
     // Memories
     document.getElementById('viewAllMemoriesLink').href = `/memories?workspaceId=${workspaceId}`;
     renderMemoriesList();
+
+    // Tag cloud
+    loadTagCloud();
+}
+
+async function loadTagCloud() {
+    const section = document.getElementById('tagCloudSection');
+    const container = document.getElementById('tagCloud');
+    const empty = document.getElementById('noTagCloud');
+
+    try {
+        const response = await fetch(`/api/memory/tags/cloud?workspaceId=${workspaceId}`);
+        if (!response.ok) throw new Error('Failed to load tag cloud');
+
+        const tags = await response.json();
+        if (!tags || tags.length === 0) {
+            section.style.display = 'none';
+            return;
+        }
+
+        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        empty.style.display = 'none';
+        section.style.display = 'block';
+    } catch (error) {
+        console.warn('Could not load tag cloud:', error);
+        section.style.display = 'none';
+    }
+}
+
+function renderTagCloudItem(tagCount) {
+    const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
+    const href = `/memories?workspaceId=${workspaceId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 
 function renderProjectCard(project) {

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -28,57 +28,53 @@
                 <span id="workspaceMeta"></span>
             </small>
         </div>
-        <div id="editButton" class="d-flex gap-2">
-            <button type="button" class="btn btn-outline-secondary" id="reparentWorkspaceBtn" data-bs-toggle="modal" data-bs-target="#reparentWorkspaceModal" onclick="openReparentModal()">
-                <i class="fas fa-sitemap me-2"></i>Move/Reparent
-            </button>
-            <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editWorkspaceModal">
-                <i class="fas fa-edit me-2"></i>Edit
-            </button>
+        <div class="d-flex gap-2">
+            <div id="createButtons" class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-primary" id="createChildWorkspaceBtn" data-bs-toggle="modal" data-bs-target="#createChildWorkspaceModal">
+                    <i class="fas fa-folder-plus me-2"></i>New Nested Workspace
+                </button>
+                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal">
+                    <i class="fas fa-plus me-2"></i>New Project
+                </button>
+            </div>
+            <div id="editButton" class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-secondary" id="reparentWorkspaceBtn" data-bs-toggle="modal" data-bs-target="#reparentWorkspaceModal" onclick="openReparentModal()">
+                    <i class="fas fa-sitemap me-2"></i>Move/Reparent
+                </button>
+                <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editWorkspaceModal">
+                    <i class="fas fa-edit me-2"></i>Edit
+                </button>
+            </div>
         </div>
     </div>
 
     <hr>
 
     <!-- Child Workspaces Section -->
-    <div class="mb-4">
+    <div class="mb-4" id="childWorkspacesSection">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h4>
                 <i class="fas fa-folder-tree me-2"></i>
                 Nested Workspaces <span class="badge bg-secondary" id="childWorkspaceCount">0</span>
             </h4>
-            <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#createChildWorkspaceModal" id="createChildWorkspaceBtn">
-                <i class="fas fa-plus me-2"></i>New Nested Workspace
-            </button>
         </div>
         <div id="childWorkspacesList"></div>
-        <div id="noChildWorkspaces" class="text-center py-4 text-muted" style="display: none;">
-            <i class="fas fa-folder-open fa-2x mb-2"></i>
-            <p>No nested workspaces. Create one to organize related areas of work.</p>
-        </div>
     </div>
 
-    <hr>
+    <hr id="childWorkspacesDivider" style="display: none;">
 
     <!-- Projects Section -->
-    <div class="mb-4">
+    <div class="mb-4" id="projectsSection">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h4>
                 <i class="fas fa-tasks me-2"></i>
                 Projects <span class="badge bg-secondary" id="projectCount">0</span>
             </h4>
-            <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#createProjectModal">
-                <i class="fas fa-plus me-2"></i>New Project
-            </button>
         </div>
         <div id="projectsList"></div>
-        <div id="noProjects" class="text-center py-4 text-muted" style="display: none;">
-            <i class="fas fa-inbox fa-2x mb-2"></i>
-            <p>No projects yet. Create one to start organizing memories.</p>
-        </div>
     </div>
 
-    <hr>
+    <hr id="projectsDivider" style="display: none;">
 
     <!-- Memories Section -->
     <div class="mb-4">
@@ -318,19 +314,27 @@ function renderWorkspace() {
 
     // Child Workspaces
     const childWorkspaces = workspace.childWorkspaces || [];
-    document.getElementById('childWorkspaceCount').textContent = childWorkspaces.length;
+    const childWorkspacesSection = document.getElementById('childWorkspacesSection');
     if (childWorkspaces.length > 0) {
+        document.getElementById('childWorkspaceCount').textContent = childWorkspaces.length;
         document.getElementById('childWorkspacesList').innerHTML = childWorkspaces.map(renderChildWorkspaceCard).join('');
+        childWorkspacesSection.style.display = 'block';
+        document.getElementById('childWorkspacesDivider').style.display = 'block';
     } else {
-        document.getElementById('noChildWorkspaces').style.display = 'block';
+        childWorkspacesSection.style.display = 'none';
+        document.getElementById('childWorkspacesDivider').style.display = 'none';
     }
 
     // Projects
-    document.getElementById('projectCount').textContent = workspace.projects.length;
+    const projectsSection = document.getElementById('projectsSection');
     if (workspace.projects.length > 0) {
+        document.getElementById('projectCount').textContent = workspace.projects.length;
         document.getElementById('projectsList').innerHTML = workspace.projects.map(renderProjectCard).join('');
+        projectsSection.style.display = 'block';
+        document.getElementById('projectsDivider').style.display = 'block';
     } else {
-        document.getElementById('noProjects').style.display = 'block';
+        projectsSection.style.display = 'none';
+        document.getElementById('projectsDivider').style.display = 'none';
     }
 
     // Memories

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -362,9 +362,12 @@ function renderWorkspace() {
     loadTagCloud();
 }
 
+const tagCloudMaxTags = 30;
+let allTagCounts = [];
+let tagCloudShowAll = false;
+
 async function loadTagCloud() {
     const section = document.getElementById('tagCloudSection');
-    const container = document.getElementById('tagCloud');
     const empty = document.getElementById('noTagCloud');
 
     try {
@@ -377,13 +380,30 @@ async function loadTagCloud() {
             return;
         }
 
-        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        allTagCounts = tags;
+        tagCloudShowAll = false;
+        renderTagCloud();
         empty.style.display = 'none';
         section.style.display = 'block';
     } catch (error) {
         console.warn('Could not load tag cloud:', error);
         section.style.display = 'none';
     }
+}
+
+function renderTagCloud() {
+    const container = document.getElementById('tagCloud');
+    const visible = tagCloudShowAll ? allTagCounts : allTagCounts.slice(0, tagCloudMaxTags);
+    let html = visible.map(renderTagCloudItem).join('');
+    if (allTagCounts.length > tagCloudMaxTags) {
+        html += `<a href="#" class="tag-cloud-toggle" onclick="toggleTagCloud(); return false;">${tagCloudShowAll ? 'Show fewer' : `Show all ${allTagCounts.length} tags`}</a>`;
+    }
+    container.innerHTML = html;
+}
+
+function toggleTagCloud() {
+    tagCloudShowAll = !tagCloudShowAll;
+    renderTagCloud();
 }
 
 function renderTagCloudItem(tagCount) {

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -50,12 +50,12 @@
 
     <hr>
 
-    <!-- Tag Cloud Section -->
+    <!-- Tags Section -->
     <div class="card mb-4" id="tagCloudSection" style="display: none;">
         <div class="card-header">
             <h5 class="mb-0">
                 <i class="fas fa-tags me-2"></i>
-                Tag Cloud
+                Tags
             </h5>
         </div>
         <div class="card-body">
@@ -388,7 +388,7 @@ async function loadTagCloud() {
 
 function renderTagCloudItem(tagCount) {
     const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
-    const href = `/memories?workspaceId=${workspaceId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    const href = `/memories?tag=${encodeURIComponent(tagCount.tag)}`;
     return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 

--- a/src/Memorizer/Views/Shared/_Layout.cshtml
+++ b/src/Memorizer/Views/Shared/_Layout.cshtml
@@ -101,6 +101,22 @@
                     <!-- Workspace/Project Tree Navigation (Primary) -->
                     @await Html.PartialAsync("_WorkspaceTree")
 
+                    <!-- Sidebar Tags (global tag navigation) -->
+                    <div id="sidebar-tags-container">
+                        <button type="button" class="sidebar-tags-header" onclick="SidebarTags.toggle()" aria-expanded="false" title="Toggle tags">
+                            <span class="sidebar-tags-toggle"><i class="fas fa-chevron-right"></i></span>
+                            <i class="fas fa-tags"></i>
+                            Tags
+                            <span class="sidebar-tags-count" id="sidebarTagsTotal" style="display: none;">0</span>
+                        </button>
+                        <div class="sidebar-tags-body">
+                            <div class="sidebar-tags-loading">
+                                <span class="spinner-border spinner-border-sm" role="status"></span>
+                                <span>Loading...</span>
+                            </div>
+                        </div>
+                    </div>
+
                     <hr class="my-3" style="border-color: var(--sidebar-divider);">
 
                     <!-- Theme Toggle -->
@@ -194,6 +210,7 @@
     <script src="~/js/memory-utils.js" asp-append-version="true"></script>
     <script src="~/js/progress-stream.js" asp-append-version="true"></script>
     <script src="~/js/workspace-tree.js" asp-append-version="true"></script>
+    <script src="~/js/sidebar-tags.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/src/Memorizer/Views/Shared/_Layout.cshtml
+++ b/src/Memorizer/Views/Shared/_Layout.cshtml
@@ -101,6 +101,8 @@
                     <!-- Workspace/Project Tree Navigation (Primary) -->
                     @await Html.PartialAsync("_WorkspaceTree")
 
+                    <hr class="my-3" style="border-color: var(--sidebar-divider);">
+
                     <!-- Sidebar Tags (global tag navigation) -->
                     <div id="sidebar-tags-container">
                         <button type="button" class="sidebar-tags-header" onclick="SidebarTags.toggle()" aria-expanded="false" title="Toggle tags">

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -92,8 +92,8 @@
 }
 
 .card-header {
-    background: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-secondary) 100%);
-    color: var(--text-on-brand);
+    background-color: var(--surface-card-alt);
+    color: var(--text-primary);
     border-radius: 0.75rem 0.75rem 0 0 !important;
 }
 

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -618,3 +618,17 @@ footer a:hover {
     color: var(--brand-primary-hover);
     text-decoration: underline;
 }
+
+.tag-cloud-toggle {
+    display: inline-block;
+    margin-left: 0.5rem;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-decoration: none;
+}
+
+.tag-cloud-toggle:hover,
+.tag-cloud-toggle:focus {
+    color: var(--md-link);
+    text-decoration: underline;
+}

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -593,3 +593,28 @@ footer a:hover {
     color: #93c5fd;
     border-color: #2d5a8e;
 }
+
+/* =================================================================
+   TAG CLOUD
+   Uses theme variables so light and dark modes are both covered.
+   ================================================================= */
+.tag-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.9rem;
+    line-height: 1.6;
+}
+
+.tag-cloud-item {
+    color: var(--md-link);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.15s ease, opacity 0.15s ease;
+}
+
+.tag-cloud-item:hover,
+.tag-cloud-item:focus {
+    color: var(--brand-primary-hover);
+    text-decoration: underline;
+}

--- a/src/Memorizer/wwwroot/css/workspace-tree.css
+++ b/src/Memorizer/wwwroot/css/workspace-tree.css
@@ -466,3 +466,135 @@
 [data-theme="dark"] .workspace-tree-breadcrumbs {
     background-color: rgba(255, 255, 255, 0.03);
 }
+
+/* =================================================================
+   SIDEBAR TAGS SECTION
+   Collapsible global tag navigation in the sidebar.
+   ================================================================= */
+.sidebar-tags-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 1rem;
+    margin-bottom: 0.25rem;
+    background: transparent;
+    border: none;
+    color: var(--text-on-brand-muted);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    text-align: left;
+    opacity: 0.8;
+    transition: all 0.15s ease;
+}
+
+.sidebar-tags-header:hover {
+    color: var(--text-on-brand);
+    opacity: 1;
+}
+
+.sidebar-tags-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    font-size: 0.65rem;
+    opacity: 0.7;
+    transition: transform 0.2s ease;
+}
+
+.sidebar-tags-toggle.expanded {
+    transform: rotate(90deg);
+}
+
+.sidebar-tags-count {
+    font-size: 0.7rem;
+    background-color: rgba(255, 255, 255, 0.2);
+    color: var(--text-on-brand-muted);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.75rem;
+    min-width: 1.25rem;
+    text-align: center;
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+.sidebar-tags-body {
+    display: none;
+    padding: 0 0.5rem 0.5rem;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.sidebar-tags-body.expanded {
+    display: block;
+}
+
+.sidebar-tags-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    color: var(--text-on-brand-muted);
+    text-decoration: none;
+    border-radius: 0.375rem;
+    margin: 0.125rem 0;
+    transition: all 0.2s ease;
+    font-size: 0.8rem;
+}
+
+.sidebar-tags-item:hover {
+    color: var(--text-on-brand);
+    background-color: var(--surface-overlay);
+}
+
+.sidebar-tags-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sidebar-tags-item .sidebar-tags-count {
+    margin-left: 0;
+}
+
+.sidebar-tags-more {
+    display: block;
+    padding: 0.375rem 0.75rem;
+    color: var(--text-on-brand-muted);
+    text-decoration: none;
+    font-size: 0.75rem;
+    font-style: italic;
+    opacity: 0.8;
+}
+
+.sidebar-tags-more:hover {
+    color: var(--text-on-brand);
+    opacity: 1;
+}
+
+.sidebar-tags-loading,
+.sidebar-tags-empty {
+    color: var(--text-on-brand-muted);
+    font-size: 0.8rem;
+    padding: 0.5rem 0.75rem;
+    opacity: 0.7;
+}
+
+.sidebar-tags-loading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.sidebar-tags-loading .spinner-border {
+    width: 0.875rem;
+    height: 0.875rem;
+    border-width: 0.125rem;
+}

--- a/src/Memorizer/wwwroot/css/workspace-tree.css
+++ b/src/Memorizer/wwwroot/css/workspace-tree.css
@@ -526,42 +526,46 @@
 
 .sidebar-tags-body {
     display: none;
-    padding: 0 0.5rem 0.5rem;
-    max-height: 320px;
-    overflow-y: auto;
+    padding: 0.25rem 0.75rem 0.75rem;
 }
 
 .sidebar-tags-body.expanded {
     display: block;
 }
 
-.sidebar-tags-item {
+.sidebar-tags-pills {
     display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+}
+
+.sidebar-tags-pill {
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.375rem 0.75rem;
-    color: var(--text-on-brand-muted);
-    text-decoration: none;
-    border-radius: 0.375rem;
-    margin: 0.125rem 0;
-    transition: all 0.2s ease;
-    font-size: 0.8rem;
-}
-
-.sidebar-tags-item:hover {
+    gap: 0.375rem;
+    padding: 0.2rem 0.625rem;
+    border-radius: 1rem;
+    background-color: rgba(255, 255, 255, 0.15);
     color: var(--text-on-brand);
-    background-color: var(--surface-overlay);
-}
-
-.sidebar-tags-name {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    text-decoration: none;
+    font-size: 0.75rem;
     white-space: nowrap;
+    transition: all 0.2s ease;
 }
 
-.sidebar-tags-item .sidebar-tags-count {
-    margin-left: 0;
+.sidebar-tags-pill:hover {
+    background-color: var(--surface-overlay);
+    color: var(--text-on-brand);
+}
+
+.sidebar-tags-pill-count {
+    font-size: 0.65rem;
+    line-height: 1;
+    background-color: rgba(255, 255, 255, 0.25);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.75rem;
+    min-width: 1rem;
+    text-align: center;
 }
 
 .sidebar-tags-more {

--- a/src/Memorizer/wwwroot/js/sidebar-tags.js
+++ b/src/Memorizer/wwwroot/js/sidebar-tags.js
@@ -1,0 +1,112 @@
+/**
+ * Sidebar Tags Module
+ * Loads global tag counts and renders a collapsible tag navigation section in the sidebar.
+ */
+const SidebarTags = (function() {
+    const STORAGE_KEY = 'memorizer-sidebar-tags-expanded';
+    const MAX_TAGS = 30;
+    let container = null;
+    let isInitialized = false;
+    let tagCounts = null;
+
+    function getExpanded() {
+        try {
+            return localStorage.getItem(STORAGE_KEY) === 'true';
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function setExpanded(expanded) {
+        try {
+            localStorage.setItem(STORAGE_KEY, expanded ? 'true' : 'false');
+        } catch (e) {
+            // ignore storage errors
+        }
+    }
+
+    function applyExpanded(expanded) {
+        container?.querySelector('.sidebar-tags-toggle')?.classList.toggle('expanded', expanded);
+        container?.querySelector('.sidebar-tags-body')?.classList.toggle('expanded', expanded);
+        container?.querySelector('.sidebar-tags-header')?.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    }
+
+    function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function render() {
+        const body = container.querySelector('.sidebar-tags-body');
+        const total = container.querySelector('#sidebarTagsTotal');
+        if (!body) return;
+
+        if (!tagCounts || tagCounts.length === 0) {
+            body.innerHTML = '<div class="sidebar-tags-empty">No tags yet</div>';
+            if (total) total.style.display = 'none';
+            return;
+        }
+
+        if (total) {
+            total.textContent = tagCounts.length;
+            total.style.display = 'inline-block';
+        }
+
+        const items = tagCounts.slice(0, MAX_TAGS).map(t =>
+            `<a href="/memories?tag=${encodeURIComponent(t.tag)}" class="sidebar-tags-item" title="${escapeHtml(t.tag)} (${t.count})">
+                <span class="sidebar-tags-name">${escapeHtml(t.tag)}</span>
+                <span class="sidebar-tags-count">${t.count}</span>
+            </a>`
+        ).join('');
+
+        const more = tagCounts.length > MAX_TAGS
+            ? `<a href="/memories" class="sidebar-tags-more">View all ${tagCounts.length} tags</a>`
+            : '';
+
+        body.innerHTML = items + more;
+    }
+
+    async function load() {
+        try {
+            const response = await fetch('/api/memory/tags/cloud');
+            if (!response.ok) throw new Error(`Failed to load tags: ${response.status}`);
+            tagCounts = await response.json();
+            render();
+        } catch (e) {
+            console.warn('Failed to load sidebar tags:', e);
+            const body = container?.querySelector('.sidebar-tags-body');
+            if (body) body.innerHTML = '<div class="sidebar-tags-empty">Failed to load</div>';
+        }
+    }
+
+    function toggle() {
+        const expanded = !getExpanded();
+        setExpanded(expanded);
+        applyExpanded(expanded);
+    }
+
+    function init() {
+        if (isInitialized) return;
+        container = document.getElementById('sidebar-tags-container');
+        if (!container) {
+            console.warn('Sidebar tags container not found');
+            return;
+        }
+        isInitialized = true;
+        applyExpanded(getExpanded());
+        load();
+    }
+
+    return {
+        init: init,
+        toggle: toggle,
+        load: load
+    };
+})();
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+    SidebarTags.init();
+});

--- a/src/Memorizer/wwwroot/js/sidebar-tags.js
+++ b/src/Memorizer/wwwroot/js/sidebar-tags.js
@@ -54,10 +54,9 @@ const SidebarTags = (function() {
             total.style.display = 'inline-block';
         }
 
-        const items = tagCounts.slice(0, MAX_TAGS).map(t =>
-            `<a href="/memories?tag=${encodeURIComponent(t.tag)}" class="sidebar-tags-item" title="${escapeHtml(t.tag)} (${t.count})">
-                <span class="sidebar-tags-name">${escapeHtml(t.tag)}</span>
-                <span class="sidebar-tags-count">${t.count}</span>
+        const pills = tagCounts.slice(0, MAX_TAGS).map(t =>
+            `<a href="/memories?tag=${encodeURIComponent(t.tag)}" class="sidebar-tags-pill" title="${escapeHtml(t.tag)} (${t.count})">
+                ${escapeHtml(t.tag)} <span class="sidebar-tags-pill-count">${t.count}</span>
             </a>`
         ).join('');
 
@@ -65,7 +64,7 @@ const SidebarTags = (function() {
             ? `<a href="/memories" class="sidebar-tags-more">View all ${tagCounts.length} tags</a>`
             : '';
 
-        body.innerHTML = items + more;
+        body.innerHTML = `<div class="sidebar-tags-pills">${pills}</div>${more}`;
     }
 
     async function load() {


### PR DESCRIPTION
## Summary

Two related workspace/project page improvements:

### 1. Hide empty sections (fork issue #1)
- The "Nested Workspaces" and "Projects" sections are now hidden entirely when empty (header + list + divider) instead of showing empty-state messages.
- The "New Nested Workspace" and "New Project" buttons moved into the workspace header toolbar (next to Move/Reparent and Edit), so they stay accessible when the sections are hidden.
- System-workspace behavior preserved (toolbar hidden; nested-workspace button hidden for system workspaces).
- Applies to all workspace levels — nested workspaces share the same view.

### 2. Tag clouds (fork issue #2)
- New `ITagCloudService` (auto-registered via `[AutoRegisterInterfaces]`; does not extend `IStorage`) with workspace-subtree, project, and global tag counts.
- New endpoint `GET /api/memory/tags/cloud?workspaceId=&projectId=` (global when unscoped).
- "Tags" cards on workspace and project detail pages, sized by frequency, limited to the **top 30** with a "Show all" toggle; tags link to the global `/memories?tag=X`.
- Top-level collapsible **"Tags" section in the sidebar** (wrapping pills with counts).
- Light + dark theme styling throughout.

## Testing
- 195 unit tests pass, 188 integration tests pass (includes new tag-cloud aggregation integration tests).

## Related
- https://github.com/netclectic/memorizer/issues/1
- https://github.com/netclectic/memorizer/issues/2
