### PR TITLE
Expose MCP prompts for correct Memorizer usage (Simplified Technical English)

### DIFF
--- a/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
@@ -1,6 +1,7 @@
 using Memorizer.IntegrationTests.Mcp;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using ModelContextProtocol.Protocol;
 using Xunit.Abstractions;
 
 namespace Memorizer.IntegrationTests;
@@ -95,5 +96,31 @@ public sealed class McpServerTests : IAsyncLifetime
             var tools = await second.Client.ListToolsAsync(cancellationToken: cts.Token);
             Assert.NotEmpty(tools);
         }
+    }
+
+    [Fact]
+    public async Task Server_advertises_usage_prompts()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        var prompts = await mcp.Client.ListPromptsAsync(cancellationToken: cts.Token);
+        var names = prompts.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        _output.WriteLine($"Advertised prompts ({names.Count}): {string.Join(", ", names.OrderBy(n => n))}");
+
+        Assert.Contains("memorizer_overview", names);
+        Assert.Contains("store_memory", names);
+        Assert.Contains("find_context", names);
+
+        // Fetch a parameterized prompt and confirm it renders the argument and the tool guidance.
+        var result = await mcp.Client.GetPromptAsync(
+            "find_context",
+            new Dictionary<string, object?> { ["topic"] = "database pooling" },
+            cancellationToken: cts.Token);
+
+        Assert.NotEmpty(result.Messages);
+        var text = string.Join("\n", result.Messages.Select(m => (m.Content as TextContentBlock)?.Text ?? ""));
+        Assert.Contains("database pooling", text);
+        Assert.Contains("search_memories", text);
     }
 }

--- a/src/Memorizer/Program.cs
+++ b/src/Memorizer/Program.cs
@@ -43,7 +43,8 @@ builder.Services.AddMemorizerOtel();
 builder.Services.AddMcpServer()
     .WithHttpTransport(options => options.Stateless = true)
     .WithTools<MemoryTools>()
-    .WithTools<WorkspaceTools>();
+    .WithTools<WorkspaceTools>()
+    .WithPrompts<MemorizerPrompts>();
 
 // Add MVC support for web UI
 builder.Services.AddControllersWithViews()

--- a/src/Memorizer/Prompts/MemorizerPrompts.cs
+++ b/src/Memorizer/Prompts/MemorizerPrompts.cs
@@ -1,0 +1,110 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace PostgMem.Tools;
+
+/// <summary>
+/// MCP prompts that teach a client the correct way to use Memorizer.
+///
+/// The prompt bodies are written in Simplified Technical English (ASD-STE100):
+/// short sentences, the imperative mood, active voice, one instruction per
+/// sentence, and a small, consistent vocabulary.
+/// </summary>
+[McpServerPromptType]
+public class MemorizerPrompts
+{
+    [McpServerPrompt(Name = "memorizer_overview", Title = "How to use Memorizer"),
+     Description("Explain the correct way to use Memorizer, including its structure and rules.")]
+    public string MemorizerOverview() =>
+        """
+        Memorizer is your long-term memory. It keeps memories between sessions.
+
+        Memorizer has three levels:
+        1. A workspace is a top-level area. Examples: Engineering, Sales.
+        2. A project is inside a workspace. A project has a goal.
+        3. A memory is a fact, a note, or a decision. A memory belongs to a project or a workspace.
+
+        Obey these rules:
+        - Search before you store. Do not make duplicate memories.
+        - Give each memory a short, clear title.
+        - Add two or more tags to each memory.
+        - Put each memory in the correct project or workspace.
+        - Load related memories before you answer.
+        - Update a memory when the facts change. Do not add a second memory for the same fact.
+        """;
+
+    [McpServerPrompt(Name = "store_memory", Title = "Store a memory correctly"),
+     Description("Give the correct steps to store a new memory without making duplicates.")]
+    public string StoreMemory(
+        [Description("Optional summary of the fact or note to store.")] string? content = null) =>
+        $"""
+        Do these steps to store a memory{(string.IsNullOrWhiteSpace(content) ? "" : $" about: {content}")}.
+
+        1. Search for related memories first. Use the search_memories tool.
+        2. If a related memory exists, update it with the edit tool. Then stop.
+        3. If no related memory exists, continue.
+        4. Choose the owner. Use a project for work items. Use a workspace for general facts.
+        5. Write a short, clear title.
+        6. Add two or more tags.
+        7. Store the memory with the store tool.
+        8. If the memory relates to another memory, link them with the create_reference tool.
+        """;
+
+    [McpServerPrompt(Name = "find_context", Title = "Find context before you answer"),
+     Description("Give the correct steps to find and load memories before you answer a question.")]
+    public string FindContext(
+        [Description("The subject of the question.")] string topic) =>
+        $"""
+        Do these steps before you answer a question about {topic}.
+
+        1. Search for memories with the search_memories tool. Use "{topic}" as the query.
+        2. Read the top results.
+        3. Load the full text of the useful memories. Use the get tool or the get_many tool.
+        4. If the question is about a project, load the project context. Use the get_project_context tool.
+        5. Use the memories in your answer.
+        6. If you find no memory, tell the user. Then answer from general knowledge.
+        """;
+
+    [McpServerPrompt(Name = "review_project", Title = "Review a project before you work"),
+     Description("Give the correct steps to load a project's context before you work on it.")]
+    public string ReviewProject(
+        [Description("The name or ID of the project.")] string project) =>
+        $"""
+        Do these steps before you work on {project}.
+
+        1. Get the project context with the get_project_context tool.
+        2. Read the goal and the status.
+        3. Read the recent memories in the project.
+        4. Note the open questions and the decisions.
+        5. Use this context in your work.
+        6. Store new decisions as memories in the project.
+        """;
+
+    [McpServerPrompt(Name = "organize_memory", Title = "Choose the correct place for a memory"),
+     Description("Give the correct steps to choose the workspace and project for a memory.")]
+    public string OrganizeMemory() =>
+        """
+        Do these steps to place a memory.
+
+        1. List the workspaces with the get_workspace tool.
+        2. Choose the workspace that matches the subject.
+        3. If no workspace matches, create one with the create_workspace tool. Use a clear name.
+        4. Look for a project in the workspace. Use the get_workspace tool with the workspace ID.
+        5. If a project matches the work, use that project.
+        6. If no project matches, keep the memory at the workspace level.
+        7. Do not use the Unfiled workspace if a better place exists.
+        """;
+
+    [McpServerPrompt(Name = "maintain_memory", Title = "Keep memories correct and current"),
+     Description("Give the correct steps to keep memories correct, current, and clean.")]
+    public string MaintainMemory() =>
+        """
+        Do these steps to keep memories correct.
+
+        1. When facts change, edit the memory with the edit tool. Do not make a new memory.
+        2. When a memory is old or not useful, archive it with the archive_memory tool.
+        3. Do not delete a memory unless it is a mistake. Archive is safer than delete.
+        4. To restore an archived memory, use the restore_memory tool.
+        5. To undo a bad change, revert the memory to an earlier version with the revert_to_version tool.
+        """;
+}


### PR DESCRIPTION
## Summary

Exposes MCP **prompts** that teach a client the correct way to drive Memorizer. Builds on the 2.2.0 SDK upgrade (#211) using the same `[McpServerPrompt]` / `.WithPrompts<>()` pattern as the tools.

## Prompts (all in Simplified Technical English / ASD-STE100)

| Name | Purpose | Args |
|------|---------|------|
| `memorizer_overview` | The structure (workspace → project → memory) and the rules | — |
| `store_memory` | Search-first capture, no duplicates | `content?` |
| `find_context` | Load memories before you answer | `topic` |
| `review_project` | Load project context before you work | `project` |
| `organize_memory` | Choose the correct workspace / project | — |
| `maintain_memory` | Edit / archive / restore / revert instead of duplicating | — |

The bodies use short imperative sentences, active voice, one instruction per sentence, and a small consistent vocabulary. Prompt names use `snake_case` to match the tool naming already in use.

## Wiring

`Program.cs`: `AddMcpServer()...WithPrompts<MemorizerPrompts>()` alongside the tool registrations. `MemorizerPrompts` lives in `PostgMem.Tools` next to `MemoryTools`/`WorkspaceTools`.

## Testing

- `dotnet build` (Release) — 0 errors.
- `McpServerTests` (3/3 pass against live Postgres + Ollama Testcontainers): the new prompts test lists the prompts and fetches the parameterized `find_context` prompt, asserting the response renders the `{topic}` argument and the `search_memories` guidance.
