### PR TITLE
feat(search): make hybrid search the UI default with a Vector/Hybrid toggle

### DIFF
--- a/src/Memorizer.IntegrationTests/HybridSearchIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/HybridSearchIntegrationTests.cs
@@ -1,0 +1,124 @@
+using Memorizer.Extensions;
+using Memorizer.Models;
+using Memorizer.Models.ValueTypes;
+using Memorizer.Services;
+using Memorizer.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Memorizer.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the hybrid search behavior that the web UI now uses by
+/// default (see ADR 2026-02-14-hybrid-search-rrf.md): short keyword queries that
+/// fail with metadata-embedding vector search at the default threshold are still
+/// found via the full-text leg.
+/// </summary>
+[Collection(nameof(IntegrationTestCollection))]
+public class HybridSearchIntegrationTests : IDisposable
+{
+    private readonly IntegrationTestFixture _fixture;
+    private readonly IServiceProvider _services;
+
+    public void Dispose()
+    {
+        (_services as IDisposable)?.Dispose();
+    }
+
+    public HybridSearchIntegrationTests(IntegrationTestFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _services = CreateServices();
+    }
+
+    private IServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:Storage"] = _fixture.PostgresConnectionString,
+                ["Embeddings:ApiUrl"] = _fixture.OllamaApiUrl,
+                ["Embeddings:Model"] = "all-minilm",
+                ["Embeddings:Timeout"] = TimeSpan.FromMinutes(1).ToString()
+            })
+            .Build());
+
+        services.AddHttpClient<IEmbeddingService, EmbeddingService>(client =>
+        {
+            client.BaseAddress = new Uri(_fixture.OllamaApiUrl);
+            client.Timeout = TimeSpan.FromMinutes(1);
+        });
+
+        services.AddSingleton(new EmbeddingSettings
+        {
+            ApiUrl = new Uri(_fixture.OllamaApiUrl),
+            Model = "all-minilm",
+            Timeout = TimeSpan.FromMinutes(1)
+        });
+
+        services.AddMemorizer();
+        services.AddLogging();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task HybridSearch_FindsShortKeywordQueries_ThatVectorSearchMisses()
+    {
+        // Arrange - the ADR scenario: short keyword queries fail at the default threshold
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "Notes about race conditions in concurrent code and mutex handling", "test",
+                new[] { "concurrency" }, new Confidence(1.0), "Race condition deep dive")).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "Understanding dependency injection containers and service lifetimes", "test",
+                new[] { "di" }, new Confidence(1.0), "Dependency injection")).Id);
+
+            // Act - hybrid search should surface exact keyword matches via the FTS leg
+            var hybridResults = await storage.HybridSearch("race condition", limit: 5, minSimilarity: null, filterTags: null);
+
+            // Assert
+            Assert.NotEmpty(hybridResults);
+            Assert.Contains(hybridResults, m => m.Title?.Contains("Race condition") == true);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+        }
+    }
+
+    [Fact]
+    public async Task VectorSearch_StillReturnsResults_ForShortKeywordQueries()
+    {
+        // Arrange
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "Notes about race conditions in concurrent code and mutex handling", "test",
+                new[] { "concurrency" }, new Confidence(1.0), "Race condition deep dive")).Id);
+
+            // Act - method=vector mode must still work (metadata embedding search)
+            var vectorResults = await storage.SearchWithMetadataEmbedding(
+                "race condition", limit: 5, new SimilarityScore(0.3), filterTags: null);
+
+            // Assert - a lenient threshold should still surface the result
+            Assert.Contains(vectorResults, m => m.Title?.Contains("Race condition") == true);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+        }
+    }
+}

--- a/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
@@ -141,4 +141,35 @@ public class TagCloudIntegrationTests : IDisposable
             await storage.DeleteWorkspaceAsync(workspace.Id);
         }
     }
+
+    [Fact]
+    public async Task GlobalTagCounts_IncludeAllNonArchivedMemories()
+    {
+        // Arrange
+        var storage = _services.GetRequiredService<IStorage>();
+        var tagCloud = _services.GetRequiredService<ITagCloudService>();
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "global memory one", "test", new[] { "global-tag" },
+                new Confidence(1.0), "Global One")).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "global memory two", "test", new[] { "global-tag", "other-tag" },
+                new Confidence(1.0), "Global Two")).Id);
+
+            // Act
+            var globalCounts = await tagCloud.GetGlobalTagCountsAsync();
+
+            // Assert - counts aggregate across all memories
+            Assert.Contains(globalCounts, x => x.Tag == "global-tag" && x.Count == 2);
+            Assert.Contains(globalCounts, x => x.Tag == "other-tag" && x.Count == 1);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+        }
+    }
 }

--- a/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/TagCloudIntegrationTests.cs
@@ -1,0 +1,144 @@
+using Memorizer.Extensions;
+using Memorizer.Models;
+using Memorizer.Models.Enums;
+using Memorizer.Models.ValueTypes;
+using Memorizer.Services;
+using Memorizer.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Memorizer.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the tag cloud service (ITagCloudService).
+/// </summary>
+[Collection(nameof(IntegrationTestCollection))]
+public class TagCloudIntegrationTests : IDisposable
+{
+    private readonly IntegrationTestFixture _fixture;
+    private readonly IServiceProvider _services;
+
+    public void Dispose()
+    {
+        (_services as IDisposable)?.Dispose();
+    }
+
+    public TagCloudIntegrationTests(IntegrationTestFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _services = CreateServices();
+    }
+
+    private IServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:Storage"] = _fixture.PostgresConnectionString,
+                ["Embeddings:ApiUrl"] = _fixture.OllamaApiUrl,
+                ["Embeddings:Model"] = "all-minilm",
+                ["Embeddings:Timeout"] = TimeSpan.FromMinutes(1).ToString()
+            })
+            .Build());
+
+        services.AddHttpClient<IEmbeddingService, EmbeddingService>(client =>
+        {
+            client.BaseAddress = new Uri(_fixture.OllamaApiUrl);
+            client.Timeout = TimeSpan.FromMinutes(1);
+        });
+
+        services.AddSingleton(new EmbeddingSettings
+        {
+            ApiUrl = new Uri(_fixture.OllamaApiUrl),
+            Model = "all-minilm",
+            Timeout = TimeSpan.FromMinutes(1)
+        });
+
+        services.AddMemorizer();
+        services.AddLogging();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task WorkspaceSubtreeTagCounts_AggregateProjectsAndNestedWorkspaces()
+    {
+        // Arrange
+        var storage = _services.GetRequiredService<IStorage>();
+        var tagCloud = _services.GetRequiredService<ITagCloudService>();
+
+        var workspace = await storage.CreateWorkspaceAsync("TagCloud Root", "root");
+        var project = await storage.CreateProjectAsync(workspace.Id, "TagCloud Project", "p");
+        var nested = await storage.CreateWorkspaceAsync("TagCloud Nested", "n", parentId: workspace.Id);
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "workspace direct memory", "test", new[] { "alpha" },
+                new Confidence(1.0), "Workspace Memory", owner: MemoryOwner.ForWorkspace(workspace.Id))).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "project memory", "test", new[] { "beta" },
+                new Confidence(1.0), "Project Memory", owner: MemoryOwner.ForProject(project.Id))).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "nested workspace memory", "test", new[] { "alpha", "gamma" },
+                new Confidence(1.0), "Nested Memory", owner: MemoryOwner.ForWorkspace(nested.Id))).Id);
+
+            // Act - subtree covers direct + project + nested workspace tags
+            var subtreeCounts = await tagCloud.GetWorkspaceSubtreeTagCountsAsync(workspace.Id);
+
+            // Assert
+            Assert.Contains(subtreeCounts, x => x.Tag == "alpha" && x.Count == 2);
+            Assert.Contains(subtreeCounts, x => x.Tag == "beta" && x.Count == 1);
+            Assert.Contains(subtreeCounts, x => x.Tag == "gamma" && x.Count == 1);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+            await storage.DeleteProjectAsync(project.Id);
+            await storage.DeleteWorkspaceAsync(nested.Id);
+            await storage.DeleteWorkspaceAsync(workspace.Id);
+        }
+    }
+
+    [Fact]
+    public async Task ProjectTagCounts_OnlyIncludeProjectMemories()
+    {
+        // Arrange
+        var storage = _services.GetRequiredService<IStorage>();
+        var tagCloud = _services.GetRequiredService<ITagCloudService>();
+
+        var workspace = await storage.CreateWorkspaceAsync("TagCloud Root", "root");
+        var project = await storage.CreateProjectAsync(workspace.Id, "TagCloud Project", "p");
+
+        var created = new List<MemoryId>();
+        try
+        {
+            created.Add((await storage.StoreMemory(
+                "reference", "workspace memory", "test", new[] { "alpha" },
+                new Confidence(1.0), "Workspace Memory", owner: MemoryOwner.ForWorkspace(workspace.Id))).Id);
+            created.Add((await storage.StoreMemory(
+                "reference", "project memory", "test", new[] { "beta" },
+                new Confidence(1.0), "Project Memory", owner: MemoryOwner.ForProject(project.Id))).Id);
+
+            // Act
+            var projectCounts = await tagCloud.GetProjectTagCountsAsync(project.Id);
+
+            // Assert - only the project's own tag, not the workspace's
+            var beta = Assert.Single(projectCounts);
+            Assert.Equal("beta", beta.Tag);
+            Assert.Equal(1, beta.Count);
+        }
+        finally
+        {
+            foreach (var id in created)
+                await storage.Delete(id);
+            await storage.DeleteProjectAsync(project.Id);
+            await storage.DeleteWorkspaceAsync(workspace.Id);
+        }
+    }
+}

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -249,6 +249,55 @@ public class MemoryToolsCanonicalUrlTests
     }
 
     [Fact]
+    public async Task RestSearchMemories_HybridWithMinSimilarity_FiltersLowSimilarityResults()
+    {
+        // Arrange
+        var highSim = CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "High");
+        highSim.Similarity = new SimilarityScore(0.9);
+        var lowSim = CreateTestMemory(new MemoryId(Guid.Parse("b2c3d4e5-f6a7-8901-bcde-f12345678901")), "Low");
+        lowSim.Similarity = new SimilarityScore(0.5);
+        var noSim = CreateTestMemory(new MemoryId(Guid.Parse("c3d4e5f6-a7b8-901c-def1-23456789012a")), "No Score");
+
+        var fakeStorage = new FakeStorage
+        {
+            HybridSearchResults = new List<Memory> { highSim, lowSim, noSim }
+        };
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
+
+        // Act - with a threshold, only results at/above it survive; no-score results are excluded
+        var result = await controller.SearchMemories("test query", minSimilarity: 0.7);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var items = Assert.IsType<List<MemoryListItem>>(ok.Value);
+        var returned = Assert.Single(items);
+        Assert.Equal(highSim.Id.Value, returned.Id);
+    }
+
+    [Fact]
+    public async Task RestSearchMemories_HybridWithoutMinSimilarity_ReturnsAllResults()
+    {
+        // Arrange
+        var scored = CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Scored");
+        scored.Similarity = new SimilarityScore(0.4);
+        var noSim = CreateTestMemory(new MemoryId(Guid.Parse("b2c3d4e5-f6a7-8901-bcde-f12345678901")), "No Score");
+
+        var fakeStorage = new FakeStorage
+        {
+            HybridSearchResults = new List<Memory> { scored, noSim }
+        };
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
+
+        // Act - no threshold means all hybrid results are returned (default ADR behavior)
+        var result = await controller.SearchMemories("test query");
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var items = Assert.IsType<List<MemoryListItem>>(ok.Value);
+        Assert.Equal(2, items.Count);
+    }
+
+    [Fact]
     public async Task RestSearchWithMetadataEmbedding_WithWorkspaceId_PassesWorkspaceScopeToStorage()
     {
         // Arrange

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -229,7 +229,7 @@ public class MemoryToolsCanonicalUrlTests
         var workspaceId = Guid.Parse("b775bb37-4af5-46fe-ad14-7f6fba7889aa");
         var fakeStorage = new FakeStorage
         {
-            SearchWithMetadataEmbeddingResults = new List<Memory>
+            HybridSearchResults = new List<Memory>
             {
                 CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Memory 1")
             }
@@ -243,9 +243,9 @@ public class MemoryToolsCanonicalUrlTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var items = Assert.IsType<List<MemoryListItem>>(ok.Value);
         Assert.Single(items);
-        Assert.True(fakeStorage.SearchWithMetadataEmbeddingCalled);
-        Assert.Null(fakeStorage.LastMetadataSearchProjectId);
-        Assert.Equal(workspaceId, fakeStorage.LastMetadataSearchWorkspaceId?.Value);
+        Assert.True(fakeStorage.HybridSearchCalled);
+        Assert.Null(fakeStorage.LastHybridSearchProjectId);
+        Assert.Equal(workspaceId, fakeStorage.LastHybridSearchWorkspaceId?.Value);
     }
 
     [Fact]
@@ -290,7 +290,7 @@ public class MemoryToolsCanonicalUrlTests
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Contains("mutually exclusive", Assert.IsType<string>(badRequest.Value));
-        Assert.False(fakeStorage.SearchWithMetadataEmbeddingCalled);
+        Assert.False(fakeStorage.HybridSearchCalled);
     }
 
     [Fact]

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -387,6 +387,9 @@ public class MemoryToolsCanonicalUrlTests
         public Task<List<TagCount>> GetProjectTagCountsAsync(
             ProjectId projectId, CancellationToken cancellationToken = default)
             => Task.FromResult(new List<TagCount>());
+
+        public Task<List<TagCount>> GetGlobalTagCountsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<TagCount>());
     }
 
     /// <summary>

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -227,12 +227,11 @@ public class MemoryToolsCanonicalUrlTests
     {
         // Arrange
         var workspaceId = Guid.Parse("b775bb37-4af5-46fe-ad14-7f6fba7889aa");
+        var memory = CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Memory 1");
+        memory.Similarity = new SimilarityScore(0.9);
         var fakeStorage = new FakeStorage
         {
-            HybridSearchResults = new List<Memory>
-            {
-                CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Memory 1")
-            }
+            HybridSearchResults = new List<Memory> { memory }
         };
         var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
@@ -275,26 +274,29 @@ public class MemoryToolsCanonicalUrlTests
     }
 
     [Fact]
-    public async Task RestSearchMemories_HybridWithoutMinSimilarity_ReturnsAllResults()
+    public async Task RestSearchMemories_HybridWithoutMinSimilarity_UsesDefaultThreshold()
     {
         // Arrange
-        var scored = CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Scored");
-        scored.Similarity = new SimilarityScore(0.4);
-        var noSim = CreateTestMemory(new MemoryId(Guid.Parse("b2c3d4e5-f6a7-8901-bcde-f12345678901")), "No Score");
+        var aboveDefault = CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Above Default");
+        aboveDefault.Similarity = new SimilarityScore(0.4);
+        var belowDefault = CreateTestMemory(new MemoryId(Guid.Parse("b2c3d4e5-f6a7-8901-bcde-f12345678901")), "Below Default");
+        belowDefault.Similarity = new SimilarityScore(0.1);
+        var noSim = CreateTestMemory(new MemoryId(Guid.Parse("c3d4e5f6-a7b8-901c-def1-23456789012a")), "No Score");
 
         var fakeStorage = new FakeStorage
         {
-            HybridSearchResults = new List<Memory> { scored, noSim }
+            HybridSearchResults = new List<Memory> { aboveDefault, belowDefault, noSim }
         };
         var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
-        // Act - no threshold means all hybrid results are returned (default ADR behavior)
+        // Act - the default threshold (0.25) filters out low/no-score noise
         var result = await controller.SearchMemories("test query");
 
         // Assert
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var items = Assert.IsType<List<MemoryListItem>>(ok.Value);
-        Assert.Equal(2, items.Count);
+        var returned = Assert.Single(items);
+        Assert.Equal(aboveDefault.Id.Value, returned.Id);
     }
 
     [Fact]

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -234,7 +234,7 @@ public class MemoryToolsCanonicalUrlTests
                 CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Memory 1")
             }
         };
-        var controller = new MemoryController(fakeStorage, new SimilaritySettings());
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
         // Act
         var result = await controller.SearchMemories("test query", workspaceId: workspaceId);
@@ -260,7 +260,7 @@ public class MemoryToolsCanonicalUrlTests
                 CreateTestMemory(new MemoryId(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")), "Memory 1")
             }
         };
-        var controller = new MemoryController(fakeStorage, new SimilaritySettings());
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
         // Act
         var result = await controller.SearchWithMetadataEmbedding("test query", workspaceId: workspaceId);
@@ -279,7 +279,7 @@ public class MemoryToolsCanonicalUrlTests
     {
         // Arrange
         var fakeStorage = new FakeStorage();
-        var controller = new MemoryController(fakeStorage, new SimilaritySettings());
+        var controller = new MemoryController(fakeStorage, new SimilaritySettings(), new FakeTagCloudService());
 
         // Act
         var result = await controller.SearchMemories(
@@ -373,6 +373,20 @@ public class MemoryToolsCanonicalUrlTests
             Archetype = ArchetypeEnum.Document,
             CurrentVersion = new VersionNumber(1)
         };
+    }
+
+    /// <summary>
+    /// Minimal ITagCloudService stub for controller constructor tests.
+    /// </summary>
+    private class FakeTagCloudService : ITagCloudService
+    {
+        public Task<List<TagCount>> GetWorkspaceSubtreeTagCountsAsync(
+            WorkspaceId workspaceId, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<TagCount>());
+
+        public Task<List<TagCount>> GetProjectTagCountsAsync(
+            ProjectId projectId, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<TagCount>());
     }
 
     /// <summary>

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -530,7 +530,10 @@ public class MemoryController : ControllerBase
     }
 
     /// <summary>
-    /// Vector search for memories using metadata embeddings (optimized for keyword queries)
+    /// Search for memories. Defaults to hybrid search (vector + full-text search via RRF),
+    /// which performs significantly better for short keyword queries (see ADR
+    /// 2026-02-14-hybrid-search-rrf.md). Pass method=vector to use metadata-embedding
+    /// vector search only.
     /// </summary>
     [HttpGet("search")]
     public async Task<ActionResult<List<MemoryListItem>>> SearchMemories(
@@ -541,7 +544,8 @@ public class MemoryController : ControllerBase
         [FromQuery] Guid? projectId = null,
         [FromQuery] bool includeUnassigned = false,
         [FromQuery] bool includeArchived = false,
-        [FromQuery] Guid? workspaceId = null)
+        [FromQuery] Guid? workspaceId = null,
+        [FromQuery] string? method = "hybrid")
     {
         if (string.IsNullOrWhiteSpace(query))
             return BadRequest("Query is required.");
@@ -552,17 +556,32 @@ public class MemoryController : ControllerBase
         ProjectId? typedProjectId = projectId.HasValue ? new ProjectId(projectId.Value) : null;
         WorkspaceId? typedWorkspaceId = workspaceId.HasValue ? new WorkspaceId(workspaceId.Value) : null;
 
-        // Use metadata embeddings by default for better keyword query performance
-        var results = await _storage.SearchWithMetadataEmbedding(
-            query,
-            limit,
-            new SimilarityScore(minSimilarity),
-            filterTags,
-            typedProjectId,
-            includeUnassigned,
-            includeArchived,
-            includeSystem: false,
-            workspaceId: typedWorkspaceId);
+        // Hybrid search is the default: vector + full-text via RRF.
+        // Note: minSimilarity is intentionally not applied by HybridSearch (see ADR).
+        bool useHybrid = string.IsNullOrWhiteSpace(method) || method.Equals("hybrid", StringComparison.OrdinalIgnoreCase);
+
+        var results = useHybrid
+            ? await _storage.HybridSearch(
+                query,
+                limit,
+                new SimilarityScore(minSimilarity),
+                filterTags,
+                typedProjectId,
+                includeUnassigned,
+                includeArchived,
+                includeSystem: false,
+                workspaceId: typedWorkspaceId)
+            : await _storage.SearchWithMetadataEmbedding(
+                query,
+                limit,
+                new SimilarityScore(minSimilarity),
+                filterTags,
+                typedProjectId,
+                includeUnassigned,
+                includeArchived,
+                includeSystem: false,
+                workspaceId: typedWorkspaceId);
+
         return Ok(results.Select(MemoryListItem.FromMemory).ToList());
     }
 

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -139,8 +139,9 @@ public class MemoryController : ControllerBase
     }
 
     /// <summary>
-    /// Get tag counts for a tag cloud, scoped to a workspace subtree or a single project.
-    /// Workspace scope aggregates across the entire subtree (nested workspaces + projects).
+    /// Get tag counts for a tag cloud. Scope to a workspace subtree or a single project
+    /// with the optional query parameters, or omit both for global counts across all
+    /// non-archived memories. Workspace scope aggregates across the entire subtree.
     /// </summary>
     [HttpGet("tags/cloud")]
     public async Task<ActionResult<List<TagCount>>> GetTagCloud(
@@ -163,7 +164,8 @@ public class MemoryController : ControllerBase
             return Ok(counts);
         }
 
-        return BadRequest("Either workspaceId or projectId is required.");
+        var globalCounts = await _tagCloudService.GetGlobalTagCountsAsync(cancellationToken);
+        return Ok(globalCounts);
     }
 
     /// <summary>

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -567,10 +567,9 @@ public class MemoryController : ControllerBase
     /// 2026-02-14-hybrid-search-rrf.md). Pass method=vector to use metadata-embedding
     /// vector search only.
     ///
-    /// For hybrid search, minSimilarity is an optional post-filter on vector similarity:
-    /// when set (&gt; 0), only results with a vector similarity at or above the threshold are
-    /// returned (full-text-only matches, which have no similarity score, are excluded).
-    /// When omitted, all hybrid results are returned (the default per the ADR).
+    /// For hybrid search, minSimilarity filters results by vector similarity: results at or
+    /// above the threshold are returned (full-text-only matches, which have no similarity
+    /// score, are excluded). Defaults to 0.25 to filter out noise; pass 0 to disable.
     /// For vector search, minSimilarity is the similarity threshold (default 0.7).
     /// </summary>
     [HttpGet("search")]
@@ -600,7 +599,8 @@ public class MemoryController : ControllerBase
         {
             // HybridSearch intentionally does not apply a similarity threshold internally
             // (see ADR 2026-02-14) so short keyword queries still surface full-text matches.
-            // Apply the optional threshold here as a post-filter on vector similarity.
+            // Apply the threshold here as a post-filter on vector similarity, defaulting to
+            // 0.25 to filter out noise.
             var results = await _storage.HybridSearch(
                 query,
                 limit,
@@ -612,7 +612,7 @@ public class MemoryController : ControllerBase
                 includeSystem: false,
                 workspaceId: typedWorkspaceId);
 
-            double threshold = minSimilarity.GetValueOrDefault();
+            double threshold = minSimilarity.GetValueOrDefault(0.25);
             if (threshold > 0)
             {
                 results = results

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -566,11 +566,17 @@ public class MemoryController : ControllerBase
     /// which performs significantly better for short keyword queries (see ADR
     /// 2026-02-14-hybrid-search-rrf.md). Pass method=vector to use metadata-embedding
     /// vector search only.
+    ///
+    /// For hybrid search, minSimilarity is an optional post-filter on vector similarity:
+    /// when set (&gt; 0), only results with a vector similarity at or above the threshold are
+    /// returned (full-text-only matches, which have no similarity score, are excluded).
+    /// When omitted, all hybrid results are returned (the default per the ADR).
+    /// For vector search, minSimilarity is the similarity threshold (default 0.7).
     /// </summary>
     [HttpGet("search")]
     public async Task<ActionResult<List<MemoryListItem>>> SearchMemories(
         [FromQuery] string query,
-        [FromQuery] double minSimilarity = 0.7,
+        [FromQuery] double? minSimilarity = null,
         [FromQuery] int limit = 10,
         [FromQuery] string[]? filterTags = null,
         [FromQuery] Guid? projectId = null,
@@ -588,25 +594,17 @@ public class MemoryController : ControllerBase
         ProjectId? typedProjectId = projectId.HasValue ? new ProjectId(projectId.Value) : null;
         WorkspaceId? typedWorkspaceId = workspaceId.HasValue ? new WorkspaceId(workspaceId.Value) : null;
 
-        // Hybrid search is the default: vector + full-text via RRF.
-        // Note: minSimilarity is intentionally not applied by HybridSearch (see ADR).
         bool useHybrid = string.IsNullOrWhiteSpace(method) || method.Equals("hybrid", StringComparison.OrdinalIgnoreCase);
 
-        var results = useHybrid
-            ? await _storage.HybridSearch(
+        if (useHybrid)
+        {
+            // HybridSearch intentionally does not apply a similarity threshold internally
+            // (see ADR 2026-02-14) so short keyword queries still surface full-text matches.
+            // Apply the optional threshold here as a post-filter on vector similarity.
+            var results = await _storage.HybridSearch(
                 query,
                 limit,
-                new SimilarityScore(minSimilarity),
-                filterTags,
-                typedProjectId,
-                includeUnassigned,
-                includeArchived,
-                includeSystem: false,
-                workspaceId: typedWorkspaceId)
-            : await _storage.SearchWithMetadataEmbedding(
-                query,
-                limit,
-                new SimilarityScore(minSimilarity),
+                minSimilarity: null,
                 filterTags,
                 typedProjectId,
                 includeUnassigned,
@@ -614,7 +612,29 @@ public class MemoryController : ControllerBase
                 includeSystem: false,
                 workspaceId: typedWorkspaceId);
 
-        return Ok(results.Select(MemoryListItem.FromMemory).ToList());
+            double threshold = minSimilarity.GetValueOrDefault();
+            if (threshold > 0)
+            {
+                results = results
+                    .Where(m => m.Similarity.HasValue && m.Similarity.Value >= threshold)
+                    .ToList();
+            }
+
+            return Ok(results.Select(MemoryListItem.FromMemory).ToList());
+        }
+
+        var vectorResults = await _storage.SearchWithMetadataEmbedding(
+            query,
+            limit,
+            new SimilarityScore(minSimilarity ?? 0.7),
+            filterTags,
+            typedProjectId,
+            includeUnassigned,
+            includeArchived,
+            includeSystem: false,
+            workspaceId: typedWorkspaceId);
+
+        return Ok(vectorResults.Select(MemoryListItem.FromMemory).ToList());
     }
 
     /// <summary>

--- a/src/Memorizer/Controllers/MemoryController.cs
+++ b/src/Memorizer/Controllers/MemoryController.cs
@@ -17,11 +17,13 @@ public class MemoryController : ControllerBase
 {
     private readonly IStorage _storage;
     private readonly SimilaritySettings _similaritySettings;
+    private readonly ITagCloudService _tagCloudService;
 
-    public MemoryController(IStorage storage, SimilaritySettings similaritySettings)
+    public MemoryController(IStorage storage, SimilaritySettings similaritySettings, ITagCloudService tagCloudService)
     {
         _storage = storage;
         _similaritySettings = similaritySettings;
+        _tagCloudService = tagCloudService;
     }
 
     /// <summary>
@@ -134,6 +136,34 @@ public class MemoryController : ControllerBase
 
         var tags = await _storage.GetDistinctTagsAsync(owner);
         return Ok(tags);
+    }
+
+    /// <summary>
+    /// Get tag counts for a tag cloud, scoped to a workspace subtree or a single project.
+    /// Workspace scope aggregates across the entire subtree (nested workspaces + projects).
+    /// </summary>
+    [HttpGet("tags/cloud")]
+    public async Task<ActionResult<List<TagCount>>> GetTagCloud(
+        [FromQuery] Guid? workspaceId = null,
+        [FromQuery] Guid? projectId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (projectId.HasValue && workspaceId.HasValue)
+            return BadRequest("projectId and workspaceId are mutually exclusive tag cloud scopes.");
+
+        if (projectId.HasValue)
+        {
+            var counts = await _tagCloudService.GetProjectTagCountsAsync(new ProjectId(projectId.Value), cancellationToken);
+            return Ok(counts);
+        }
+
+        if (workspaceId.HasValue)
+        {
+            var counts = await _tagCloudService.GetWorkspaceSubtreeTagCountsAsync(new WorkspaceId(workspaceId.Value), cancellationToken);
+            return Ok(counts);
+        }
+
+        return BadRequest("Either workspaceId or projectId is required.");
     }
 
     /// <summary>

--- a/src/Memorizer/Models/TagCount.cs
+++ b/src/Memorizer/Models/TagCount.cs
@@ -1,0 +1,10 @@
+namespace Memorizer.Models;
+
+/// <summary>
+/// A single tag and the number of non-archived memories using it.
+/// </summary>
+public class TagCount
+{
+    public string Tag { get; init; } = "";
+    public int Count { get; init; }
+}

--- a/src/Memorizer/Services/ITagCloudService.cs
+++ b/src/Memorizer/Services/ITagCloudService.cs
@@ -22,4 +22,9 @@ public interface ITagCloudService
     Task<List<TagCount>> GetProjectTagCountsAsync(
         ProjectId projectId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets tag counts across all non-archived memories (no owner scope).
+    /// </summary>
+    Task<List<TagCount>> GetGlobalTagCountsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Memorizer/Services/ITagCloudService.cs
+++ b/src/Memorizer/Services/ITagCloudService.cs
@@ -1,0 +1,25 @@
+using Memorizer.Models;
+using Memorizer.Models.ValueTypes;
+
+namespace Memorizer.Services;
+
+/// <summary>
+/// Computes tag clouds (tag → memory count) scoped to workspaces and projects.
+/// </summary>
+public interface ITagCloudService
+{
+    /// <summary>
+    /// Gets tag counts across the entire workspace subtree: direct workspace
+    /// memories, all projects, and all nested workspaces (recursive).
+    /// </summary>
+    Task<List<TagCount>> GetWorkspaceSubtreeTagCountsAsync(
+        WorkspaceId workspaceId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets tag counts for memories directly owned by a single project.
+    /// </summary>
+    Task<List<TagCount>> GetProjectTagCountsAsync(
+        ProjectId projectId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Memorizer/Services/TagCloudService.cs
+++ b/src/Memorizer/Services/TagCloudService.cs
@@ -1,0 +1,89 @@
+using Memorizer.Models;
+using Memorizer.Models.Enums;
+using Memorizer.Models.ValueTypes;
+using Npgsql;
+using Registrator.Net;
+
+namespace Memorizer.Services;
+
+/// <summary>
+/// Computes tag clouds (tag → memory count) scoped to workspaces and projects.
+/// </summary>
+[AutoRegisterInterfaces(ServiceLifetime.Scoped)]
+public class TagCloudService : ITagCloudService
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public TagCloudService(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task<List<TagCount>> GetWorkspaceSubtreeTagCountsAsync(
+        WorkspaceId workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = @"
+            WITH RECURSIVE ws_tree AS (
+                SELECT id FROM workspaces WHERE id = @root
+                UNION ALL
+                SELECT w.id FROM workspaces w JOIN ws_tree t ON w.parent_id = t.id
+            )
+            SELECT tag, COUNT(*) AS cnt
+            FROM memories, unnest(tags) AS tag
+            WHERE archetype IN (0, 1)
+              AND (
+                    (owner_type = @workspaceType AND owner_id IN (SELECT id FROM ws_tree))
+                 OR (owner_type = @projectType AND owner_id IN (
+                        SELECT id FROM projects WHERE workspace_id IN (SELECT id FROM ws_tree)))
+              )
+            GROUP BY tag
+            ORDER BY cnt DESC, tag";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("root", workspaceId.Value);
+        command.Parameters.AddWithValue("workspaceType", (short)OwnerTypeEnum.Workspace);
+        command.Parameters.AddWithValue("projectType", (short)OwnerTypeEnum.Project);
+
+        return await ReadTagCountsAsync(command, cancellationToken);
+    }
+
+    public async Task<List<TagCount>> GetProjectTagCountsAsync(
+        ProjectId projectId,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = @"
+            SELECT tag, COUNT(*) AS cnt
+            FROM memories, unnest(tags) AS tag
+            WHERE archetype IN (0, 1)
+              AND owner_type = @projectType
+              AND owner_id = @projectId
+            GROUP BY tag
+            ORDER BY cnt DESC, tag";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("projectId", projectId.Value);
+        command.Parameters.AddWithValue("projectType", (short)OwnerTypeEnum.Project);
+
+        return await ReadTagCountsAsync(command, cancellationToken);
+    }
+
+    private static async Task<List<TagCount>> ReadTagCountsAsync(
+        NpgsqlCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<TagCount>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new TagCount
+            {
+                Tag = reader.GetString(0),
+                Count = reader.GetInt32(1)
+            });
+        }
+        return result;
+    }
+}

--- a/src/Memorizer/Services/TagCloudService.cs
+++ b/src/Memorizer/Services/TagCloudService.cs
@@ -70,6 +70,21 @@ public class TagCloudService : ITagCloudService
         return await ReadTagCountsAsync(command, cancellationToken);
     }
 
+    public async Task<List<TagCount>> GetGlobalTagCountsAsync(CancellationToken cancellationToken = default)
+    {
+        const string sql = @"
+            SELECT tag, COUNT(*) AS cnt
+            FROM memories, unnest(tags) AS tag
+            WHERE archetype IN (0, 1)
+            GROUP BY tag
+            ORDER BY cnt DESC, tag";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        return await ReadTagCountsAsync(command, cancellationToken);
+    }
+
     private static async Task<List<TagCount>> ReadTagCountsAsync(
         NpgsqlCommand command,
         CancellationToken cancellationToken)

--- a/src/Memorizer/Views/Home/Index.cshtml
+++ b/src/Memorizer/Views/Home/Index.cshtml
@@ -8,7 +8,7 @@
             <i class="fas fa-brain me-2 text-primary"></i>
             Memory Manager
         </h1>
-        <p class="text-muted mb-0">Manage your AI agent memories with vector search capabilities</p>
+        <p class="text-muted mb-0">Manage your AI agent memories with semantic and hybrid search</p>
     </div>
     <div>        <a asp-controller="Home" asp-action="Create" class="btn btn-primary">            <i class="fas fa-plus me-2"></i>            Add Memory        </a>    </div>
 </div>
@@ -58,19 +58,25 @@
     </div>
 </div>
 
-<!-- Vector Search Bar - Moved to top -->
+<!-- Search Bar - hybrid by default, vector available via toggle -->
 <div class="card mb-4">
     <div class="card-body">
-        <form id="vectorSearchForm" class="row g-2 align-items-center" onsubmit="return runVectorSearch(event)">
-            <div class="col-md-8">
-                <input type="text" id="vectorSearchQuery" class="form-control" placeholder="Vector search memories..." autocomplete="off">
+        <form id="vectorSearchForm" class="row g-2 align-items-center" onsubmit="return runSearch(event)">
+            <div class="col-auto">
+                <select id="searchMode" class="form-select" title="Search mode" onchange="onSearchModeChange()">
+                    <option value="hybrid" selected>Hybrid</option>
+                    <option value="vector">Vector</option>
+                </select>
             </div>
-            <div class="col-md-2">
+            <div class="col-md-7">
+                <input type="text" id="vectorSearchQuery" class="form-control" placeholder="Search memories..." autocomplete="off">
+            </div>
+            <div class="col-md-2" id="minSimContainer" style="display: none;">
                 <input type="number" id="vectorSearchMinSim" class="form-control" placeholder="Min similarity (0-1)" min="0" max="1" step="0.01" value="0.7">
             </div>
             <div class="col-md-2">
                 <button type="submit" class="btn btn-success w-100">
-                    <i class="fas fa-search me-1"></i> Vector Search
+                    <i class="fas fa-search me-1"></i> <span id="searchButtonLabel">Search</span>
                 </button>
             </div>
         </form>
@@ -203,9 +209,9 @@ function parseUrlParams() {
     const searchQuery = params.get('q');
     if (searchQuery) {
         document.getElementById('vectorSearchQuery').value = searchQuery;
-        // Auto-trigger vector search
+        // Auto-trigger search
         setTimeout(() => {
-            runVectorSearch(new Event('submit'));
+            runSearch(new Event('submit'));
         }, 100);
     }
 }
@@ -905,10 +911,27 @@ async function deleteMemory(id) {
     }
 }
 
-async function runVectorSearch(event) {
+function onSearchModeChange() {
+    const mode = document.getElementById('searchMode').value;
+    const minSimContainer = document.getElementById('minSimContainer');
+    const buttonLabel = document.getElementById('searchButtonLabel');
+    const input = document.getElementById('vectorSearchQuery');
+
+    if (mode === 'vector') {
+        minSimContainer.style.display = 'block';
+        buttonLabel.textContent = 'Vector Search';
+        input.placeholder = 'Vector search memories...';
+    } else {
+        minSimContainer.style.display = 'none';
+        buttonLabel.textContent = 'Search';
+        input.placeholder = 'Search memories...';
+    }
+}
+
+async function runSearch(event) {
     event.preventDefault();
     const query = document.getElementById('vectorSearchQuery').value.trim();
-    const minSim = parseFloat(document.getElementById('vectorSearchMinSim').value) || 0.7;
+    const method = document.getElementById('searchMode').value;
     if (!query) {
         // If search bar is cleared, revert to default list
         isVectorSearch = false;
@@ -919,21 +942,27 @@ async function runVectorSearch(event) {
     isVectorSearch = true;
     document.getElementById('vectorSearchResults').innerHTML = `<div class='d-flex justify-content-center py-5'><div class='spinner-border text-success' role='status'><span class='visually-hidden'>Searching...</span></div></div>`;
     try {
-        const response = await fetch(`/api/memory/search?query=${encodeURIComponent(query)}&minSimilarity=${minSim}&limit=20`);
+        let url = `/api/memory/search?query=${encodeURIComponent(query)}&method=${method}&limit=20`;
+        if (method === 'vector') {
+            const minSim = parseFloat(document.getElementById('vectorSearchMinSim').value) || 0.7;
+            url += `&minSimilarity=${minSim}`;
+        }
+        const response = await fetch(url);
         const results = await response.json();
-        displayVectorSearchResults(results);
+        displayVectorSearchResults(results, method);
     } catch (error) {
-        document.getElementById('vectorSearchResults').innerHTML = `<div class='alert alert-danger'><i class='fas fa-exclamation-triangle me-2'></i>Error running vector search. Please try again.</div>`;
+        document.getElementById('vectorSearchResults').innerHTML = `<div class='alert alert-danger'><i class='fas fa-exclamation-triangle me-2'></i>Error running search. Please try again.</div>`;
     }
     return false;
 }
 
-function displayVectorSearchResults(results) {
+function displayVectorSearchResults(results, method) {
+    const resultsTitle = method === 'vector' ? 'Vector Search Results' : 'Search Results';
     if (!results || results.length === 0) {
-        document.getElementById('vectorSearchResults').innerHTML = `<div class='alert alert-info'><i class='fas fa-info-circle me-2'></i>No vector search results found.</div>`;
+        document.getElementById('vectorSearchResults').innerHTML = `<div class='alert alert-info'><i class='fas fa-info-circle me-2'></i>No search results found.</div>`;
         return;
     }
-    let html = `<div class='card mb-4'><div class='card-body'><h5 class='mb-3'><i class='fas fa-search me-2 text-success'></i>Vector Search Results</h5><div class='row'>`;
+    let html = `<div class='card mb-4'><div class='card-body'><h5 class='mb-3'><i class='fas fa-search me-2 text-success'></i>${resultsTitle}</h5><div class='row'>`;
     results.forEach(memory => {
         const tags = createClickableTagBadges(memory.tags);
         const title = memory.title || 'Untitled Memory';

--- a/src/Memorizer/Views/Home/Index.cshtml
+++ b/src/Memorizer/Views/Home/Index.cshtml
@@ -71,8 +71,8 @@
             <div class="col-md-7">
                 <input type="text" id="vectorSearchQuery" class="form-control" placeholder="Search memories..." autocomplete="off">
             </div>
-            <div class="col-md-2" id="minSimContainer" style="display: none;">
-                <input type="number" id="vectorSearchMinSim" class="form-control" placeholder="Min similarity (0-1)" min="0" max="1" step="0.01" value="0.7">
+            <div class="col-md-2" id="minSimContainer">
+                <input type="number" id="vectorSearchMinSim" class="form-control" placeholder="Min similarity (optional)" min="0" max="1" step="0.01" value="">
             </div>
             <div class="col-md-2">
                 <button type="submit" class="btn btn-success w-100">
@@ -677,6 +677,7 @@ function updateFilterUrl() {
 
 // Load memories on page load
 document.addEventListener('DOMContentLoaded', function() {
+    onSearchModeChange();
     parseUrlParams();
     updateFilterContext();
     loadLocationDropdown();
@@ -913,18 +914,19 @@ async function deleteMemory(id) {
 
 function onSearchModeChange() {
     const mode = document.getElementById('searchMode').value;
-    const minSimContainer = document.getElementById('minSimContainer');
     const buttonLabel = document.getElementById('searchButtonLabel');
     const input = document.getElementById('vectorSearchQuery');
+    const minSimInput = document.getElementById('vectorSearchMinSim');
 
     if (mode === 'vector') {
-        minSimContainer.style.display = 'block';
         buttonLabel.textContent = 'Vector Search';
         input.placeholder = 'Vector search memories...';
+        minSimInput.placeholder = 'Min similarity (0-1)';
+        if (!minSimInput.value) minSimInput.value = '0.7';
     } else {
-        minSimContainer.style.display = 'none';
         buttonLabel.textContent = 'Search';
         input.placeholder = 'Search memories...';
+        minSimInput.placeholder = 'Min similarity (optional)';
     }
 }
 
@@ -942,11 +944,19 @@ async function runSearch(event) {
     isVectorSearch = true;
     document.getElementById('vectorSearchResults').innerHTML = `<div class='d-flex justify-content-center py-5'><div class='spinner-border text-success' role='status'><span class='visually-hidden'>Searching...</span></div></div>`;
     try {
+        const minSimRaw = document.getElementById('vectorSearchMinSim').value.trim();
         let url = `/api/memory/search?query=${encodeURIComponent(query)}&method=${method}&limit=20`;
+
         if (method === 'vector') {
-            const minSim = parseFloat(document.getElementById('vectorSearchMinSim').value) || 0.7;
+            const minSim = parseFloat(minSimRaw) || 0.7;
             url += `&minSimilarity=${minSim}`;
+        } else if (minSimRaw !== '') {
+            const minSim = parseFloat(minSimRaw);
+            if (!isNaN(minSim) && minSim > 0) {
+                url += `&minSimilarity=${minSim}`;
+            }
         }
+
         const response = await fetch(url);
         const results = await response.json();
         displayVectorSearchResults(results, method);

--- a/src/Memorizer/Views/Home/Index.cshtml
+++ b/src/Memorizer/Views/Home/Index.cshtml
@@ -68,11 +68,15 @@
                     <option value="vector">Vector</option>
                 </select>
             </div>
-            <div class="col-md-7">
+            <div class="col-md-5">
                 <input type="text" id="vectorSearchQuery" class="form-control" placeholder="Search memories..." autocomplete="off">
             </div>
-            <div class="col-md-2" id="minSimContainer">
-                <input type="number" id="vectorSearchMinSim" class="form-control" placeholder="Min similarity (optional)" min="0" max="1" step="0.01" value="">
+            <div class="col-md-3" id="minSimContainer">
+                <div class="d-flex align-items-center gap-2">
+                    <input type="range" id="vectorSearchMinSim" class="form-range flex-grow-1" min="0" max="100" step="5" value="25"
+                           oninput="onMinSimChange()" title="Minimum similarity threshold">
+                    <span class="text-muted small text-nowrap" id="minSimValue">25%</span>
+                </div>
             </div>
             <div class="col-md-2">
                 <button type="submit" class="btn btn-success w-100">
@@ -678,6 +682,7 @@ function updateFilterUrl() {
 // Load memories on page load
 document.addEventListener('DOMContentLoaded', function() {
     onSearchModeChange();
+    onMinSimChange();
     parseUrlParams();
     updateFilterContext();
     loadLocationDropdown();
@@ -912,21 +917,22 @@ async function deleteMemory(id) {
     }
 }
 
+function onMinSimChange() {
+    const value = document.getElementById('vectorSearchMinSim').value;
+    document.getElementById('minSimValue').textContent = value + '%';
+}
+
 function onSearchModeChange() {
     const mode = document.getElementById('searchMode').value;
     const buttonLabel = document.getElementById('searchButtonLabel');
     const input = document.getElementById('vectorSearchQuery');
-    const minSimInput = document.getElementById('vectorSearchMinSim');
 
     if (mode === 'vector') {
         buttonLabel.textContent = 'Vector Search';
         input.placeholder = 'Vector search memories...';
-        minSimInput.placeholder = 'Min similarity (0-1)';
-        if (!minSimInput.value) minSimInput.value = '0.7';
     } else {
         buttonLabel.textContent = 'Search';
         input.placeholder = 'Search memories...';
-        minSimInput.placeholder = 'Min similarity (optional)';
     }
 }
 
@@ -944,19 +950,8 @@ async function runSearch(event) {
     isVectorSearch = true;
     document.getElementById('vectorSearchResults').innerHTML = `<div class='d-flex justify-content-center py-5'><div class='spinner-border text-success' role='status'><span class='visually-hidden'>Searching...</span></div></div>`;
     try {
-        const minSimRaw = document.getElementById('vectorSearchMinSim').value.trim();
-        let url = `/api/memory/search?query=${encodeURIComponent(query)}&method=${method}&limit=20`;
-
-        if (method === 'vector') {
-            const minSim = parseFloat(minSimRaw) || 0.7;
-            url += `&minSimilarity=${minSim}`;
-        } else if (minSimRaw !== '') {
-            const minSim = parseFloat(minSimRaw);
-            if (!isNaN(minSim) && minSim > 0) {
-                url += `&minSimilarity=${minSim}`;
-            }
-        }
-
+        const minSim = (parseFloat(document.getElementById('vectorSearchMinSim').value) || 0) / 100;
+        const url = `/api/memory/search?query=${encodeURIComponent(query)}&method=${method}&limit=20&minSimilarity=${minSim}`;
         const response = await fetch(url);
         const results = await response.json();
         displayVectorSearchResults(results, method);

--- a/src/Memorizer/Views/Home/Index.cshtml
+++ b/src/Memorizer/Views/Home/Index.cshtml
@@ -926,14 +926,18 @@ function onSearchModeChange() {
     const mode = document.getElementById('searchMode').value;
     const buttonLabel = document.getElementById('searchButtonLabel');
     const input = document.getElementById('vectorSearchQuery');
+    const minSimInput = document.getElementById('vectorSearchMinSim');
 
     if (mode === 'vector') {
         buttonLabel.textContent = 'Vector Search';
         input.placeholder = 'Vector search memories...';
+        minSimInput.value = '70';
     } else {
         buttonLabel.textContent = 'Search';
         input.placeholder = 'Search memories...';
+        minSimInput.value = '25';
     }
+    onMinSimChange();
 }
 
 async function runSearch(event) {

--- a/src/Memorizer/Views/Home/ProjectDetail.cshtml
+++ b/src/Memorizer/Views/Home/ProjectDetail.cshtml
@@ -46,6 +46,23 @@
 
     <hr>
 
+    <!-- Tag Cloud Section -->
+    <div class="card mb-4" id="tagCloudSection" style="display: none;">
+        <div class="card-header">
+            <h5 class="mb-0">
+                <i class="fas fa-tags me-2"></i>
+                Tag Cloud
+            </h5>
+        </div>
+        <div class="card-body">
+            <div id="tagCloud" class="tag-cloud"></div>
+            <div id="noTagCloud" class="text-muted" style="display: none;">
+                <i class="fas fa-info-circle me-2"></i>
+                No tags yet.
+            </div>
+        </div>
+    </div>
+
     <!-- Status Section - Compact inline design -->
     <div class="d-flex align-items-center gap-3 mb-4 p-3 rounded" style="background-color: var(--surface-card-alt);">
         <span class="text-muted"><i class="fas fa-flag me-2"></i>Status:</span>
@@ -411,6 +428,39 @@ function renderProject() {
         archiveBtn.innerHTML = '<i class="fas fa-archive me-2"></i>Archive Project';
         archiveBtn.onclick = archiveProject;
     }
+
+    // Tag cloud
+    loadTagCloud();
+}
+
+async function loadTagCloud() {
+    const section = document.getElementById('tagCloudSection');
+    const container = document.getElementById('tagCloud');
+    const empty = document.getElementById('noTagCloud');
+
+    try {
+        const response = await fetch(`/api/memory/tags/cloud?projectId=${projectId}`);
+        if (!response.ok) throw new Error('Failed to load tag cloud');
+
+        const tags = await response.json();
+        if (!tags || tags.length === 0) {
+            section.style.display = 'none';
+            return;
+        }
+
+        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        empty.style.display = 'none';
+        section.style.display = 'block';
+    } catch (error) {
+        console.warn('Could not load tag cloud:', error);
+        section.style.display = 'none';
+    }
+}
+
+function renderTagCloudItem(tagCount) {
+    const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
+    const href = `/memories?projectId=${projectId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 
 function renderStatusDropdown() {

--- a/src/Memorizer/Views/Home/ProjectDetail.cshtml
+++ b/src/Memorizer/Views/Home/ProjectDetail.cshtml
@@ -433,9 +433,12 @@ function renderProject() {
     loadTagCloud();
 }
 
+const tagCloudMaxTags = 30;
+let allTagCounts = [];
+let tagCloudShowAll = false;
+
 async function loadTagCloud() {
     const section = document.getElementById('tagCloudSection');
-    const container = document.getElementById('tagCloud');
     const empty = document.getElementById('noTagCloud');
 
     try {
@@ -448,13 +451,30 @@ async function loadTagCloud() {
             return;
         }
 
-        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        allTagCounts = tags;
+        tagCloudShowAll = false;
+        renderTagCloud();
         empty.style.display = 'none';
         section.style.display = 'block';
     } catch (error) {
         console.warn('Could not load tag cloud:', error);
         section.style.display = 'none';
     }
+}
+
+function renderTagCloud() {
+    const container = document.getElementById('tagCloud');
+    const visible = tagCloudShowAll ? allTagCounts : allTagCounts.slice(0, tagCloudMaxTags);
+    let html = visible.map(renderTagCloudItem).join('');
+    if (allTagCounts.length > tagCloudMaxTags) {
+        html += `<a href="#" class="tag-cloud-toggle" onclick="toggleTagCloud(); return false;">${tagCloudShowAll ? 'Show fewer' : `Show all ${allTagCounts.length} tags`}</a>`;
+    }
+    container.innerHTML = html;
+}
+
+function toggleTagCloud() {
+    tagCloudShowAll = !tagCloudShowAll;
+    renderTagCloud();
 }
 
 function renderTagCloudItem(tagCount) {

--- a/src/Memorizer/Views/Home/ProjectDetail.cshtml
+++ b/src/Memorizer/Views/Home/ProjectDetail.cshtml
@@ -46,12 +46,12 @@
 
     <hr>
 
-    <!-- Tag Cloud Section -->
+    <!-- Tags Section -->
     <div class="card mb-4" id="tagCloudSection" style="display: none;">
         <div class="card-header">
             <h5 class="mb-0">
                 <i class="fas fa-tags me-2"></i>
-                Tag Cloud
+                Tags
             </h5>
         </div>
         <div class="card-body">
@@ -459,7 +459,7 @@ async function loadTagCloud() {
 
 function renderTagCloudItem(tagCount) {
     const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
-    const href = `/memories?projectId=${projectId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    const href = `/memories?tag=${encodeURIComponent(tagCount.tag)}`;
     return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -50,6 +50,23 @@
 
     <hr>
 
+    <!-- Tag Cloud Section -->
+    <div class="card mb-4" id="tagCloudSection" style="display: none;">
+        <div class="card-header">
+            <h5 class="mb-0">
+                <i class="fas fa-tags me-2"></i>
+                Tag Cloud
+            </h5>
+        </div>
+        <div class="card-body">
+            <div id="tagCloud" class="tag-cloud"></div>
+            <div id="noTagCloud" class="text-muted" style="display: none;">
+                <i class="fas fa-info-circle me-2"></i>
+                No tags yet.
+            </div>
+        </div>
+    </div>
+
     <!-- Child Workspaces Section -->
     <div class="mb-4" id="childWorkspacesSection">
         <div class="d-flex justify-content-between align-items-center mb-3">
@@ -340,6 +357,39 @@ function renderWorkspace() {
     // Memories
     document.getElementById('viewAllMemoriesLink').href = `/memories?workspaceId=${workspaceId}`;
     renderMemoriesList();
+
+    // Tag cloud
+    loadTagCloud();
+}
+
+async function loadTagCloud() {
+    const section = document.getElementById('tagCloudSection');
+    const container = document.getElementById('tagCloud');
+    const empty = document.getElementById('noTagCloud');
+
+    try {
+        const response = await fetch(`/api/memory/tags/cloud?workspaceId=${workspaceId}`);
+        if (!response.ok) throw new Error('Failed to load tag cloud');
+
+        const tags = await response.json();
+        if (!tags || tags.length === 0) {
+            section.style.display = 'none';
+            return;
+        }
+
+        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        empty.style.display = 'none';
+        section.style.display = 'block';
+    } catch (error) {
+        console.warn('Could not load tag cloud:', error);
+        section.style.display = 'none';
+    }
+}
+
+function renderTagCloudItem(tagCount) {
+    const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
+    const href = `/memories?workspaceId=${workspaceId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 
 function renderProjectCard(project) {

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -28,57 +28,53 @@
                 <span id="workspaceMeta"></span>
             </small>
         </div>
-        <div id="editButton" class="d-flex gap-2">
-            <button type="button" class="btn btn-outline-secondary" id="reparentWorkspaceBtn" data-bs-toggle="modal" data-bs-target="#reparentWorkspaceModal" onclick="openReparentModal()">
-                <i class="fas fa-sitemap me-2"></i>Move/Reparent
-            </button>
-            <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editWorkspaceModal">
-                <i class="fas fa-edit me-2"></i>Edit
-            </button>
+        <div class="d-flex gap-2">
+            <div id="createButtons" class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-primary" id="createChildWorkspaceBtn" data-bs-toggle="modal" data-bs-target="#createChildWorkspaceModal">
+                    <i class="fas fa-folder-plus me-2"></i>New Nested Workspace
+                </button>
+                <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createProjectModal">
+                    <i class="fas fa-plus me-2"></i>New Project
+                </button>
+            </div>
+            <div id="editButton" class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-secondary" id="reparentWorkspaceBtn" data-bs-toggle="modal" data-bs-target="#reparentWorkspaceModal" onclick="openReparentModal()">
+                    <i class="fas fa-sitemap me-2"></i>Move/Reparent
+                </button>
+                <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editWorkspaceModal">
+                    <i class="fas fa-edit me-2"></i>Edit
+                </button>
+            </div>
         </div>
     </div>
 
     <hr>
 
     <!-- Child Workspaces Section -->
-    <div class="mb-4">
+    <div class="mb-4" id="childWorkspacesSection">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h4>
                 <i class="fas fa-folder-tree me-2"></i>
                 Nested Workspaces <span class="badge bg-secondary" id="childWorkspaceCount">0</span>
             </h4>
-            <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#createChildWorkspaceModal" id="createChildWorkspaceBtn">
-                <i class="fas fa-plus me-2"></i>New Nested Workspace
-            </button>
         </div>
         <div id="childWorkspacesList"></div>
-        <div id="noChildWorkspaces" class="text-center py-4 text-muted" style="display: none;">
-            <i class="fas fa-folder-open fa-2x mb-2"></i>
-            <p>No nested workspaces. Create one to organize related areas of work.</p>
-        </div>
     </div>
 
-    <hr>
+    <hr id="childWorkspacesDivider" style="display: none;">
 
     <!-- Projects Section -->
-    <div class="mb-4">
+    <div class="mb-4" id="projectsSection">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h4>
                 <i class="fas fa-tasks me-2"></i>
                 Projects <span class="badge bg-secondary" id="projectCount">0</span>
             </h4>
-            <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#createProjectModal">
-                <i class="fas fa-plus me-2"></i>New Project
-            </button>
         </div>
         <div id="projectsList"></div>
-        <div id="noProjects" class="text-center py-4 text-muted" style="display: none;">
-            <i class="fas fa-inbox fa-2x mb-2"></i>
-            <p>No projects yet. Create one to start organizing memories.</p>
-        </div>
     </div>
 
-    <hr>
+    <hr id="projectsDivider" style="display: none;">
 
     <!-- Memories Section -->
     <div class="mb-4">
@@ -318,19 +314,27 @@ function renderWorkspace() {
 
     // Child Workspaces
     const childWorkspaces = workspace.childWorkspaces || [];
-    document.getElementById('childWorkspaceCount').textContent = childWorkspaces.length;
+    const childWorkspacesSection = document.getElementById('childWorkspacesSection');
     if (childWorkspaces.length > 0) {
+        document.getElementById('childWorkspaceCount').textContent = childWorkspaces.length;
         document.getElementById('childWorkspacesList').innerHTML = childWorkspaces.map(renderChildWorkspaceCard).join('');
+        childWorkspacesSection.style.display = 'block';
+        document.getElementById('childWorkspacesDivider').style.display = 'block';
     } else {
-        document.getElementById('noChildWorkspaces').style.display = 'block';
+        childWorkspacesSection.style.display = 'none';
+        document.getElementById('childWorkspacesDivider').style.display = 'none';
     }
 
     // Projects
-    document.getElementById('projectCount').textContent = workspace.projects.length;
+    const projectsSection = document.getElementById('projectsSection');
     if (workspace.projects.length > 0) {
+        document.getElementById('projectCount').textContent = workspace.projects.length;
         document.getElementById('projectsList').innerHTML = workspace.projects.map(renderProjectCard).join('');
+        projectsSection.style.display = 'block';
+        document.getElementById('projectsDivider').style.display = 'block';
     } else {
-        document.getElementById('noProjects').style.display = 'block';
+        projectsSection.style.display = 'none';
+        document.getElementById('projectsDivider').style.display = 'none';
     }
 
     // Memories

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -362,9 +362,12 @@ function renderWorkspace() {
     loadTagCloud();
 }
 
+const tagCloudMaxTags = 30;
+let allTagCounts = [];
+let tagCloudShowAll = false;
+
 async function loadTagCloud() {
     const section = document.getElementById('tagCloudSection');
-    const container = document.getElementById('tagCloud');
     const empty = document.getElementById('noTagCloud');
 
     try {
@@ -377,13 +380,30 @@ async function loadTagCloud() {
             return;
         }
 
-        container.innerHTML = tags.map(renderTagCloudItem).join('');
+        allTagCounts = tags;
+        tagCloudShowAll = false;
+        renderTagCloud();
         empty.style.display = 'none';
         section.style.display = 'block';
     } catch (error) {
         console.warn('Could not load tag cloud:', error);
         section.style.display = 'none';
     }
+}
+
+function renderTagCloud() {
+    const container = document.getElementById('tagCloud');
+    const visible = tagCloudShowAll ? allTagCounts : allTagCounts.slice(0, tagCloudMaxTags);
+    let html = visible.map(renderTagCloudItem).join('');
+    if (allTagCounts.length > tagCloudMaxTags) {
+        html += `<a href="#" class="tag-cloud-toggle" onclick="toggleTagCloud(); return false;">${tagCloudShowAll ? 'Show fewer' : `Show all ${allTagCounts.length} tags`}</a>`;
+    }
+    container.innerHTML = html;
+}
+
+function toggleTagCloud() {
+    tagCloudShowAll = !tagCloudShowAll;
+    renderTagCloud();
 }
 
 function renderTagCloudItem(tagCount) {

--- a/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
+++ b/src/Memorizer/Views/Home/WorkspaceDetail.cshtml
@@ -50,12 +50,12 @@
 
     <hr>
 
-    <!-- Tag Cloud Section -->
+    <!-- Tags Section -->
     <div class="card mb-4" id="tagCloudSection" style="display: none;">
         <div class="card-header">
             <h5 class="mb-0">
                 <i class="fas fa-tags me-2"></i>
-                Tag Cloud
+                Tags
             </h5>
         </div>
         <div class="card-body">
@@ -388,7 +388,7 @@ async function loadTagCloud() {
 
 function renderTagCloudItem(tagCount) {
     const fontSize = 0.8 + Math.min(0.8, (tagCount.count - 1) * 0.15);
-    const href = `/memories?workspaceId=${workspaceId}&tag=${encodeURIComponent(tagCount.tag)}`;
+    const href = `/memories?tag=${encodeURIComponent(tagCount.tag)}`;
     return `<a href="${href}" class="tag-cloud-item" style="font-size: ${fontSize.toFixed(2)}rem;" title="${escapeHtml(tagCount.tag)} (${tagCount.count})">${escapeHtml(tagCount.tag)}</a>`;
 }
 

--- a/src/Memorizer/Views/Shared/_Layout.cshtml
+++ b/src/Memorizer/Views/Shared/_Layout.cshtml
@@ -101,6 +101,22 @@
                     <!-- Workspace/Project Tree Navigation (Primary) -->
                     @await Html.PartialAsync("_WorkspaceTree")
 
+                    <!-- Sidebar Tags (global tag navigation) -->
+                    <div id="sidebar-tags-container">
+                        <button type="button" class="sidebar-tags-header" onclick="SidebarTags.toggle()" aria-expanded="false" title="Toggle tags">
+                            <span class="sidebar-tags-toggle"><i class="fas fa-chevron-right"></i></span>
+                            <i class="fas fa-tags"></i>
+                            Tags
+                            <span class="sidebar-tags-count" id="sidebarTagsTotal" style="display: none;">0</span>
+                        </button>
+                        <div class="sidebar-tags-body">
+                            <div class="sidebar-tags-loading">
+                                <span class="spinner-border spinner-border-sm" role="status"></span>
+                                <span>Loading...</span>
+                            </div>
+                        </div>
+                    </div>
+
                     <hr class="my-3" style="border-color: var(--sidebar-divider);">
 
                     <!-- Theme Toggle -->
@@ -194,6 +210,7 @@
     <script src="~/js/memory-utils.js" asp-append-version="true"></script>
     <script src="~/js/progress-stream.js" asp-append-version="true"></script>
     <script src="~/js/workspace-tree.js" asp-append-version="true"></script>
+    <script src="~/js/sidebar-tags.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/src/Memorizer/Views/Shared/_Layout.cshtml
+++ b/src/Memorizer/Views/Shared/_Layout.cshtml
@@ -101,6 +101,8 @@
                     <!-- Workspace/Project Tree Navigation (Primary) -->
                     @await Html.PartialAsync("_WorkspaceTree")
 
+                    <hr class="my-3" style="border-color: var(--sidebar-divider);">
+
                     <!-- Sidebar Tags (global tag navigation) -->
                     <div id="sidebar-tags-container">
                         <button type="button" class="sidebar-tags-header" onclick="SidebarTags.toggle()" aria-expanded="false" title="Toggle tags">

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -92,8 +92,8 @@
 }
 
 .card-header {
-    background: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-secondary) 100%);
-    color: var(--text-on-brand);
+    background-color: var(--surface-card-alt);
+    color: var(--text-primary);
     border-radius: 0.75rem 0.75rem 0 0 !important;
 }
 

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -618,3 +618,17 @@ footer a:hover {
     color: var(--brand-primary-hover);
     text-decoration: underline;
 }
+
+.tag-cloud-toggle {
+    display: inline-block;
+    margin-left: 0.5rem;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-decoration: none;
+}
+
+.tag-cloud-toggle:hover,
+.tag-cloud-toggle:focus {
+    color: var(--md-link);
+    text-decoration: underline;
+}

--- a/src/Memorizer/wwwroot/css/site.css
+++ b/src/Memorizer/wwwroot/css/site.css
@@ -593,3 +593,28 @@ footer a:hover {
     color: #93c5fd;
     border-color: #2d5a8e;
 }
+
+/* =================================================================
+   TAG CLOUD
+   Uses theme variables so light and dark modes are both covered.
+   ================================================================= */
+.tag-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.9rem;
+    line-height: 1.6;
+}
+
+.tag-cloud-item {
+    color: var(--md-link);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.15s ease, opacity 0.15s ease;
+}
+
+.tag-cloud-item:hover,
+.tag-cloud-item:focus {
+    color: var(--brand-primary-hover);
+    text-decoration: underline;
+}

--- a/src/Memorizer/wwwroot/css/workspace-tree.css
+++ b/src/Memorizer/wwwroot/css/workspace-tree.css
@@ -466,3 +466,135 @@
 [data-theme="dark"] .workspace-tree-breadcrumbs {
     background-color: rgba(255, 255, 255, 0.03);
 }
+
+/* =================================================================
+   SIDEBAR TAGS SECTION
+   Collapsible global tag navigation in the sidebar.
+   ================================================================= */
+.sidebar-tags-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 1rem;
+    margin-bottom: 0.25rem;
+    background: transparent;
+    border: none;
+    color: var(--text-on-brand-muted);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    text-align: left;
+    opacity: 0.8;
+    transition: all 0.15s ease;
+}
+
+.sidebar-tags-header:hover {
+    color: var(--text-on-brand);
+    opacity: 1;
+}
+
+.sidebar-tags-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    font-size: 0.65rem;
+    opacity: 0.7;
+    transition: transform 0.2s ease;
+}
+
+.sidebar-tags-toggle.expanded {
+    transform: rotate(90deg);
+}
+
+.sidebar-tags-count {
+    font-size: 0.7rem;
+    background-color: rgba(255, 255, 255, 0.2);
+    color: var(--text-on-brand-muted);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.75rem;
+    min-width: 1.25rem;
+    text-align: center;
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+.sidebar-tags-body {
+    display: none;
+    padding: 0 0.5rem 0.5rem;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.sidebar-tags-body.expanded {
+    display: block;
+}
+
+.sidebar-tags-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    color: var(--text-on-brand-muted);
+    text-decoration: none;
+    border-radius: 0.375rem;
+    margin: 0.125rem 0;
+    transition: all 0.2s ease;
+    font-size: 0.8rem;
+}
+
+.sidebar-tags-item:hover {
+    color: var(--text-on-brand);
+    background-color: var(--surface-overlay);
+}
+
+.sidebar-tags-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sidebar-tags-item .sidebar-tags-count {
+    margin-left: 0;
+}
+
+.sidebar-tags-more {
+    display: block;
+    padding: 0.375rem 0.75rem;
+    color: var(--text-on-brand-muted);
+    text-decoration: none;
+    font-size: 0.75rem;
+    font-style: italic;
+    opacity: 0.8;
+}
+
+.sidebar-tags-more:hover {
+    color: var(--text-on-brand);
+    opacity: 1;
+}
+
+.sidebar-tags-loading,
+.sidebar-tags-empty {
+    color: var(--text-on-brand-muted);
+    font-size: 0.8rem;
+    padding: 0.5rem 0.75rem;
+    opacity: 0.7;
+}
+
+.sidebar-tags-loading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.sidebar-tags-loading .spinner-border {
+    width: 0.875rem;
+    height: 0.875rem;
+    border-width: 0.125rem;
+}

--- a/src/Memorizer/wwwroot/css/workspace-tree.css
+++ b/src/Memorizer/wwwroot/css/workspace-tree.css
@@ -526,42 +526,46 @@
 
 .sidebar-tags-body {
     display: none;
-    padding: 0 0.5rem 0.5rem;
-    max-height: 320px;
-    overflow-y: auto;
+    padding: 0.25rem 0.75rem 0.75rem;
 }
 
 .sidebar-tags-body.expanded {
     display: block;
 }
 
-.sidebar-tags-item {
+.sidebar-tags-pills {
     display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+}
+
+.sidebar-tags-pill {
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.375rem 0.75rem;
-    color: var(--text-on-brand-muted);
-    text-decoration: none;
-    border-radius: 0.375rem;
-    margin: 0.125rem 0;
-    transition: all 0.2s ease;
-    font-size: 0.8rem;
-}
-
-.sidebar-tags-item:hover {
+    gap: 0.375rem;
+    padding: 0.2rem 0.625rem;
+    border-radius: 1rem;
+    background-color: rgba(255, 255, 255, 0.15);
     color: var(--text-on-brand);
-    background-color: var(--surface-overlay);
-}
-
-.sidebar-tags-name {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    text-decoration: none;
+    font-size: 0.75rem;
     white-space: nowrap;
+    transition: all 0.2s ease;
 }
 
-.sidebar-tags-item .sidebar-tags-count {
-    margin-left: 0;
+.sidebar-tags-pill:hover {
+    background-color: var(--surface-overlay);
+    color: var(--text-on-brand);
+}
+
+.sidebar-tags-pill-count {
+    font-size: 0.65rem;
+    line-height: 1;
+    background-color: rgba(255, 255, 255, 0.25);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.75rem;
+    min-width: 1rem;
+    text-align: center;
 }
 
 .sidebar-tags-more {

--- a/src/Memorizer/wwwroot/js/sidebar-tags.js
+++ b/src/Memorizer/wwwroot/js/sidebar-tags.js
@@ -1,0 +1,112 @@
+/**
+ * Sidebar Tags Module
+ * Loads global tag counts and renders a collapsible tag navigation section in the sidebar.
+ */
+const SidebarTags = (function() {
+    const STORAGE_KEY = 'memorizer-sidebar-tags-expanded';
+    const MAX_TAGS = 30;
+    let container = null;
+    let isInitialized = false;
+    let tagCounts = null;
+
+    function getExpanded() {
+        try {
+            return localStorage.getItem(STORAGE_KEY) === 'true';
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function setExpanded(expanded) {
+        try {
+            localStorage.setItem(STORAGE_KEY, expanded ? 'true' : 'false');
+        } catch (e) {
+            // ignore storage errors
+        }
+    }
+
+    function applyExpanded(expanded) {
+        container?.querySelector('.sidebar-tags-toggle')?.classList.toggle('expanded', expanded);
+        container?.querySelector('.sidebar-tags-body')?.classList.toggle('expanded', expanded);
+        container?.querySelector('.sidebar-tags-header')?.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    }
+
+    function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function render() {
+        const body = container.querySelector('.sidebar-tags-body');
+        const total = container.querySelector('#sidebarTagsTotal');
+        if (!body) return;
+
+        if (!tagCounts || tagCounts.length === 0) {
+            body.innerHTML = '<div class="sidebar-tags-empty">No tags yet</div>';
+            if (total) total.style.display = 'none';
+            return;
+        }
+
+        if (total) {
+            total.textContent = tagCounts.length;
+            total.style.display = 'inline-block';
+        }
+
+        const items = tagCounts.slice(0, MAX_TAGS).map(t =>
+            `<a href="/memories?tag=${encodeURIComponent(t.tag)}" class="sidebar-tags-item" title="${escapeHtml(t.tag)} (${t.count})">
+                <span class="sidebar-tags-name">${escapeHtml(t.tag)}</span>
+                <span class="sidebar-tags-count">${t.count}</span>
+            </a>`
+        ).join('');
+
+        const more = tagCounts.length > MAX_TAGS
+            ? `<a href="/memories" class="sidebar-tags-more">View all ${tagCounts.length} tags</a>`
+            : '';
+
+        body.innerHTML = items + more;
+    }
+
+    async function load() {
+        try {
+            const response = await fetch('/api/memory/tags/cloud');
+            if (!response.ok) throw new Error(`Failed to load tags: ${response.status}`);
+            tagCounts = await response.json();
+            render();
+        } catch (e) {
+            console.warn('Failed to load sidebar tags:', e);
+            const body = container?.querySelector('.sidebar-tags-body');
+            if (body) body.innerHTML = '<div class="sidebar-tags-empty">Failed to load</div>';
+        }
+    }
+
+    function toggle() {
+        const expanded = !getExpanded();
+        setExpanded(expanded);
+        applyExpanded(expanded);
+    }
+
+    function init() {
+        if (isInitialized) return;
+        container = document.getElementById('sidebar-tags-container');
+        if (!container) {
+            console.warn('Sidebar tags container not found');
+            return;
+        }
+        isInitialized = true;
+        applyExpanded(getExpanded());
+        load();
+    }
+
+    return {
+        init: init,
+        toggle: toggle,
+        load: load
+    };
+})();
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+    SidebarTags.init();
+});

--- a/src/Memorizer/wwwroot/js/sidebar-tags.js
+++ b/src/Memorizer/wwwroot/js/sidebar-tags.js
@@ -54,10 +54,9 @@ const SidebarTags = (function() {
             total.style.display = 'inline-block';
         }
 
-        const items = tagCounts.slice(0, MAX_TAGS).map(t =>
-            `<a href="/memories?tag=${encodeURIComponent(t.tag)}" class="sidebar-tags-item" title="${escapeHtml(t.tag)} (${t.count})">
-                <span class="sidebar-tags-name">${escapeHtml(t.tag)}</span>
-                <span class="sidebar-tags-count">${t.count}</span>
+        const pills = tagCounts.slice(0, MAX_TAGS).map(t =>
+            `<a href="/memories?tag=${encodeURIComponent(t.tag)}" class="sidebar-tags-pill" title="${escapeHtml(t.tag)} (${t.count})">
+                ${escapeHtml(t.tag)} <span class="sidebar-tags-pill-count">${t.count}</span>
             </a>`
         ).join('');
 
@@ -65,7 +64,7 @@ const SidebarTags = (function() {
             ? `<a href="/memories" class="sidebar-tags-more">View all ${tagCounts.length} tags</a>`
             : '';
 
-        body.innerHTML = items + more;
+        body.innerHTML = `<div class="sidebar-tags-pills">${pills}</div>${more}`;
     }
 
     async function load() {


### PR DESCRIPTION
## Summary

Make the web UI search use **hybrid search** (vector + PostgreSQL full-text via Reciprocal Rank Fusion) by default, as documented in ADR `docs/adr/2026-02-14-hybrid-search-rrf.md`, and add a minimum-similarity control.

### Changes
- `GET /api/memory/search` now defaults to `HybridSearch` via a `method=hybrid|vector` query param; `method=vector` keeps the metadata-embedding path.
- Hybrid results are post-filtered by vector similarity when a threshold is supplied. Default threshold **0.25** (pass `0` to disable). Full-text-only matches (which have no similarity score) are excluded when a threshold is active.
- The `HybridSearch` storage method is **unchanged** (still ignores `minSimilarity` per the ADR), so the MCP `SearchMemories` tool and short-keyword searches keep working.
- UI: a **Hybrid / Vector** toggle plus a **0–100 step-5 slider** for the threshold, with mode-aware defaults (Hybrid 25%, Vector 70%). The sidebar search benefits automatically.

> **Note:** this branch builds on #201 (workspace-page) and its diff includes those changes until #201 merges.

## Related
- https://github.com/netclectic/memorizer/issues/3
