### PR TITLE
Upgrade Model Context Protocol SDK to 2.2.0 (stateless) + MCP endpoint tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <PropertyGroup Label="SharedVersions">
     <MsftVersion>10.0.0</MsftVersion>
+    <!-- All ModelContextProtocol.* packages move together; bump here to upgrade the MCP SDK. -->
+    <McpVersion>2.2.0</McpVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
@@ -14,8 +16,9 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="$(MsftVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MsftVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MsftVersion)" />
-    <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
+    <PackageVersion Include="ModelContextProtocol" Version="$(McpVersion)" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="$(McpVersion)" />
+    <PackageVersion Include="ModelContextProtocol.Core" Version="$(McpVersion)" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="OllamaSharp" Version="5.4.12" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />

--- a/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
@@ -1,0 +1,99 @@
+using Memorizer.IntegrationTests.Mcp;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Xunit.Abstractions;
+
+namespace Memorizer.IntegrationTests;
+
+/// <summary>
+/// End-to-end tests for the MCP server surface. Boots the real Memorizer app
+/// in-process via <see cref="WebApplicationFactory{TEntryPoint}"/> (pointed at
+/// the shared Postgres + Ollama Testcontainers) and drives it with the SDK MCP
+/// client over the Streamable HTTP transport - exercising the same code path a
+/// real MCP client uses, including the stateless-HTTP handshake.
+/// </summary>
+[Collection(nameof(IntegrationTestCollection))]
+public sealed class McpServerTests : IAsyncLifetime
+{
+    private readonly IntegrationTestFixture _fixture;
+    private readonly ITestOutputHelper _output;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public McpServerTests(IntegrationTestFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    public Task InitializeAsync()
+    {
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                // Highest-precedence config, so the app connects to the test containers.
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["ConnectionStrings:Storage"] = _fixture.PostgresConnectionString,
+                        ["Embeddings:ApiUrl"] = _fixture.OllamaApiUrl,
+                        ["Embeddings:Model"] = "all-minilm",
+                    });
+                });
+            });
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Task<McpTestClient> ConnectAsync(CancellationToken ct) =>
+        McpTestClient.ConnectAsync(_factory.CreateClient(), cancellationToken: ct);
+
+    [Fact]
+    public async Task Server_advertises_memory_and_workspace_tools()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        var tools = await mcp.Client.ListToolsAsync(cancellationToken: cts.Token);
+        var names = tools.Select(t => t.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        _output.WriteLine($"Advertised tools ({names.Count}): {string.Join(", ", names.OrderBy(n => n))}");
+
+        Assert.NotEmpty(tools);
+        // A representative slice of the memory + workspace tool surface. The SDK advertises
+        // tools in snake_case (derived from the [McpServerTool] method names).
+        Assert.Contains("store", names);
+        Assert.Contains("search_memories", names);
+        Assert.Contains("get_workspace", names);
+        Assert.Contains("get_project_context", names);
+    }
+
+    [Fact]
+    public async Task Stateless_server_handles_independent_connections()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+
+        // Two independent handshakes against the stateless server. Each connection is a
+        // separate client with no shared server-side session; both must succeed on their own.
+        await using (var first = await ConnectAsync(cts.Token))
+        {
+            var result = await first.Client.CallToolAsync(
+                "get_workspace",
+                new Dictionary<string, object?>(),
+                cancellationToken: cts.Token);
+
+            Assert.NotEqual(true, result.IsError);
+            Assert.NotEmpty(result.Content);
+        }
+
+        await using (var second = await ConnectAsync(cts.Token))
+        {
+            var tools = await second.Client.ListToolsAsync(cancellationToken: cts.Token);
+            Assert.NotEmpty(tools);
+        }
+    }
+}

--- a/src/Memorizer.IntegrationTests/Mcp/McpTestClient.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpTestClient.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Client;
+
+namespace Memorizer.IntegrationTests.Mcp;
+
+/// <summary>
+/// Lightweight, programmable MCP client for integration tests. Connects to a
+/// Memorizer MCP endpoint over the SDK's Streamable HTTP transport using a
+/// caller-supplied <see cref="HttpClient"/> (e.g. one from
+/// <c>WebApplicationFactory</c>, so the whole exchange runs in-process).
+///
+/// Intentionally minimal - no OAuth, catalog subscriptions, protocol-version
+/// fallback, or session management - just enough to exercise the server end to
+/// end. The full-featured client lives elsewhere; this is the thin harness.
+/// </summary>
+public sealed class McpTestClient : IAsyncDisposable
+{
+    /// <summary>The underlying SDK client, for tool discovery and invocation.</summary>
+    public McpClient Client { get; }
+
+    private McpTestClient(McpClient client) => Client = client;
+
+    /// <summary>
+    /// Connect to <paramref name="endpoint"/> on the server behind
+    /// <paramref name="httpClient"/> and complete the MCP initialize handshake.
+    /// </summary>
+    public static async Task<McpTestClient> ConnectAsync(
+        HttpClient httpClient,
+        string endpoint = "/mcp",
+        CancellationToken cancellationToken = default)
+    {
+        var baseAddress = httpClient.BaseAddress ?? new Uri("http://localhost/");
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri(baseAddress, endpoint),
+                // Memorizer serves stateless Streamable HTTP; pin the transport to it so the
+                // client does not first probe for a legacy SSE endpoint that does not exist.
+                TransportMode = HttpTransportMode.StreamableHttp,
+            },
+            httpClient,
+            NullLoggerFactory.Instance,
+            ownsHttpClient: true);
+
+        var client = await McpClient.CreateAsync(transport, null, NullLoggerFactory.Instance, cancellationToken);
+        return new McpTestClient(client);
+    }
+
+    public ValueTask DisposeAsync() => Client.DisposeAsync();
+}

--- a/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
+++ b/src/Memorizer.IntegrationTests/Memorizer.IntegrationTests.csproj
@@ -32,6 +32,7 @@
     <ItemGroup>
       <PackageReference Include="Akka.Persistence.Sql.Hosting" />
       <PackageReference Include="ModelContextProtocol.AspNetCore" />
+      <PackageReference Include="ModelContextProtocol.Core" />
       <PackageReference Include="OllamaSharp" />
         <ProjectReference Include="..\Memorizer\Memorizer.csproj" />
     </ItemGroup>

--- a/src/Memorizer/Program.cs
+++ b/src/Memorizer/Program.cs
@@ -148,3 +148,6 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
+
+// Exposed so integration tests can boot the app in-process via WebApplicationFactory<Program>.
+public partial class Program;


### PR DESCRIPTION
## Summary

Upgrades the Model Context Protocol SDK from `0.4.0-preview.3` to the stable **`2.2.0`**, keeps the server in **stateless** Streamable HTTP mode, and adds the runtime MCP-endpoint coverage the repo was missing — via a small reusable programmable client.

## Changes

- **SDK → 2.2.0.** `ModelContextProtocol` + `ModelContextProtocol.AspNetCore` bumped; `ModelContextProtocol.Core` added for the client API. The server wiring — `AddMcpServer().WithHttpTransport(o => o.Stateless = true).WithTools<MemoryTools>().WithTools<WorkspaceTools>()`, `MapMcp("/mcp")`, and the `[McpServerTool]` attributes — **compiles unchanged**. No breaking API changes for our usage.
- **Stateless mode** (`Program.cs`) retained and now covered by a test.
- **Shared version variable.** All `ModelContextProtocol.*` versions now use a single `$(McpVersion)` MSBuild property (next to `MsftVersion`), so they always move together on the next bump.
- **`McpTestClient`** (new): a ~40-line reusable, programmable MCP client over the SDK's `HttpClientTransport` + `McpClient`, taking a caller-supplied `HttpClient`. Deliberately minimal — no OAuth, catalog subscriptions, or session management.
- **`McpServerTests`** (new): boots the real app in-process with `WebApplicationFactory<Program>` (against the shared Postgres + Ollama Testcontainers) and drives it with the SDK client:
  - asserts the advertised tool surface (22 tools; a representative slice: `store`, `search_memories`, `get_workspace`, `get_project_context`);
  - exercises **two independent stateless connections** end to end, including a live `get_workspace` tool call.
- `Program` made `public partial` so the test host can reference it.

## Tool naming: no change

2.2.0 advertises tools in `snake_case` (`store`, `search_memories`, `get_workspace`, …). This is the **same** convention the server already used before the upgrade, so no MCP client sees a renamed tool. (MCP clients discover tools dynamically per session regardless.)

## Testing

- `dotnet build` (Release) — 0 errors; 195 unit tests pass.
- New `McpServerTests` — **2/2 pass** against live Postgres + Ollama containers, connecting with the real SDK client over Streamable HTTP.
