### PR TITLE
Fix embedding search threshold trap and remove random-embedding fallback

### DIFF
--- a/src/Memorizer.IntegrationTests/MetadataEmbeddingStorageTests.cs
+++ b/src/Memorizer.IntegrationTests/MetadataEmbeddingStorageTests.cs
@@ -209,4 +209,182 @@ public class MetadataEmbeddingStorageTests : IDisposable
 
         _output.WriteLine($"✅ UpdateMemoryOwner method works correctly for moving between workspace and unfiled");
     }
+
+    /// <summary>
+    /// Regression test for the "no similarity threshold" defect.
+    /// <para>
+    /// A minimum similarity of <c>0.0</c> must mean "no distance filter": the search should return
+    /// the nearest matches regardless of the sign of the cosine similarity, including a memory that
+    /// is (near-)orthogonal/negatively-correlated to the query. Previously <c>minSimilarity: 0.0</c>
+    /// mapped to a distance ceiling of <c>1.0</c>, which still silently dropped every row with cosine
+    /// similarity &lt;= 0 (a real flaky-test trap). A positive threshold must still filter that memory out.
+    /// </para>
+    /// <para>
+    /// Determinism: everything is scoped to a fresh per-run workspace so only the two crafted memories
+    /// are search candidates, and the query is the target memory's exact (GUID-nonced) title, which
+    /// guarantees a top match. The unrelated memory is an intentionally dissimilar topic.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task SearchWithMetadataEmbedding_ZeroThreshold_ReturnsLowSimilarityMemory()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var nonce = Guid.NewGuid().ToString("N")[..12];
+        var unrelatedNonce = Guid.NewGuid().ToString("N")[..12];
+
+        // Scope everything to a fresh workspace so only our two memories are candidates.
+        var workspace = await storage.CreateWorkspaceAsync(
+            $"ZeroThresholdWs-{nonce}",
+            "Workspace for the no-threshold regression test");
+        var wsOwner = MemoryOwner.ForWorkspace(workspace.Id);
+
+        // Query == target title => guaranteed strong (near-1.0) match.
+        var query = $"quantum orchid saxophone {nonce}";
+
+        Memory? target = null;
+        Memory? unrelated = null;
+        try
+        {
+            target = await storage.StoreMemory(
+                type: "reference",
+                content: "Target memory content for the no-threshold regression test",
+                source: "test",
+                tags: null,
+                confidence: new Confidence(1.0),
+                title: query,
+                owner: wsOwner,
+                cancellationToken: default);
+
+            // Deliberately dissimilar topic with a different nonce => low / near-orthogonal similarity.
+            unrelated = await storage.StoreMemory(
+                type: "reference",
+                content: "Unrelated memory content for the no-threshold regression test",
+                source: "test",
+                tags: null,
+                confidence: new Confidence(1.0),
+                title: $"municipal drainage culvert inspection schedule {unrelatedNonce}",
+                owner: wsOwner,
+                cancellationToken: default);
+
+            // 1) Positive threshold: the unrelated memory is filtered out (proves it is below threshold),
+            //    while the exact-match target still passes.
+            var thresholded = await storage.SearchWithMetadataEmbedding(
+                query: query,
+                limit: 20,
+                minSimilarity: new SimilarityScore(0.6),
+                filterTags: null,
+                projectId: null,
+                includeUnassigned: false,
+                includeArchived: false,
+                includeSystem: false,
+                workspaceId: workspace.Id,
+                cancellationToken: default);
+
+            var thresholdedIds = thresholded.Select(m => m.Id).ToHashSet();
+            _output.WriteLine($"Positive-threshold search returned {thresholded.Count} results");
+            Assert.Contains(target.Id, thresholdedIds);
+            Assert.DoesNotContain(unrelated.Id, thresholdedIds);
+
+            // 2) Zero threshold ("no threshold"): the SAME low-similarity memory IS now returned.
+            var noThreshold = await storage.SearchWithMetadataEmbedding(
+                query: query,
+                limit: 20,
+                minSimilarity: new SimilarityScore(0.0),
+                filterTags: null,
+                projectId: null,
+                includeUnassigned: false,
+                includeArchived: false,
+                includeSystem: false,
+                workspaceId: workspace.Id,
+                cancellationToken: default);
+
+            var noThresholdIds = noThreshold.Select(m => m.Id).ToHashSet();
+            _output.WriteLine($"Zero-threshold search returned {noThreshold.Count} results");
+            Assert.Contains(target.Id, noThresholdIds);
+            Assert.Contains(unrelated.Id, noThresholdIds);
+        }
+        finally
+        {
+            if (target != null) await storage.Delete(target.Id, default);
+            if (unrelated != null) await storage.Delete(unrelated.Id, default);
+            await storage.DeleteWorkspaceAsync(workspace.Id, default);
+        }
+    }
+
+    /// <summary>
+    /// Companion to <see cref="SearchWithMetadataEmbedding_ZeroThreshold_ReturnsLowSimilarityMemory"/>
+    /// covering the content-embedding <see cref="IStorage.SearchWithFullEmbedding"/> path: a zero
+    /// minimum similarity must not apply a distance filter, so a dissimilar memory is still returned
+    /// among the nearest matches, whereas a positive threshold filters it out.
+    /// </summary>
+    [Fact]
+    public async Task SearchWithFullEmbedding_ZeroThreshold_ReturnsLowSimilarityMemory()
+    {
+        var storage = _services.GetRequiredService<IStorage>();
+
+        var nonce = Guid.NewGuid().ToString("N")[..12];
+        var unrelatedNonce = Guid.NewGuid().ToString("N")[..12];
+
+        // Query == target title => guaranteed strong match.
+        var query = $"holographic marmalade turbine {nonce}";
+
+        Memory? target = null;
+        Memory? unrelated = null;
+        try
+        {
+            target = await storage.StoreMemory(
+                type: "reference",
+                content: query,
+                source: "test",
+                tags: null,
+                confidence: new Confidence(1.0),
+                title: query,
+                owner: null,
+                cancellationToken: default);
+
+            unrelated = await storage.StoreMemory(
+                type: "reference",
+                content: $"quarterly hydroelectric dam sediment removal report {unrelatedNonce}",
+                source: "test",
+                tags: null,
+                confidence: new Confidence(1.0),
+                title: $"quarterly hydroelectric dam sediment removal report {unrelatedNonce}",
+                owner: null,
+                cancellationToken: default);
+
+            // 1) Positive threshold: the unrelated memory is filtered out.
+            var thresholded = await storage.SearchWithFullEmbedding(
+                query: query,
+                limit: 50,
+                minSimilarity: new SimilarityScore(0.6),
+                filterTags: null,
+                includeArchived: false,
+                cancellationToken: default);
+
+            var thresholdedIds = thresholded.Select(m => m.Id).ToHashSet();
+            Assert.Contains(target.Id, thresholdedIds);
+            Assert.DoesNotContain(unrelated.Id, thresholdedIds);
+
+            // 2) Zero threshold ("no threshold"): the unrelated memory IS returned among the nearest,
+            //    proving the distance predicate was omitted. (The target, an exact match, is the very
+            //    nearest, so both land inside a generous limit even on a shared database.)
+            var noThreshold = await storage.SearchWithFullEmbedding(
+                query: query,
+                limit: 1000,
+                minSimilarity: new SimilarityScore(0.0),
+                filterTags: null,
+                includeArchived: false,
+                cancellationToken: default);
+
+            var noThresholdIds = noThreshold.Select(m => m.Id).ToHashSet();
+            Assert.Contains(target.Id, noThresholdIds);
+            Assert.Contains(unrelated.Id, noThresholdIds);
+        }
+        finally
+        {
+            if (target != null) await storage.Delete(target.Id, default);
+            if (unrelated != null) await storage.Delete(unrelated.Id, default);
+        }
+    }
 }

--- a/src/Memorizer.UnitTests/EmbeddingServiceTests.cs
+++ b/src/Memorizer.UnitTests/EmbeddingServiceTests.cs
@@ -1,0 +1,106 @@
+using Memorizer.Models;
+using Memorizer.Services;
+using Memorizer.Settings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Memorizer.UnitTests;
+
+/// <summary>
+/// Verifies that <see cref="EmbeddingService"/> fails loudly when the underlying
+/// embedding API client fails, rather than silently substituting a random vector
+/// (which would corrupt the persisted embedding/embedding_metadata columns).
+/// </summary>
+public class EmbeddingServiceTests
+{
+    [Fact]
+    public async Task Generate_WhenApiClientThrows_ThrowsInsteadOfReturningRandomVector()
+    {
+        var underlying = new HttpRequestException("simulated Ollama 503");
+        var service = CreateService(new ThrowingEmbeddingApiClient(underlying));
+
+        var thrown = await Assert.ThrowsAsync<EmbeddingGenerationException>(
+            () => service.Generate("some text that should not be persisted with a garbage embedding"));
+
+        // The original failure must be preserved as the inner exception so callers can diagnose it.
+        Assert.Same(underlying, thrown.InnerException);
+        // The message carries the model name for diagnostics.
+        Assert.Contains("test-model", thrown.Message);
+    }
+
+    [Fact]
+    public async Task Generate_WhenApiClientThrows_DoesNotLeakInputTextInException()
+    {
+        const string secret = "SUPER-SECRET-INPUT-THAT-MUST-NOT-BE-LOGGED-OR-THROWN";
+        var service = CreateService(new ThrowingEmbeddingApiClient(new InvalidOperationException("boom")));
+
+        var thrown = await Assert.ThrowsAsync<EmbeddingGenerationException>(
+            () => service.Generate(secret));
+
+        Assert.DoesNotContain(secret, thrown.Message);
+        // Length is safe to include; the raw text is not.
+        Assert.Contains(secret.Length.ToString(), thrown.Message);
+    }
+
+    [Fact]
+    public async Task Generate_WhenCallerCancels_PropagatesOperationCanceledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Simulate the api client honoring the cancellation token.
+        var service = CreateService(new ThrowingEmbeddingApiClient(
+            new OperationCanceledException(cts.Token)));
+
+        // Cancellation must propagate as-is, NOT be wrapped as an embedding failure.
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.Generate("text", cts.Token));
+    }
+
+    [Fact]
+    public async Task Generate_WhenTimeoutButTokenNotCancelled_FailsLoudly()
+    {
+        // HttpClient timeouts surface as TaskCanceledException (an OperationCanceledException)
+        // even though the caller's token was never cancelled. This must still fail loudly.
+        var service = CreateService(new ThrowingEmbeddingApiClient(
+            new TaskCanceledException("The request timed out")));
+
+        await Assert.ThrowsAsync<EmbeddingGenerationException>(
+            () => service.Generate("text", CancellationToken.None));
+    }
+
+    private static EmbeddingService CreateService(IEmbeddingApiClient apiClient)
+    {
+        var settings = new EmbeddingSettings
+        {
+            Provider = ProviderNames.Ollama,
+            ApiUrl = new Uri("http://embed.local"),
+            Model = "test-model"
+        };
+
+        return new EmbeddingService(
+            apiClient,
+            new TestOptionsSnapshot<EmbeddingSettings>(settings),
+            NullLogger<EmbeddingService>.Instance);
+    }
+
+    private sealed class ThrowingEmbeddingApiClient : IEmbeddingApiClient
+    {
+        private readonly Exception _toThrow;
+
+        public ThrowingEmbeddingApiClient(Exception toThrow)
+        {
+            _toThrow = toThrow;
+        }
+
+        public Task<float[]> GenerateAsync(string model, string text, CancellationToken cancellationToken = default)
+            => Task.FromException<float[]>(_toThrow);
+    }
+
+    private sealed class TestOptionsSnapshot<T> : IOptionsSnapshot<T> where T : class
+    {
+        public TestOptionsSnapshot(T value) { Value = value; }
+        public T Value { get; }
+        public T Get(string? name) => Value;
+    }
+}

--- a/src/Memorizer/Services/EmbeddingService.cs
+++ b/src/Memorizer/Services/EmbeddingService.cs
@@ -18,6 +18,20 @@ public interface IEmbeddingService
 }
 
 /// <summary>
+/// Thrown when an embedding cannot be generated. This exception is deliberately
+/// allowed to propagate to callers (e.g. StoreMemory) so that a failed embedding
+/// request never results in a garbage/fallback vector being persisted, which would
+/// silently corrupt semantic search for that row.
+/// </summary>
+public sealed class EmbeddingGenerationException : Exception
+{
+    public EmbeddingGenerationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
 /// Embedding service that uses IOptionsSnapshot for reloadable configuration.
 /// Register as Scoped to get fresh settings on each request scope.
 /// </summary>
@@ -25,7 +39,6 @@ public class EmbeddingService : IEmbeddingService
 {
     private readonly IEmbeddingApiClient _apiClient;
     private readonly IOptionsSnapshot<EmbeddingSettings> _settingsSnapshot;
-    private readonly IEmbeddingDimensionService _dimensionService;
     private readonly ILogger<EmbeddingService> _logger;
 
     private EmbeddingSettings Settings => _settingsSnapshot.Value;
@@ -33,12 +46,10 @@ public class EmbeddingService : IEmbeddingService
     public EmbeddingService(
         IEmbeddingApiClient apiClient,
         IOptionsSnapshot<EmbeddingSettings> settingsSnapshot,
-        IEmbeddingDimensionService dimensionService,
         ILogger<EmbeddingService> logger)
     {
         _apiClient = apiClient;
         _settingsSnapshot = settingsSnapshot;
-        _dimensionService = dimensionService;
         _logger = logger;
     }
 
@@ -57,33 +68,30 @@ public class EmbeddingService : IEmbeddingService
 
             return embedding;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller cancelled: propagate as cancellation, do NOT treat as an
+            // embedding failure and do NOT substitute a fallback vector.
+            throw;
+        }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error generating embedding: {ErrorMessage}", ex.Message);
+            // Fail loudly. Previously this method fell back to a random unit vector,
+            // which was then persisted into the embedding/embedding_metadata columns,
+            // silently poisoning that row for semantic search. We now surface the
+            // failure so the caller (e.g. StoreMemory) aborts instead of storing garbage.
+            // Note: we include the model name and input length for diagnostics but never
+            // the full input text.
+            _logger.LogError(
+                ex,
+                "Failed to generate embedding using model '{Model}' for text of length {TextLength}",
+                Settings.Model,
+                text.Length);
 
-            _logger.LogWarning("Falling back to random embedding generation");
-            var dimensions = await _dimensionService.GetEffectiveDimensionsAsync(cancellationToken);
-
-            Random random = new();
-            float[] embedding = new float[dimensions];
-            for (int i = 0; i < embedding.Length; i++)
-            {
-                embedding[i] = (float)random.NextDouble();
-            }
-
-            float sum = 0;
-            for (int i = 0; i < embedding.Length; i++)
-            {
-                sum += embedding[i] * embedding[i];
-            }
-
-            float magnitude = (float)Math.Sqrt(sum);
-            for (int i = 0; i < embedding.Length; i++)
-            {
-                embedding[i] /= magnitude;
-            }
-
-            return embedding;
+            throw new EmbeddingGenerationException(
+                $"Failed to generate embedding using model '{Settings.Model}' for input of length {text.Length}. " +
+                "Refusing to persist a fallback embedding, which would corrupt semantic search for this record.",
+                ex);
         }
     }
 

--- a/src/Memorizer/Services/Memory.cs
+++ b/src/Memorizer/Services/Memory.cs
@@ -640,11 +640,15 @@ public class Storage : IStorage
             ? "AND archetype != 3"  // Exclude only System
             : "AND archetype IN (0, 1)";  // Only Document and Record
 
+        // minSimilarity 0.0 == no threshold: omit the distance predicate (see BuildDistanceFilter).
+        string distanceFilter = BuildDistanceFilter(effectiveMinSimilarity, "embedding <=> @embedding");
+
         string sql =
             $@"
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence, created_at, updated_at, title, current_version, owner_type, owner_id, archetype, embedding <=> @embedding AS similarity
             FROM memories
-            WHERE embedding <=> @embedding < @maxDistance
+            WHERE embedding IS NOT NULL
+            {distanceFilter}
             {archetypeFilter}
             ORDER BY embedding <=> @embedding LIMIT @limit";
 
@@ -904,8 +908,11 @@ public class Storage : IStorage
         // similarity = 1 - distance, so distance = 1 - similarity
         double maxDistance = effectiveMinSimilarity.ToDistance();
 
+        // minSimilarity 0.0 == no threshold: omit the distance predicate (see BuildDistanceFilter).
+        string distanceFilter = BuildDistanceFilter(effectiveMinSimilarity, "m.embedding_metadata <=> @embedding");
+
         // Query for similar memories using metadata embeddings, excluding self, archived, and checking for existing relationships
-        const string sql = @"
+        string sql = $@"
             SELECT m.id, m.title, m.type_legacy,
                    1 - (m.embedding_metadata <=> @embedding) AS similarity,
                    CASE WHEN EXISTS (
@@ -916,7 +923,7 @@ public class Storage : IStorage
             FROM memories m
             WHERE m.id != @sourceId
               AND m.embedding_metadata IS NOT NULL
-              AND m.embedding_metadata <=> @embedding < @maxDistance
+              {distanceFilter}
               AND m.archetype IN (0, 1)  -- Only Document and Record, exclude Archived and System
             ORDER BY m.embedding_metadata <=> @embedding
             LIMIT @limit";
@@ -1289,11 +1296,15 @@ public class Storage : IStorage
             ? "AND archetype != 3"  // Exclude only System
             : "AND archetype IN (0, 1)";  // Only Document and Record
 
+        // minSimilarity 0.0 == no threshold: omit the distance predicate (see BuildDistanceFilter).
+        string distanceFilter = BuildDistanceFilter(effectiveMinSimilarity, "embedding <=> @embedding");
+
         string sql =
             $@"
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence, created_at, updated_at, title, current_version, owner_type, owner_id, archetype, embedding <=> @embedding AS similarity
             FROM memories
-            WHERE embedding <=> @embedding < @maxDistance
+            WHERE embedding IS NOT NULL
+            {distanceFilter}
             {archetypeFilter}
             ORDER BY embedding <=> @embedding LIMIT @limit";
 
@@ -1402,11 +1413,15 @@ public class Storage : IStorage
             (true, true) => ""                                 // All archetypes
         };
 
+        // minSimilarity 0.0 == no threshold: omit the distance predicate (see BuildDistanceFilter).
+        string distanceFilter = BuildDistanceFilter(effectiveMinSimilarity, "embedding_metadata <=> @embedding");
+
         string sql =
             $@"
             SELECT id, type_legacy, content, text, source, embedding, embedding_metadata, tags, confidence, created_at, updated_at, title, current_version, owner_type, owner_id, archetype, embedding_metadata <=> @embedding AS similarity
             FROM memories
-            WHERE embedding_metadata <=> @embedding < @maxDistance
+            WHERE embedding_metadata IS NOT NULL
+            {distanceFilter}
             {ownerFilter}
             {archetypeFilter}
             ORDER BY embedding_metadata <=> @embedding LIMIT @limit";
@@ -1527,6 +1542,44 @@ public class Storage : IStorage
             (false, true) => "AND archetype IN (0, 1, 3)",
             (true, true) => ""
         };
+    }
+
+    /// <summary>
+    /// Builds the optional pgvector distance predicate for a similarity search, treating an
+    /// effective minimum similarity of <c>0.0</c> as "no similarity threshold".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Vector searches filter with <c>&lt;distanceExpression&gt; &lt; @maxDistance</c>, where
+    /// <c>maxDistance = effectiveMinSimilarity.ToDistance() = 1.0 - minSimilarity</c> against
+    /// pgvector cosine distance (0 = identical, 1 = orthogonal, 2 = opposite).
+    /// </para>
+    /// <para>
+    /// Because <see cref="SimilarityScore"/> is clamped to <c>[0.0, 1.0]</c>, the smallest
+    /// expressible <c>maxDistance</c> ceiling is <c>1.0</c> (at <c>minSimilarity == 0.0</c>).
+    /// A ceiling of <c>1.0</c> still drops every row whose cosine similarity is <c>&lt;= 0</c>
+    /// (orthogonal or negatively correlated), so there is no in-range value that disables the
+    /// filter. Callers reasonably read <c>minSimilarity: 0.0</c> as "no threshold, return the
+    /// top matches regardless of sign", so we honor that by omitting the distance predicate
+    /// entirely when the effective minimum similarity is <c>0.0</c>. The caller keeps its
+    /// <c>ORDER BY &lt;distance&gt; LIMIT</c>, so the search still returns the nearest N rows.
+    /// </para>
+    /// <para>
+    /// For any positive threshold (including the <c>null =&gt; DefaultThreshold (0.7)</c> case)
+    /// the predicate is returned unchanged, preserving the historical filtering behavior.
+    /// </para>
+    /// </remarks>
+    /// <param name="effectiveMinSimilarity">The resolved minimum similarity (after applying the default).</param>
+    /// <param name="distanceExpression">The pgvector distance expression, e.g. <c>"embedding &lt;=&gt; @embedding"</c>.</param>
+    /// <returns>An <c>"AND ..."</c> SQL fragment, or an empty string when no distance filter should be applied.</returns>
+    private static string BuildDistanceFilter(SimilarityScore effectiveMinSimilarity, string distanceExpression)
+    {
+        // minSimilarity 0.0 == no threshold: omit the distance predicate so the search returns
+        // the nearest rows regardless of the sign of the cosine similarity.
+        if (effectiveMinSimilarity.Value <= 0.0)
+            return string.Empty;
+
+        return $"AND {distanceExpression} < @maxDistance";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Two embedding-correctness fixes flagged during the flaky-test investigation (#214). Independent changes, disjoint files, combined into one PR; developed in parallel by two sub-agents in isolated worktrees.

## 1. `minSimilarity: 0.0` now means "no similarity threshold"

`SimilarityScore` is clamped to `[0,1]` and `ToDistance() = 1 - similarity`, so the vector searches filtered `<embedding> <=> @embedding < @maxDistance` where `maxDistance` bottoms out at `1.0` — meaning `minSimilarity: 0.0` still silently dropped every row with cosine similarity ≤ 0. There was **no value that disabled the filter**, which is a trap callers fall into (and was the root of the earlier flaky tests).

**Fix** (`Memory.cs`): a `BuildDistanceFilter` helper omits the `< @maxDistance` predicate entirely when the effective minimum similarity is `0.0`, so the search returns the nearest `N` (via the unchanged `ORDER BY <=> LIMIT`) regardless of similarity sign. Any positive threshold — including the `null → DefaultThreshold (0.7)` default — behaves exactly as before. Applied consistently to `Search`, `SearchWithFullEmbedding`, `SearchWithMetadataEmbedding`, and `GetSimilarMemories`; `HybridSearch`'s vector leg already had no hard threshold. Caller audit confirmed no code relied on `0.0` meaning "similarity > 0".

## 2. No more silent random-embedding fallback

`EmbeddingService.Generate` caught **any** exception and returned a **random unit vector**, which callers then persisted into `embedding` / `embedding_metadata` — silently poisoning stored data on transient embedding-service errors and hiding the failure.

**Fix** (`EmbeddingService.cs`): remove the random fallback and **fail loudly** — wrap the failure in a new `EmbeddingGenerationException` (message carries the model name and input length, never the raw text) so `StoreMemory` aborts the write instead of persisting garbage. Cancellation is preserved (caller-initiated `OperationCanceledException` propagates as-is; an HttpClient timeout becomes a loud failure). Nothing depended on the fallback: real-service tests use the Ollama Testcontainer; no-backend tests use `FakeEmbeddingService`. A graceful backfill path already exists (`EmbeddingRegenerationActor` records per-memory failures) for operators to re-embed affected rows — left as-is, not extended here.

## Testing

- `dotnet build` (Release) — 0 errors/warnings.
- **199 unit tests pass** (incl. 4 new `EmbeddingServiceTests` asserting the throw + cancellation behavior).
- Affected integration tests (new zero-threshold tests for both content and metadata paths, plus the `minSimilarity: 0.0` scoping tests) — **15/15, run 2× for determinism**, against live Postgres + Ollama containers.
