### PR TITLE
Bump OpenTelemetry packages to 1.17.0 to fix moderate advisories

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,11 +18,11 @@
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="OllamaSharp" Version="5.4.12" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="pgvector" Version="0.3.2" />
     <PackageVersion Include="Registrator.Net" Version="3.2.4" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />


### PR DESCRIPTION
## Problem

A full vulnerability scan (`dotnet list package --vulnerable --include-transitive`) — run in response to the SSH.NET fix (#207) — surfaced additional advisories in the OpenTelemetry `1.14.0` packages, affecting all three projects (the app references the OTLP exporter directly; the tests get it transitively):

| Package | Advisory | Fixed in |
|---|---|---|
| OpenTelemetry.Api (transitive) | [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) | 1.15.3 |
| OpenTelemetry.Exporter.OpenTelemetryProtocol | [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) (CVE-2026-40182) | 1.15.2 |
| OpenTelemetry.Exporter.OpenTelemetryProtocol | GHSA-mr8r-92fq-pj8p | — |
| OpenTelemetry.Exporter.OpenTelemetryProtocol | GHSA-4625-4j76-fww9 | — |

All Moderate (DoS: unbounded memory allocation in propagation-header parsing and OTLP error-response body reads). With `TreatWarningsAsErrors` + NuGet audit, these become build errors (NU1902) once they reach the restore-time audit database — the same failure mode as the SSH.NET issue.

## Fix

Bump all `OpenTelemetry.*` packages to the latest stable **1.17.0**, which clears every flagged advisory with margin (and covers the two advisories whose exact fix version isn't stated).

## Testing

- `dotnet build src/Memorizer` (Release) — compiles, 0 errors.
- `dotnet list package --vulnerable --include-transitive` — **no vulnerable packages** in any of the three projects.