### PR TITLE
Fix connection-pool self-deadlock behind flaky GetMany stress test

### DIFF
--- a/src/Memorizer.IntegrationTests/PostgresContainerTests.cs
+++ b/src/Memorizer.IntegrationTests/PostgresContainerTests.cs
@@ -516,12 +516,18 @@ public class IntegrationTests : TestKit
             }));
         }
         
-        // Wait for all tasks to complete - should not hang due to infinite recursion
+        // Wait for all tasks to complete - should not hang due to infinite recursion or a
+        // connection-pool deadlock.
+        var allTasks = Task.WhenAll(tasks);
         var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30));
-        var completedTask = await Task.WhenAny(Task.WhenAll(tasks), timeoutTask);
-        
-        Assert.True(completedTask != timeoutTask, 
+        var completedTask = await Task.WhenAny(allTasks, timeoutTask);
+
+        Assert.True(completedTask != timeoutTask,
             "Stress test timed out - possible infinite recursion or connection leak");
+
+        // Observe the worker tasks so a fault (e.g. connection-pool exhaustion) fails the test
+        // loudly instead of being silently swallowed by Task.WhenAny.
+        await allTasks;
     }
 
     [Fact]

--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -713,20 +713,25 @@ public class Storage : IStorage
             FROM memories
             WHERE id = @id";
 
-        await using NpgsqlCommand cmd = new(sql, connection);
-        cmd.Parameters.AddWithValue("id", id.Value);
-
-        await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-
-        if (await reader.ReadAsync(cancellationToken))
+        Memorizer.Models.Memory? memory = null;
+        // Read the memory, then dispose the reader before loading relationships on the SAME
+        // connection. Npgsql has no MARS, so the reader must be closed first; reusing this
+        // connection (instead of opening a second one) keeps the call to a single pooled
+        // connection and prevents hold-and-wait pool deadlock under concurrency.
+        await using (NpgsqlCommand cmd = new(sql, connection))
         {
-            var memory = ReadMemoryFromReader(reader, withSimilarity: false);
-            // Fetch relationships for this memory
-            memory.Relationships = await GetRelationships(memory.Id, type: null, includeArchivedTargets: false, cancellationToken);
-            return memory;
+            cmd.Parameters.AddWithValue("id", id.Value);
+            await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+                memory = ReadMemoryFromReader(reader, withSimilarity: false);
         }
 
-        return null;
+        if (memory is null)
+            return null;
+
+        // Fetch relationships for this memory on the same connection.
+        memory.Relationships = await GetRelationships(connection, memory.Id, type: null, includeArchivedTargets: false, cancellationToken);
+        return memory;
     }
 
     public async Task<bool> Delete(
@@ -752,21 +757,27 @@ public class Storage : IStorage
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence, created_at, updated_at, title, current_version, owner_type, owner_id, archetype
             FROM memories
             WHERE id = ANY(@ids)";
-        await using NpgsqlCommand cmd = new(sql, connection);
-        cmd.Parameters.AddWithValue("ids", ids.Select(id => id.Value).ToArray());
         List<Memorizer.Models.Memory> memories = [];
         List<MemoryId> memoryIds = new();
-        await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-        while (await reader.ReadAsync(cancellationToken))
+        // Read the memories first, then fully dispose the reader/command before issuing the
+        // relationship query on the SAME connection. Npgsql has no MARS, so the reader must be
+        // closed first; reusing this connection (instead of opening a second one) keeps the call
+        // to a single pooled connection and prevents hold-and-wait pool deadlock under concurrency.
+        await using (NpgsqlCommand cmd = new(sql, connection))
         {
-            var memory = ReadMemoryFromReader(reader, withSimilarity: false);
-            memories.Add(memory);
-            memoryIds.Add(memory.Id);
+            cmd.Parameters.AddWithValue("ids", ids.Select(id => id.Value).ToArray());
+            await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var memory = ReadMemoryFromReader(reader, withSimilarity: false);
+                memories.Add(memory);
+                memoryIds.Add(memory.Id);
+            }
         }
-        // Batch fetch relationships for all found memories - now safe from infinite recursion!
+        // Batch fetch relationships for all found memories on the same connection - safe from recursion.
         if (memoryIds.Count > 0)
         {
-            var relationships = await GetRelationshipsForMany(memoryIds, cancellationToken);
+            var relationships = await GetRelationshipsForMany(connection, memoryIds, cancellationToken);
             var relLookup = relationships.GroupBy(r => r.FromMemoryId).ToDictionary(g => g.Key, g => g.ToList());
             foreach (var memory in memories)
             {
@@ -813,7 +824,14 @@ public class Storage : IStorage
     public async Task<List<MemoryRelationship>> GetRelationships(MemoryId memoryId, string? type = null, bool includeArchivedTargets = false, CancellationToken cancellationToken = default)
     {
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        return await GetRelationships(connection, memoryId, type, includeArchivedTargets, cancellationToken);
+    }
 
+    // Overload that reuses an already-open connection instead of checking out a second one from the
+    // pool. Callers that already hold a connection (e.g. Get) must dispose any open reader before
+    // calling this, since Npgsql has no MARS.
+    private async Task<List<MemoryRelationship>> GetRelationships(NpgsqlConnection connection, MemoryId memoryId, string? type, bool includeArchivedTargets, CancellationToken cancellationToken)
+    {
         // Single query with JOIN to get relationships and related memory titles/types - NO RECURSION!
         // Optionally filter out relationships pointing to archived memories
         string sql = $@"
@@ -1118,7 +1136,14 @@ public class Storage : IStorage
     private async Task<List<MemoryRelationship>> GetRelationshipsForMany(IEnumerable<MemoryId> memoryIds, CancellationToken cancellationToken, bool includeArchivedTargets = false)
     {
         await using NpgsqlConnection connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        return await GetRelationshipsForMany(connection, memoryIds, cancellationToken, includeArchivedTargets);
+    }
 
+    // Overload that reuses an already-open connection instead of checking out a second one from the
+    // pool. Callers that already hold a connection (e.g. GetMany) must dispose any open reader before
+    // calling this, since Npgsql has no MARS.
+    private async Task<List<MemoryRelationship>> GetRelationshipsForMany(NpgsqlConnection connection, IEnumerable<MemoryId> memoryIds, CancellationToken cancellationToken, bool includeArchivedTargets = false)
+    {
         // Single query to get relationships with related memory titles/types - NO RECURSION!
         // Optionally filter out relationships pointing to archived memories
         string sql = $@"


### PR DESCRIPTION
## Problem

`Stress_Test_Memory_Relationships_Should_Not_Leak_Connections` (`PostgresContainerTests.cs`) is flaky on CI — it intermittently trips its hard 30s timeout ("possible infinite recursion or connection leak") and passes on re-run. It only started running on CI once the build was un-broken (SSH.NET fix, #207); it turns out to expose a **real latent connection-pool self-deadlock**, not just a tight timeout.

## Root cause

Diagnosed via the `analyze-racy-test` specialists. `Get` and `GetMany` each:
1. open a pooled connection and hold it open (reader not yet disposed) for the memories query, then
2. open a **second** pooled connection to load relationships (`GetRelationships` / `GetRelationshipsForMany`).

So every call peaks at **2** concurrent pool connections. The integration fixture caps the pool at `Maximum Pool Size=10` (`IntegrationTestFixture.cs:20`) and the stress test runs **20** concurrent callers. Once ≥10 callers hold their first connection, the pool is empty and every one blocks waiting for a second that can never free — a classic **hold-and-wait self-deadlock**, broken only when Npgsql's 15s acquisition timeout fires. The dead-embedding-server retry storm (EAGAIN spam from the background init service) is the *trigger*: it inflates the ThreadPool so more of the 20 tasks run at once and tip past the ceiling. On quiet runs the work serializes and passes — hence the flakiness.

## Fix

Reuse the already-open connection for the relationship query so each `Get`/`GetMany` holds **exactly one** pooled connection — making hold-and-wait impossible (20 callers simply drain 10-at-a-time with guaranteed forward progress). The reader is disposed before the relationship command runs on the same connection (Npgsql has no MARS). `GetRelationships` and `GetRelationshipsForMany` each gain a private overload that accepts an existing connection; the public/parameterless versions still open their own connection for other callers.

Also hardens the test guard: it previously used `Task.WhenAny(Task.WhenAll(tasks), timeout)` **without observing the worker tasks**, so a pool-exhaustion fault completing under 30s was silently swallowed (the test could go green while a deadlock actually occurred). It now `await`s the worker tasks so faults fail loudly.

Deliberately **not** bumping the pool size or the 30s timeout — those would mask the deadlock.

## Testing

- `dotnet build` (Release) — 0 errors; 195 unit tests pass.
- Ran the stress test locally against real Postgres + Ollama Testcontainers — **passes in ~0.4s** (vs the 30s deadlock timeout it used to hit).

## Scoped follow-up (not in this PR)

The same open-a-second-connection pattern remains in five other `GetRelationshipsForMany` callers (search / filter / paged-query paths) and one other `GetRelationships` caller. They're lower-risk (production pool is larger than the test's 10) and are left as a deliberate follow-up rather than expanding this fix's blast radius.
