### PR TITLE
Fix canonical URLs for projects and workspaces (singular vs. plural route mismatch)

### DIFF
--- a/src/Memorizer.UnitTests/CanonicalUrlServiceTests.cs
+++ b/src/Memorizer.UnitTests/CanonicalUrlServiceTests.cs
@@ -70,7 +70,9 @@ public class CanonicalUrlServiceTests
     {
         var workspaceId = new WorkspaceId(Guid.Parse("b775bb37-4af5-46fe-ad14-7f6fba7889aa"));
         var url = _configuredService.GetWorkspaceUrl(workspaceId);
-        Assert.Equal("https://memory.testlab.petabridge.net/workspace/b775bb37-4af5-46fe-ad14-7f6fba7889aa", url);
+        // Must use the plural "workspaces" segment to match the web UI route
+        // HomeController: [Route("workspaces/{id:guid}")]
+        Assert.Equal("https://memory.testlab.petabridge.net/workspaces/b775bb37-4af5-46fe-ad14-7f6fba7889aa", url);
     }
 
     [Fact]
@@ -86,7 +88,9 @@ public class CanonicalUrlServiceTests
     {
         var projectId = new ProjectId(Guid.Parse("a1874a6b-8a15-4da6-a413-99bf3249d1e4"));
         var url = _configuredService.GetProjectUrl(projectId);
-        Assert.Equal("https://memory.testlab.petabridge.net/project/a1874a6b-8a15-4da6-a413-99bf3249d1e4", url);
+        // Must use the plural "projects" segment to match the web UI route
+        // HomeController: [Route("projects/{id:guid}")]
+        Assert.Equal("https://memory.testlab.petabridge.net/projects/a1874a6b-8a15-4da6-a413-99bf3249d1e4", url);
     }
 
     [Fact]

--- a/src/Memorizer.UnitTests/Tools/FakeCanonicalUrlService.cs
+++ b/src/Memorizer.UnitTests/Tools/FakeCanonicalUrlService.cs
@@ -24,12 +24,12 @@ internal class FakeCanonicalUrlService : ICanonicalUrlService
     public string? GetWorkspaceUrl(WorkspaceId workspaceId)
     {
         GetWorkspaceUrlCalled = true;
-        return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/workspace/{workspaceId.Value}" : null;
+        return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/workspaces/{workspaceId.Value}" : null;
     }
 
     public string? GetProjectUrl(ProjectId projectId)
     {
         GetProjectUrlCalled = true;
-        return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/project/{projectId.Value}" : null;
+        return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/projects/{projectId.Value}" : null;
     }
 }

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -596,13 +596,13 @@ public class MemoryToolsCanonicalUrlTests
         public string? GetWorkspaceUrl(WorkspaceId workspaceId)
         {
             GetWorkspaceUrlCalled = true;
-            return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/workspace/{workspaceId.Value}" : null;
+            return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/workspaces/{workspaceId.Value}" : null;
         }
 
         public string? GetProjectUrl(ProjectId projectId)
         {
             GetProjectUrlCalled = true;
-            return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/project/{projectId.Value}" : null;
+            return IsConfigured ? $"{BaseUrl.TrimEnd('/')}/projects/{projectId.Value}" : null;
         }
     }
 }

--- a/src/Memorizer.UnitTests/Tools/WorkspaceToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/WorkspaceToolsCanonicalUrlTests.cs
@@ -35,7 +35,7 @@ public class WorkspaceToolsCanonicalUrlTests
 
         // Assert
         Assert.Contains(TestCanonicalUrl, result);
-        Assert.Contains("/workspace/b775bb37-4af5-46fe-ad14-7f6fba7889aa", result);
+        Assert.Contains("/workspaces/b775bb37-4af5-46fe-ad14-7f6fba7889aa", result);
         Assert.True(fakeUrlService.GetWorkspaceUrlCalled);
     }
 
@@ -83,7 +83,7 @@ public class WorkspaceToolsCanonicalUrlTests
 
         // Assert
         Assert.Contains(TestCanonicalUrl, result);
-        Assert.Contains("/workspace/b775bb37-4af5-46fe-ad14-7f6fba7889aa", result);
+        Assert.Contains("/workspaces/b775bb37-4af5-46fe-ad14-7f6fba7889aa", result);
         Assert.True(fakeUrlService.GetWorkspaceUrlCalled);
     }
 
@@ -132,7 +132,7 @@ public class WorkspaceToolsCanonicalUrlTests
 
         // Assert
         Assert.Contains(TestCanonicalUrl, result);
-        Assert.Contains("/project/a1874a6b-8a15-4da6-a413-99bf3249d1e4", result);
+        Assert.Contains("/projects/a1874a6b-8a15-4da6-a413-99bf3249d1e4", result);
         Assert.True(fakeUrlService.GetProjectUrlCalled);
     }
 
@@ -159,7 +159,7 @@ public class WorkspaceToolsCanonicalUrlTests
 
         // Assert
         Assert.Contains(TestCanonicalUrl, result);
-        Assert.Contains("/project/a1874a6b-8a15-4da6-a413-99bf3249d1e4", result);
+        Assert.Contains("/projects/a1874a6b-8a15-4da6-a413-99bf3249d1e4", result);
         Assert.True(fakeUrlService.GetProjectUrlCalled);
     }
 

--- a/src/Memorizer/Services/CanonicalUrlService.cs
+++ b/src/Memorizer/Services/CanonicalUrlService.cs
@@ -37,7 +37,7 @@ public class CanonicalUrlService : ICanonicalUrlService
         if (!IsConfigured)
             return null;
 
-        return $"{BaseUrl.TrimEnd('/')}/workspace/{workspaceId.Value}";
+        return $"{BaseUrl.TrimEnd('/')}/workspaces/{workspaceId.Value}";
     }
 
     /// <inheritdoc />
@@ -46,6 +46,6 @@ public class CanonicalUrlService : ICanonicalUrlService
         if (!IsConfigured)
             return null;
 
-        return $"{BaseUrl.TrimEnd('/')}/project/{projectId.Value}";
+        return $"{BaseUrl.TrimEnd('/')}/projects/{projectId.Value}";
     }
 }


### PR DESCRIPTION
Closes #204.

## Problem

`CanonicalUrlService` generated **singular** path segments for project and workspace links (`/project/{id}`, `/workspace/{id}`), but the web UI (`HomeController`) only registers the **plural** routes `projects/{id:guid}` and `workspaces/{id:guid}`. Every project/workspace link included in MCP tool responses therefore 404'd. Memory links (`/view/{id}`) matched their route and were unaffected.

This has been present since canonical URL support was added (#162, v2.1.0); the plural routes predate it (V2 merge, #133). It is not a deployment/version regression.

## Fix

- `CanonicalUrlService`: emit `/projects/{id}` and `/workspaces/{id}` to match the registered routes.
- Corrected the unit tests, which had codified the singular URLs, and the test doubles (`FakeCanonicalUrlService` + the inline fake in `MemoryToolsCanonicalUrlTests`) so they stay faithful to the real service.

Note: the JSON API endpoints (`/api/project/{id}`, `/api/workspace/{id}`) are correctly singular and unchanged — this only affects the human-facing web UI links.

## Testing

`dotnet test` — 195 passing (the two corrected assertions failed against the pre-fix service, confirming the bug).