### PR TITLE
Deflake metadata-embedding search scoping tests (per-run nonce)

### DIFF
--- a/src/Memorizer.IntegrationTests/McpToolsProjectScopingTests.cs
+++ b/src/Memorizer.IntegrationTests/McpToolsProjectScopingTests.cs
@@ -293,6 +293,12 @@ public class McpToolsProjectScopingTests : IDisposable
     {
         var storage = _services.GetRequiredService<IStorage>();
 
+        // Unique per-run nonce shared between the target titles and the query. The metadata
+        // embedding is built from title+tags, so this makes the targets the only positive-
+        // similarity matches in the shared container - they cannot be crowded out of the limit
+        // or land on the distance cutoff, which is what made this test flaky.
+        var nonce = Guid.NewGuid().ToString("N");
+
         // Create a workspace and project
         var workspace = await storage.CreateWorkspaceAsync("Global Search Test", null, cancellationToken: default);
         var project = await storage.CreateProjectAsync(workspace.Id, "Test Project", null, cancellationToken: default);
@@ -309,7 +315,7 @@ public class McpToolsProjectScopingTests : IDisposable
                 source: "test",
                 tags: null,
                 confidence: new Confidence(1.0),
-                title: "Project Global Search Test",
+                title: $"{nonce} scope-probe project",
                 owner: MemoryOwner.ForProject(project.Id),
                 cancellationToken: default
             );
@@ -320,16 +326,17 @@ public class McpToolsProjectScopingTests : IDisposable
                 source: "test",
                 tags: null,
                 confidence: new Confidence(1.0),
-                title: "Unfiled Global Search Test",
+                title: $"{nonce} scope-probe unfiled",
                 owner: null,
                 cancellationToken: default
             );
 
-            // Search without projectId (should search all).
-            // Use minSimilarity=0.0 (accept any distance) so this test verifies owner-filter
-            // bypass behavior rather than embedding quality, which is nondeterministic in CI.
+            // Search without projectId (should search all). The nonce in each target title makes
+            // them the only positive-similarity matches, so this deterministically verifies the
+            // owner-filter bypass (projectId=null returns both project-owned and unfiled memories)
+            // rather than embedding quality, which is nondeterministic in CI.
             var globalResults = await storage.SearchWithMetadataEmbedding(
-                query: "global search testing",
+                query: $"{nonce} scope-probe",
                 limit: 10,
                 minSimilarity: new SimilarityScore(0.0),
                 filterTags: null,
@@ -459,6 +466,12 @@ public class McpToolsProjectScopingTests : IDisposable
     {
         var storage = _services.GetRequiredService<IStorage>();
 
+        // Unique per-run nonce shared between the target titles and the query. All five memories
+        // carry it, so all are positive-similarity matches; the workspace-A-scoped search must
+        // then return exactly A's memories and exclude B's by the owner filter alone - which is
+        // what this test verifies. Removes the title/query mismatch that made it flaky.
+        var nonce = Guid.NewGuid().ToString("N");
+
         var workspaceA = await storage.CreateWorkspaceAsync("Workspace A", null, cancellationToken: default);
         var workspaceB = await storage.CreateWorkspaceAsync("Workspace B", null, cancellationToken: default);
         var projectA1 = await storage.CreateProjectAsync(workspaceA.Id, "Project A1", null, cancellationToken: default);
@@ -479,7 +492,7 @@ public class McpToolsProjectScopingTests : IDisposable
                 source: "test",
                 tags: null,
                 confidence: new Confidence(1.0),
-                title: "Workspace A Note",
+                title: $"{nonce} rollup-probe workspace-a",
                 owner: MemoryOwner.ForWorkspace(workspaceA.Id),
                 cancellationToken: default
             );
@@ -490,7 +503,7 @@ public class McpToolsProjectScopingTests : IDisposable
                 source: "test",
                 tags: null,
                 confidence: new Confidence(1.0),
-                title: "Project A1 Note",
+                title: $"{nonce} rollup-probe project-a1",
                 owner: MemoryOwner.ForProject(projectA1.Id),
                 cancellationToken: default
             );
@@ -501,7 +514,7 @@ public class McpToolsProjectScopingTests : IDisposable
                 source: "test",
                 tags: null,
                 confidence: new Confidence(1.0),
-                title: "Project A2 Note",
+                title: $"{nonce} rollup-probe project-a2",
                 owner: MemoryOwner.ForProject(projectA2.Id),
                 cancellationToken: default
             );
@@ -512,7 +525,7 @@ public class McpToolsProjectScopingTests : IDisposable
                 source: "test",
                 tags: null,
                 confidence: new Confidence(1.0),
-                title: "Workspace B Note",
+                title: $"{nonce} rollup-probe workspace-b",
                 owner: MemoryOwner.ForWorkspace(workspaceB.Id),
                 cancellationToken: default
             );
@@ -523,13 +536,13 @@ public class McpToolsProjectScopingTests : IDisposable
                 source: "test",
                 tags: null,
                 confidence: new Confidence(1.0),
-                title: "Project B1 Note",
+                title: $"{nonce} rollup-probe project-b1",
                 owner: MemoryOwner.ForProject(projectB1.Id),
                 cancellationToken: default
             );
 
             var results = await storage.SearchWithMetadataEmbedding(
-                query: "flux capacitor configuration",
+                query: $"{nonce} rollup-probe",
                 limit: 20,
                 minSimilarity: new SimilarityScore(0.0),
                 filterTags: null,


### PR DESCRIPTION
## Problem

Two integration tests failed intermittently on CI with `Assert.Contains() Failure: Item not found in set` (passed on the PR run of #212, failed on its dev-push run):

- `SearchWithMetadataEmbedding_WithNoProjectId_SearchesAll`
- `SearchWithMetadataEmbedding_WithWorkspaceId_RollsUpWorkspaceAndProjects`

Diagnosed with `/analyze-racy-test` (Akka + concurrency specialists). It's a **test-only** flake — the query is correct (owner/workspace filter is in the `WHERE` before `LIMIT`):

1. The metadata embedding is built from **title + tags**, but the target titles (`"Workspace A Note"`, …) share no tokens with the query — the matching phrase was only in the *content*. So the targets sat at the ~0 cosine-similarity noise floor.
2. `minSimilarity: 0.0` does **not** mean "accept any distance": `ToDistance()` is `1.0 - similarity`, and the search filters `distance < 1.0` (cosine similarity strictly `> 0`). Targets on the noise floor flip in and out run-to-run.
3. The global search (no owner filter) also lets the two targets get **crowded out** of the top-`2×limit` by the shared Testcontainer's rows from other test classes, worsened by **IVFFlat approximate recall** on the growing table.

## Fix (test-only)

Give each target title a unique per-run **GUID nonce** and query for that same nonce. The targets become the only positive-similarity matches — top-ranked, above the cutoff, within the limit, and un-crowdable by the shared pool.

The workspace test is now **stronger**: the nonce goes on all five memories (including workspace B's), so the `DoesNotContain` assertions prove the **owner filter** excludes B, not an embedding mismatch.

No production code changes.

## Verification

Both tests pass **3/3 consecutive runs** against live Postgres + Ollama Testcontainers.

## Separate follow-ups (intentionally not bundled — they change production behavior)

- The `minSimilarity: 0.0 → distance < 1.0` trap: there is no `SimilarityScore` value that disables the distance filter (the type is clamped to `[0,1]`). A true "no threshold" mode should omit the predicate rather than rely on `0.0`.
- The silent random-embedding fallback in `EmbeddingService` persists a random vector into `embedding_metadata` on transient errors — poisoning stored data and hiding failures.
