### PR TITLE
Reuse pooled connection in remaining relationship-loading query paths

### DIFF
--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -655,19 +655,23 @@ public class Storage : IStorage
 
         List<Memorizer.Models.Memory> memories = [];
         List<MemoryId> memoryIds = new();
-        await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-
-        while (await reader.ReadAsync(cancellationToken))
+        // Read the matched memories first, then dispose the reader before the relationship query
+        // runs on the SAME connection (Npgsql has no MARS), keeping this call to a single pooled
+        // connection and preventing hold-and-wait pool deadlock under concurrency.
+        await using (NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken))
         {
-            var memory = ReadMemoryFromReader(reader, withSimilarity: true);
-            memories.Add(memory);
-            memoryIds.Add(memory.Id);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var memory = ReadMemoryFromReader(reader, withSimilarity: true);
+                memories.Add(memory);
+                memoryIds.Add(memory.Id);
+            }
         }
 
-        // Batch fetch relationships for all found memories
+        // Batch fetch relationships for all found memories on the same connection
         if (memoryIds.Count > 0)
         {
-            var relationships = await GetRelationshipsForMany(memoryIds, cancellationToken);
+            var relationships = await GetRelationshipsForMany(connection, memoryIds, cancellationToken);
             var relLookup = relationships.GroupBy(r => r.FromMemoryId).ToDictionary(g => g.Key, g => g.ToList());
             foreach (var memory in memories)
             {
@@ -975,15 +979,18 @@ public class Storage : IStorage
         cmd.Parameters.AddWithValue("offset", (page - 1) * pageSize);
 
         List<Memorizer.Models.Memory> memories = [];
-        await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-
-        while (await reader.ReadAsync(cancellationToken))
+        // Read all rows and dispose the reader before loading relationships, so the relationship
+        // queries reuse THIS connection instead of each opening a second pooled connection while
+        // the reader is held open (which risks pool exhaustion/deadlock under concurrency).
+        await using (NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken))
         {
-            var memory = ReadMemoryFromReader(reader, withSimilarity: false);
-            // Fetch relationships for this memory
-            memory.Relationships = await GetRelationships(memory.Id, type: null, includeArchivedTargets: false, cancellationToken);
-            memories.Add(memory);
+            while (await reader.ReadAsync(cancellationToken))
+                memories.Add(ReadMemoryFromReader(reader, withSimilarity: false));
         }
+
+        // Fetch relationships for each memory on the same connection.
+        foreach (var memory in memories)
+            memory.Relationships = await GetRelationships(connection, memory.Id, type: null, includeArchivedTargets: false, cancellationToken);
 
         return (memories, (int)totalCount);
     }
@@ -1297,19 +1304,23 @@ public class Storage : IStorage
 
         List<Memorizer.Models.Memory> memories = [];
         List<MemoryId> memoryIds = new();
-        await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-
-        while (await reader.ReadAsync(cancellationToken))
+        // Read the matched memories first, then dispose the reader before the relationship query
+        // runs on the SAME connection (Npgsql has no MARS), keeping this call to a single pooled
+        // connection and preventing hold-and-wait pool deadlock under concurrency.
+        await using (NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken))
         {
-            var memory = ReadMemoryFromReader(reader, withSimilarity: true);
-            memories.Add(memory);
-            memoryIds.Add(memory.Id);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var memory = ReadMemoryFromReader(reader, withSimilarity: true);
+                memories.Add(memory);
+                memoryIds.Add(memory.Id);
+            }
         }
 
-        // Batch fetch relationships for all found memories
+        // Batch fetch relationships for all found memories on the same connection
         if (memoryIds.Count > 0)
         {
-            var relationships = await GetRelationshipsForMany(memoryIds, cancellationToken);
+            var relationships = await GetRelationshipsForMany(connection, memoryIds, cancellationToken);
             var relLookup = relationships.GroupBy(r => r.FromMemoryId).ToDictionary(g => g.Key, g => g.ToList());
             foreach (var memory in memories)
             {
@@ -1416,19 +1427,23 @@ public class Storage : IStorage
 
         List<Memorizer.Models.Memory> memories = [];
         List<MemoryId> memoryIds = new();
-        await using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-
-        while (await reader.ReadAsync(cancellationToken))
+        // Read the matched memories first, then dispose the reader before the relationship query
+        // runs on the SAME connection (Npgsql has no MARS), keeping this call to a single pooled
+        // connection and preventing hold-and-wait pool deadlock under concurrency.
+        await using (NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken))
         {
-            var memory = ReadMemoryFromReader(reader, withSimilarity: true);
-            memories.Add(memory);
-            memoryIds.Add(memory.Id);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var memory = ReadMemoryFromReader(reader, withSimilarity: true);
+                memories.Add(memory);
+                memoryIds.Add(memory.Id);
+            }
         }
 
-        // Batch fetch relationships for all found memories
+        // Batch fetch relationships for all found memories on the same connection
         if (memoryIds.Count > 0)
         {
-            var relationships = await GetRelationshipsForMany(memoryIds, cancellationToken);
+            var relationships = await GetRelationshipsForMany(connection, memoryIds, cancellationToken);
             var relLookup = relationships.GroupBy(r => r.FromMemoryId).ToDictionary(g => g.Key, g => g.ToList());
             foreach (var memory in memories)
             {
@@ -1694,10 +1709,11 @@ public class Storage : IStorage
             memoryIds.Add(memory.Id);
         }
 
-        // Batch fetch relationships for all found memories
+        // Batch fetch relationships for all found memories on the same connection (no reader is
+        // open here; the leg queries above ran in their own scoped blocks).
         if (memoryIds.Count > 0)
         {
-            var relationships = await GetRelationshipsForMany(memoryIds, cancellationToken);
+            var relationships = await GetRelationshipsForMany(connection, memoryIds, cancellationToken);
             var relLookup = relationships.GroupBy(r => r.FromMemoryId).ToDictionary(g => g.Key, g => g.ToList());
             foreach (var memory in memories)
             {
@@ -1741,19 +1757,22 @@ public class Storage : IStorage
 
         var memories = new List<Memorizer.Models.Memory>();
         var memoryIds = new List<MemoryId>();
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-
-        while (await reader.ReadAsync(cancellationToken))
+        // Read the memories first, then dispose the reader before the relationship query runs on
+        // the SAME connection (Npgsql has no MARS), keeping this call to a single pooled connection.
+        await using (var reader = await command.ExecuteReaderAsync(cancellationToken))
         {
-            var memory = ReadMemoryFromReader(reader, withSimilarity: false);
-            memories.Add(memory);
-            memoryIds.Add(memory.Id);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var memory = ReadMemoryFromReader(reader, withSimilarity: false);
+                memories.Add(memory);
+                memoryIds.Add(memory.Id);
+            }
         }
 
-        // Batch fetch relationships for all found memories
+        // Batch fetch relationships for all found memories on the same connection
         if (memoryIds.Count > 0)
         {
-            var relationships = await GetRelationshipsForMany(memoryIds, cancellationToken);
+            var relationships = await GetRelationshipsForMany(connection, memoryIds, cancellationToken);
             var relLookup = relationships.GroupBy(r => r.FromMemoryId).ToDictionary(g => g.Key, g => g.ToList());
             foreach (var memory in memories)
             {


### PR DESCRIPTION
## Summary

Follow-up to #209 (which fixed `Get`/`GetMany`). The same two-connection pattern — hold a pooled connection open (usually with the memories reader still open) while `GetRelationships`/`GetRelationshipsForMany` opens a **second** connection — remained in six other query methods. Under enough concurrency against a small pool, each can self-deadlock the same way the `GetMany` stress test did. This finishes the job so the whole class of bug is gone.

## Methods fixed

| Method | Before | After |
|--------|--------|-------|
| `Search` | reader held open → 2nd connection | reader disposed, reuse connection |
| `SearchWithFullEmbedding` | reader held open → 2nd connection | reader disposed, reuse connection |
| `SearchWithMetadataEmbedding` | reader held open → 2nd connection | reader disposed, reuse connection |
| `GetMemoriesWithoutMetadataEmbeddings` | reader held open → 2nd connection | reader disposed, reuse connection |
| `GetMemoriesPaginated` | **N+1**: single `GetRelationships` per row *inside* the open reader loop | read all rows first, then load relationships on the same connection |
| `HybridSearch` | no open reader, but leg connection held open while a 2nd was opened | reuse the leg connection |

All reuse the connection-accepting overloads of `GetRelationships`/`GetRelationshipsForMany` added in #209, so every call now holds **exactly one** pooled connection.

## Behavior

No public API or behavior change. In particular, `GetMemoriesPaginated` keeps its per-memory `GetRelationships` call (which populates the relationship `Score` that the batched loader does not select) — it's just moved out of the open-reader loop and onto the shared connection, rather than switched to the batched loader.

## Testing

- `dotnet build` (Release) — 0 errors; 195 unit tests pass.
- Full integration suite run locally against real Postgres + Ollama Testcontainers (covers `Search*`, `HybridSearch`, `GetMemoriesPaginated`, and the metadata-embedding path).

With this, the connection-pool self-deadlock pattern is eliminated across all `IStorage` read paths.
