### PR TITLE
Pin SSH.NET to 2026.0.0 to fix high-severity advisory (GHSA-q939-rpr3-3284)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,9 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.9.0" />
+    <!-- Security pin: overrides the vulnerable SSH.NET brought in transitively by Testcontainers.
+         SSH.NET <= 2025.1.0 has a high-severity advisory (GHSA-q939-rpr3-3284); fixed in 2026.0.0. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Akka.Hosting" Version="1.5.55.1" />

--- a/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
+++ b/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
@@ -17,6 +17,9 @@
         <PackageReference Include="Npgsql" />
         <PackageReference Include="Pgvector" />
         <PackageReference Include="Testcontainers.PostgreSql" />
+        <!-- Direct reference forces the patched SSH.NET (2026.0.0) over the vulnerable
+             transitive version pulled in by Testcontainers. See GHSA-q939-rpr3-3284. -->
+        <PackageReference Include="SSH.NET" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="Akka.Hosting.TestKit" />


### PR DESCRIPTION
## Problem

CI is red on `dev` (and therefore on every open PR) because of a NuGet audit failure:

```
error NU1903: Package 'SSH.NET' 2025.1.0 has a known high severity vulnerability (GHSA-q939-rpr3-3284)
```

`SSH.NET` is pulled in **transitively** by `Testcontainers.PostgreSql` in the integration test project. Versions `<= 2025.1.0` carry a high-severity advisory (CVSS 7.1 — `ScpClient.Download()` path traversal). With `TreatWarningsAsErrors` and NuGet audit enabled, this turns into a hard build error.

## Fix

Pin `SSH.NET` to the patched **2026.0.0**:
- Add a central `PackageVersion` entry in `Directory.Packages.props`.
- Add a bare `PackageReference` in `Memorizer.IntegrationTests` (the only project with the transitive dependency) so the patched version wins over the vulnerable transitive one.

Follows the repo's CPM conventions (version in `Directory.Packages.props`, no `VersionOverride`).

## Testing

`dotnet build src/Memorizer.IntegrationTests -c Release` — succeeds with 0 errors; the NU1903 audit error is gone.

## Note

This unblocks CI for the other open PRs (#205, #206), whose `pull_request` checks re-evaluate against `dev` once this merges.