### PR TITLE
Relax global.json SDK rollForward to latestMinor

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.102",
-    "rollForward": "patch",
+    "rollForward": "latestMinor",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
## Problem

Local builds fail on machines that have a newer 10.0.x SDK installed but not the exact pinned patch (`10.0.102`). `rollForward: patch` only rolls **up** within the same feature band and never down or across bands, so e.g. a machine with `10.0.101` + `10.0.30x` can't resolve the pin.

## Fix

Set `rollForward: latestMinor` so local development resolves against any newer **10.0.x** SDK while staying on the .NET 10 line.

- **CI is unaffected**: both workflows install the exact pinned version via `actions/setup-dotnet` + `global-json-file`. `rollForward` only governs which locally-installed SDK the `dotnet` muxer selects at runtime.
- **Dependabot continues to own the version pin** — this only changes the roll-forward policy, not the version.
- Verified locally: `dotnet --version` resolves to `10.0.302` and the solution builds.

## Relationship to #189

Dependabot #189 proposes bumping the SDK to an **11.0.100 preview**. `latestMinor` deliberately keeps us on the stable .NET 10 line and avoids silently rolling onto a .NET 11 preview, so this PR supersedes #189, which I'm closing.