### PR TITLE
Add start_project prompt and workspace-tree MCP resource

### DIFF
--- a/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
@@ -111,6 +111,7 @@ public sealed class McpServerTests : IAsyncLifetime
         Assert.Contains("memorizer_overview", names);
         Assert.Contains("store_memory", names);
         Assert.Contains("find_context", names);
+        Assert.Contains("start_project", names);
 
         // Fetch a parameterized prompt and confirm it renders the argument and the tool guidance.
         var result = await mcp.Client.GetPromptAsync(
@@ -122,5 +123,30 @@ public sealed class McpServerTests : IAsyncLifetime
         var text = string.Join("\n", result.Messages.Select(m => (m.Content as TextContentBlock)?.Text ?? ""));
         Assert.Contains("database pooling", text);
         Assert.Contains("search_memories", text);
+    }
+
+    [Fact]
+    public async Task Server_exposes_workspace_tree_resource()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        // The workspace tree resource must appear in the resource list.
+        var resources = await mcp.Client.ListResourcesAsync(cancellationToken: cts.Token);
+        var uris = resources.Select(r => r.Uri).ToHashSet();
+        _output.WriteLine($"Resources: {string.Join(", ", uris)}");
+        Assert.Contains("memorizer://workspaces", uris);
+
+        // Create a workspace via a tool, then confirm the resource reflects it (unique name
+        // to stay isolated from other tests sharing the container).
+        var workspaceName = $"McpResourceTest-{Guid.NewGuid():N}";
+        await mcp.Client.CallToolAsync(
+            "create_workspace",
+            new Dictionary<string, object?> { ["name"] = workspaceName },
+            cancellationToken: cts.Token);
+
+        var read = await mcp.Client.ReadResourceAsync("memorizer://workspaces", cancellationToken: cts.Token);
+        var contents = string.Join("\n", read.Contents.OfType<TextResourceContents>().Select(c => c.Text));
+        Assert.Contains(workspaceName, contents);
     }
 }

--- a/src/Memorizer/Program.cs
+++ b/src/Memorizer/Program.cs
@@ -44,7 +44,8 @@ builder.Services.AddMcpServer()
     .WithHttpTransport(options => options.Stateless = true)
     .WithTools<MemoryTools>()
     .WithTools<WorkspaceTools>()
-    .WithPrompts<MemorizerPrompts>();
+    .WithPrompts<MemorizerPrompts>()
+    .WithResources<MemorizerResources>();
 
 // Add MVC support for web UI
 builder.Services.AddControllersWithViews()

--- a/src/Memorizer/Prompts/MemorizerPrompts.cs
+++ b/src/Memorizer/Prompts/MemorizerPrompts.cs
@@ -107,4 +107,21 @@ public class MemorizerPrompts
         4. To restore an archived memory, use the restore_memory tool.
         5. To undo a bad change, revert the memory to an earlier version with the revert_to_version tool.
         """;
+
+    [McpServerPrompt(Name = "start_project", Title = "Start a project correctly"),
+     Description("Give the correct steps to create a new project with a goal and victory conditions.")]
+    public string StartProject(
+        [Description("Optional one-sentence goal of the project.")] string? goal = null) =>
+        $"""
+        Do these steps to create a project{(string.IsNullOrWhiteSpace(goal) ? "" : $" with this goal: {goal}")}.
+
+        1. Choose the workspace for the project. List the workspaces with the get_workspace tool.
+        2. Look at the projects in that workspace. Do not make a duplicate project.
+        3. Choose a short, clear name for the project.
+        4. Write the goal in one sentence.
+        5. Write the victory conditions. State how you know the project is complete.
+        6. Create the project with the create_project tool. Put it in the workspace.
+        7. To make a sub-project, set the parent project.
+        8. Store the first decisions as memories in the project.
+        """;
 }

--- a/src/Memorizer/Resources/MemorizerResources.cs
+++ b/src/Memorizer/Resources/MemorizerResources.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Memorizer.Models;
+using Memorizer.Services;
+using ModelContextProtocol.Server;
+
+namespace PostgMem.Tools;
+
+/// <summary>
+/// MCP resources that expose readable Memorizer context. Where tools perform
+/// actions and prompts give guidance, a resource is content a client can read
+/// and attach as context.
+/// </summary>
+[McpServerResourceType]
+public class MemorizerResources
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly IStorage _storage;
+
+    public MemorizerResources(IStorage storage) => _storage = storage;
+
+    /// <summary>
+    /// The live tree of workspaces and their projects. A fixed-URI (non-template)
+    /// resource, so it appears in the client's resource list.
+    /// </summary>
+    [McpServerResource(
+        UriTemplate = "memorizer://workspaces",
+        Name = "workspace_tree",
+        Title = "Workspace and project tree",
+        MimeType = "application/json"),
+     Description("The current tree of workspaces and the projects inside them. Read this to learn the structure before you store, search, or organize memories.")]
+    public async Task<string> WorkspaceTree(CancellationToken cancellationToken)
+    {
+        var roots = await _storage.GetWorkspacesAsync(parentId: null, includeSystem: false, cancellationToken);
+
+        var nodes = new List<object>();
+        foreach (var workspace in roots)
+            nodes.Add(await BuildNodeAsync(workspace, cancellationToken));
+
+        return JsonSerializer.Serialize(new { workspaces = nodes }, JsonOptions);
+    }
+
+    private async Task<object> BuildNodeAsync(Workspace workspace, CancellationToken cancellationToken)
+    {
+        var projects = await _storage.GetProjectsAsync(workspace.Id, parentId: null, statusFilter: null, cancellationToken);
+        var childWorkspaces = await _storage.GetWorkspacesAsync(parentId: workspace.Id, includeSystem: false, cancellationToken);
+
+        var childNodes = new List<object>();
+        foreach (var child in childWorkspaces)
+            childNodes.Add(await BuildNodeAsync(child, cancellationToken));
+
+        return new
+        {
+            id = workspace.Id.Value,
+            name = workspace.Name,
+            slug = workspace.Slug,
+            projects = projects.Select(p => new
+            {
+                id = p.Id.Value,
+                name = p.Name,
+                status = p.Status.ToString(),
+            }).ToList(),
+            workspaces = childNodes,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the MCP prompts (#212). Adds the project-creation prompt that was missing, and Memorizer's first MCP **resource**.

## `start_project` prompt

Guides a client to create a project correctly: search for duplicates, name it, write the **goal** and the **victory conditions**, place it in a workspace, and optionally nest it as a sub-project (mirrors the `create_project` tool's parameters). This fills the gap left by `organize_memory`, which only creates a *workspace* incidentally when placing a memory — nothing covered deliberately setting up a *project*. Body is in Simplified Technical English, like the other prompts.

## `memorizer://workspaces` resource

A fixed-URI MCP resource (`MemorizerResources`, registered with `.WithResources<>()`) returning the live workspace → project tree as JSON, built from `IStorage` (`GetWorkspacesAsync` / `GetProjectsAsync`, including nested workspaces).

Where **tools** act and **prompts** guide, a **resource** is readable context a client can attach — this hands the client the structure the prompts keep telling it to "list."

## Testing

- `dotnet build` (Release) — 0 errors.
- `McpServerTests` (4/4 pass against live Postgres + Ollama containers): asserts `start_project` is advertised, the resource is listed, and a workspace created through the `create_workspace` **tool** then appears in the **resource** — a tool-to-resource round trip.
