### PR TITLE
Release 2.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,19 +3,31 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/petabridge/memorizer-v1</PackageProjectUrl>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
     <PackageReleaseNotes>**Features**
-- [Support get_workspace by slug](https://github.com/petabridge/memorizer/pull/199) - The `GetWorkspace` MCP tool now accepts workspace slugs in addition to IDs
-  - Enables workspace lookup without needing to know the workspace ID in advance
-  - Slug matching is case-insensitive
+- [Upgrade Model Context Protocol SDK to 2.2.0](https://github.com/petabridge/memorizer/pull/211) - Moves Memorizer onto the stable MCP SDK
+  - The MCP server now runs in stateless Streamable HTTP mode
+  - Adds MCP endpoint integration tests driven by a lightweight SDK client
+- [Expose MCP prompts that teach correct Memorizer usage](https://github.com/petabridge/memorizer/pull/212) - Adds seven guided prompts written in Simplified Technical English
+  - `memorizer_overview`, `store_memory`, `find_context`, `review_project`, `organize_memory`, `maintain_memory`, and `start_project`
+- [Add start_project prompt and a workspace-tree MCP resource](https://github.com/petabridge/memorizer/pull/213) - Exposes the live workspace and project hierarchy as readable MCP context
+  - The `memorizer://workspaces` resource surfaces the current workspace/project tree so agents can orient before acting
+
+**Security**
+- [Pin SSH.NET to 2026.0.0 to fix high-severity advisory (GHSA-q939-rpr3-3284)](https://github.com/petabridge/memorizer/pull/207) - Addresses a high-severity advisory pulled in transitively via Testcontainers
+- [Bump OpenTelemetry packages to 1.17.0 to fix moderate advisories](https://github.com/petabridge/memorizer/pull/208) - Resolves four moderate denial-of-service advisories in `OpenTelemetry.Api` and the OTLP exporter
 
 **Bug Fixes**
-- [Make MCP tools resilient to missing required parameters](https://github.com/petabridge/memorizer/pull/184) - MCP tools now return descriptive error messages when required parameters are missing or malformed, instead of throwing unhandled exceptions
-  - Fixes compatibility with MCP clients (Claude Code, opencode) that may omit required parameters
-  - Affected tools: `Store`, `Edit`, `CreateReference`, `MoveMemory`</PackageReleaseNotes>
+- [Fix canonical URLs for projects and workspaces](https://github.com/petabridge/memorizer/pull/205) - MCP tool responses now link to the correct web UI routes ([#204](https://github.com/petabridge/memorizer/issues/204))
+  - Project and workspace links now use the plural `/projects/{id}` and `/workspaces/{id}` routes
+- [Fix connection-pool self-deadlock in Get/GetMany relationship loading](https://github.com/petabridge/memorizer/pull/209) - Prevents pool exhaustion under concurrency during relationship loading
+  - `Get`, `GetMany`, and the remaining query paths now reuse a single pooled connection instead of holding two ([#210](https://github.com/petabridge/memorizer/pull/210))
+- [Fix embedding search threshold trap and remove random-embedding fallback](https://github.com/petabridge/memorizer/pull/215) - Corrects similarity-threshold behavior and surfaces embedding failures
+  - `minSimilarity: 0.0` now means "no threshold" instead of filtering out all results
+  - Embedding failures now surface loudly instead of silently persisting a random vector</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+#### 2.3.0 August 17th 2026 ####
+
+**Features**
+- [Upgrade Model Context Protocol SDK to 2.2.0](https://github.com/petabridge/memorizer/pull/211) - Moves Memorizer onto the stable MCP SDK
+  - The MCP server now runs in stateless Streamable HTTP mode
+  - Adds MCP endpoint integration tests driven by a lightweight SDK client
+- [Expose MCP prompts that teach correct Memorizer usage](https://github.com/petabridge/memorizer/pull/212) - Adds seven guided prompts written in Simplified Technical English
+  - `memorizer_overview`, `store_memory`, `find_context`, `review_project`, `organize_memory`, `maintain_memory`, and `start_project`
+- [Add start_project prompt and a workspace-tree MCP resource](https://github.com/petabridge/memorizer/pull/213) - Exposes the live workspace and project hierarchy as readable MCP context
+  - The `memorizer://workspaces` resource surfaces the current workspace/project tree so agents can orient before acting
+
+**Security**
+- [Pin SSH.NET to 2026.0.0 to fix high-severity advisory (GHSA-q939-rpr3-3284)](https://github.com/petabridge/memorizer/pull/207) - Addresses a high-severity advisory pulled in transitively via Testcontainers
+- [Bump OpenTelemetry packages to 1.17.0 to fix moderate advisories](https://github.com/petabridge/memorizer/pull/208) - Resolves four moderate denial-of-service advisories in `OpenTelemetry.Api` and the OTLP exporter
+
+**Bug Fixes**
+- [Fix canonical URLs for projects and workspaces](https://github.com/petabridge/memorizer/pull/205) - MCP tool responses now link to the correct web UI routes ([#204](https://github.com/petabridge/memorizer/issues/204))
+  - Project and workspace links now use the plural `/projects/{id}` and `/workspaces/{id}` routes
+- [Fix connection-pool self-deadlock in Get/GetMany relationship loading](https://github.com/petabridge/memorizer/pull/209) - Prevents pool exhaustion under concurrency during relationship loading
+  - `Get`, `GetMany`, and the remaining query paths now reuse a single pooled connection instead of holding two ([#210](https://github.com/petabridge/memorizer/pull/210))
+- [Fix embedding search threshold trap and remove random-embedding fallback](https://github.com/petabridge/memorizer/pull/215) - Corrects similarity-threshold behavior and surfaces embedding failures
+  - `minSimilarity: 0.0` now means "no threshold" instead of filtering out all results
+  - Embedding failures now surface loudly instead of silently persisting a random vector
+
 #### 2.2.0 July 3rd 2026 ####
 
 **Features**


### PR DESCRIPTION
Release preparation for 2.3.0.

Updates `RELEASE_NOTES.md` with the 2.3.0 section and syncs the version metadata (`VersionPrefix` and `PackageReleaseNotes`) into `Directory.Build.props`.

## Highlights

**Features**
- Upgrade Model Context Protocol SDK to 2.2.0 (#211) - stateless Streamable HTTP mode plus MCP endpoint integration tests
- Expose MCP prompts that teach correct Memorizer usage (#212) - seven guided prompts in Simplified Technical English
- Add start_project prompt and a workspace-tree MCP resource (#213) - `memorizer://workspaces` exposes the live workspace/project tree

**Security**
- Pin SSH.NET to 2026.0.0 (#207) - fixes high-severity advisory GHSA-q939-rpr3-3284 pulled in transitively via Testcontainers
- Bump OpenTelemetry to 1.17.0 (#208) - fixes four moderate DoS advisories in OpenTelemetry.Api and the OTLP exporter

**Bug Fixes**
- Fix canonical URLs for projects and workspaces (#205, closes #204) - link to the correct plural `/projects/{id}` and `/workspaces/{id}` routes
- Fix connection-pool self-deadlock in Get/GetMany relationship loading (#209, #210) - reuse a single pooled connection to prevent pool exhaustion
- Fix embedding search threshold trap and remove random-embedding fallback (#215) - `minSimilarity: 0.0` means no threshold; embedding failures now surface loudly
