### PR TITLE
Own the MCP tool-argument error surface (Piece 1)

### DIFF
--- a/docs/agent-resilient-tool-surface-plan.md
+++ b/docs/agent-resilient-tool-surface-plan.md
@@ -1,0 +1,183 @@
+# Fix-up plan: agent-resilient MCP tool surface
+
+Status: proposed
+Owner: TBD
+Related: #166, #184, #211, #215
+
+## Why this exists
+
+After the 2.3.0 deploy, agents began getting opaque `An error occurred
+invoking '<tool>'` failures from `store` and `get`. We traced it end to end
+(netclaw session logs → memorizer OTel logs in Seq).
+
+Two **separate** problem classes surfaced. Only the first is what agents hit in
+the incident; the second is a real, distinct risk that this plan must not
+pretend to cover with the same fix.
+
+### Class A — argument-binding failures (the incident)
+
+Server-side exceptions in Seq (`service = memorizer`, 2026-08-20 ~18:31 UTC):
+
+```
+"store" threw an unhandled exception.
+System.ArgumentException: The arguments dictionary is missing a value for the
+required parameter 'type'.
+  at Microsoft.Extensions.AI.AIFunctionFactory.ReflectionAIFunctionDescriptor…GetParameterMarshaller
+```
+
+Root cause: **#211 upgraded the MCP SDK** (`ModelContextProtocol`
+`0.4.0-preview.3 → 2.2.0`). The stable SDK marshals tool arguments through
+`AIFunctionFactory` and **validates before the tool method runs** — a missing
+required parameter (`type`) or a malformed typed parameter (an unhyphenated
+32-hex string for a `Guid id`) throws at the binder and surfaces as the generic
+error. The tool code did not change between 2.2.0 and 2.3.0 (byte-identical
+`MemoryTools.cs`); only the SDK moved.
+
+This defeated our own resilience work:
+
+- **#166** changed optional `Guid?` params to `string?` + `Guid.TryParse`
+  because "some MCP clients send empty strings or the literal 'null'… causing
+  System.Text.Json to throw before the tool method is ever reached." The
+  **required** `id` was left as `Guid` — the gap now biting.
+- **#184** added in-body `if (string.IsNullOrWhiteSpace(type)) return "…"`
+  checks. These only run if the method is called. The preview SDK delivered
+  loose/missing args to the method; 2.2.0 rejects them at the binder first, so
+  the checks are now dead code.
+
+Timeline (Seq): first binder exception 2026-08-18, none before — i.e. it
+started with the deploy.
+
+Confirmed failing inputs from the incident:
+- `store` × 2: missing `type` (model dropped it on retry).
+- `get` × 1: `dec906c7e5d14abebaf827af5a842ae5` — a netclaw recall id
+  (`doc-…` prefix stripped), N-format, which `Guid` binding rejects.
+
+### Class B — embedding-layer store failures (separate)
+
+**#215** removed the silent random-embedding fallback. Embedding-backend
+failures now throw `EmbeddingGenerationException` from `StoreMemory`, **after**
+argument validation, aborting the write. This is correct (it stopped persisting
+garbage vectors) but it means a healthy, well-formed `store` call can still fail
+at the embedding step. **The Class A boundary does nothing for this.** It needs
+its own handling (Piece 4).
+
+## Design principles
+
+1. **Own the error surface.** Never let the SDK author the message. Every
+   rejection returns a memorizer-written, *correctable* message: what was wrong,
+   why, the expected shape, and a minimal valid example.
+2. **Pit of success.** The natural, low-effort call an agent makes should be the
+   one that works. Fail correctable, never opaque. Minimize required fields.
+   Be liberal in what you accept (Postel's law).
+3. **Require load-bearing fields; default organizational ones.** Don't default a
+   field the core function depends on — that silently degrades quality (the same
+   mistake the random-embedding fallback made). Do default metadata that has a
+   safe fallback.
+
+## Field policy (the require-vs-default decision)
+
+`store` should succeed with `text` alone. The rest default, **except `title`.**
+
+| Field | Role | Vectorized? | Decision |
+|---|---|---|---|
+| `text` | the memory body | yes (content embedding) | **required** |
+| `title` | the search index — dominates the metadata embedding (`embedding_metadata = title + tags`) and is prepended to the content embedding | **yes** | **required**, with a teaching error that explains it is what search indexes |
+| `type` | free-form category / `GetByFilter` facet; written to `type_legacy`; not validated against the enum | no | **default** `reference` (the `MemoryTypeEnum` fallback already is `reference`) |
+| `source` | provenance label | no | **default** `LLM` |
+| `confidence` | score | no | default `1.0` (already) |
+| `archetype` | `document` (mutable) vs `record` (immutable) | no | default `document` (already) |
+
+Rationale for keeping `title` required: `metadataText = title` (+ tags) is the
+vector that metadata search and similarity rank on
+(`embedding_metadata <=> @embedding`). Deriving a title from the first line of
+`text` (e.g. a bash script or JSON blob) would produce a weak/garbage search
+vector and make the memory unfindable — the same silent-quality-loss failure
+mode we just removed in #215. Requiring it with a good error guides the agent to
+write a real, searchable title, which is the correct path *and* the easy one.
+
+Note: `type` — the exact field the agent dropped in the incident — is one we can
+safely default. With a default, that specific `store` failure does not occur.
+
+## The plan
+
+### Piece 1 — CallTool validation boundary (own the error)
+
+Register one filter via the 2.2.0 SDK's real seam:
+`IMcpServerBuilder.WithRequestFilters(f => f.AddCallToolFilter(next => …))`.
+
+Filter logic (runs for every tool, no per-tool wiring):
+
+1. Read `ctx.Params.Arguments` (`IDictionary<string, JsonElement>`) and the
+   tool's own schema from `ctx.MatchedPrimitive` (`McpServerTool.ProtocolTool.InputSchema`).
+2. Validate against the schema: required present, each present value's JSON kind
+   matches the declared type, formats (uuid/enum) parse. This reuses the schema
+   the SDK already emits for `ListTools`, so validation and contract can't drift.
+3. On failure: return `CallToolResult { IsError = true, Content =
+   [TextContentBlock { Text = correctable message }] }` **without calling
+   `next`** — the SDK marshaller never runs, so it never authors the error.
+4. On success: `await next(ctx, ct)`, wrapped in a backstop `try/catch` that
+   converts any later exception into an owned, logged message. Nothing opaque
+   escapes, ever.
+
+Message contract lives in one helper so every tool speaks the same format:
+`store: required field 'type' is missing. Provide a string like "document" or
+"how-to". Minimal call: {"text":"…","type":"document"}`.
+
+### Piece 2 — Fall-into-success tool ergonomics
+
+- **Defaults** per the field-policy table. Make defaulted params
+  nullable-with-default so binding always succeeds and the body fills gaps.
+- **`title` stays required** — enforced by the boundary with the teaching error.
+- **ID normalization.** Add `MemoryId.TryParseLoose(string)`: trim, strip known
+  prefixes (`doc-`, `memory-`, a pasted `/view/{id}` URL), accept N- and
+  D-format via `Guid.TryParse`. Change `get`, `get_many`, `delete`, `edit`,
+  `revert_to_version`, `archive`, `restore` from `Guid id` to `string id` using
+  it. This extends the #166 pattern (already applied to optional ids) to the
+  required id.
+- **Postel.** Accept a bare string where `string[]` is declared (tags, ids),
+  comma/space-delimited lists, case-insensitive `type`/`archetype`.
+
+### Piece 3 — Agent-shaped regression tests (the guard)
+
+Extend `McpServerTests` (boots the real app via `WebApplicationFactory<Program>`
+against the Testcontainers Postgres + Ollama, drives the real MCP client over
+Streamable HTTP). Assert graceful, correctable results — not exceptions:
+
+- `store` with `type` omitted → `IsError`, message names `type` + example (the
+  literal 18:31 repro).
+- `store` with only `text` → **succeeds** (defaults fill `type`, `source`, etc.).
+- `store` with `title` omitted → `IsError`, message explains title is the search
+  index (verifies we did NOT default it).
+- `get` with N-format id, and with a `doc-`-prefixed id → normalized, returns
+  found/not-found, never a binder error.
+- `get` with genuine garbage id → correctable "invalid id" message.
+- Parameterized sweep: every tool, omit each required param → never an exception.
+- **Tripwire:** assert no response text ever equals the SDK's generic
+  `"An error occurred invoking …"`. This is the standing guard that fails the
+  next SDK bump the moment it changes binding behavior — the thing #211 lacked.
+- Verify snapshot of the tool input schemas so drift is a reviewed diff.
+
+### Piece 4 — Embedding-failure handling in the store path (Class B)
+
+Separate track; the boundary does not cover this. Catch
+`EmbeddingGenerationException` in the store path and return an actionable,
+retryable result instead of an opaque failure. Decide the real policy:
+
+- chunk/truncate over-long text before embedding, and/or
+- queue a re-embed and store flagged-degraded, and/or
+- surface a clear "embedding backend unavailable, memory not stored" that the
+  agent can retry.
+
+Also audit: memories written **before** 2.3.0 may carry random-fallback
+embeddings and be unfindable by semantic search — candidate for a re-embed pass.
+
+## Sequencing
+
+1. Piece 1 + Piece 3 together — converts every opaque arg-binding failure into a
+   correctable one and locks it with the tripwire. Biggest immediate win, no
+   signature changes required beyond the filter.
+2. Piece 2 — defaults + id normalization ergonomics.
+3. Piece 4 — embedding-failure handling (independent; can proceed in parallel).
+
+All server-side in `petabridge/memorizer`; deploys via the `memory-mcp` repo, no
+client change.

--- a/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
@@ -149,4 +149,99 @@ public sealed class McpServerTests : IAsyncLifetime
         var contents = string.Join("\n", read.Contents.OfType<TextResourceContents>().Select(c => c.Text));
         Assert.Contains(workspaceName, contents);
     }
+
+    // ---- Argument-validation boundary (Piece 1) ----
+    //
+    // These drive the real server the way a confused agent does. Before the 2.3.0 SDK
+    // bump these calls returned the opaque "An error occurred invoking '<tool>'"; the
+    // CallTool boundary must now return a correctable message instead. The negative
+    // assertion on OpaqueSdkError is the standing tripwire for the next SDK bump.
+
+    private const string OpaqueSdkError = "An error occurred invoking";
+
+    private static string ResultText(CallToolResult result) =>
+        string.Join("\n", result.Content.OfType<TextContentBlock>().Select(c => c.Text));
+
+    [Fact]
+    public async Task Store_without_type_returns_a_correctable_error_not_the_opaque_sdk_error()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        // 'type' deliberately omitted — the exact shape that failed in the incident.
+        var result = await mcp.Client.CallToolAsync(
+            "store",
+            new Dictionary<string, object?>
+            {
+                ["text"] = "hello world",
+                ["source"] = "LLM",
+                ["title"] = "Boundary test",
+            },
+            cancellationToken: cts.Token);
+
+        var text = ResultText(result);
+        _output.WriteLine(text);
+        Assert.True(result.IsError == true);
+        Assert.DoesNotContain(OpaqueSdkError, text);
+        Assert.Contains("type", text);
+    }
+
+    [Fact]
+    public async Task Valid_id_passes_the_filter_and_reaches_the_tool()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        // A well-formed, hyphenated UUID must pass straight through the filter to the
+        // tool body — the positive counterpart to the N-format case. A nonexistent id
+        // returns a graceful "not found" without touching the embedding backend, so the
+        // assertion stays independent of Class B (embedding) behaviour.
+        var result = await mcp.Client.CallToolAsync(
+            "get",
+            new Dictionary<string, object?> { ["id"] = "00000000-0000-0000-0000-000000000001" },
+            cancellationToken: cts.Token);
+
+        var text = ResultText(result);
+        _output.WriteLine(text);
+        Assert.NotEqual(true, result.IsError);
+        Assert.Contains("not found", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Get_with_unhyphenated_id_returns_a_correctable_error_not_the_opaque_sdk_error()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        // 32-hex, no hyphens — as a recall doc-id (minus its 'doc-' prefix) would arrive.
+        var result = await mcp.Client.CallToolAsync(
+            "get",
+            new Dictionary<string, object?> { ["id"] = "dec906c7e5d14abebaf827af5a842ae5" },
+            cancellationToken: cts.Token);
+
+        var text = ResultText(result);
+        _output.WriteLine(text);
+        Assert.True(result.IsError == true);
+        Assert.DoesNotContain(OpaqueSdkError, text);
+    }
+
+    [Theory]
+    [InlineData("store")]
+    [InlineData("get")]
+    [InlineData("edit")]
+    public async Task Omitting_required_parameters_never_yields_the_opaque_sdk_error(string tool)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        var result = await mcp.Client.CallToolAsync(
+            tool,
+            new Dictionary<string, object?>(), // no arguments at all
+            cancellationToken: cts.Token);
+
+        var text = ResultText(result);
+        _output.WriteLine($"{tool}: {text}");
+        Assert.True(result.IsError == true);
+        Assert.DoesNotContain(OpaqueSdkError, text);
+    }
 }

--- a/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
@@ -183,7 +183,12 @@ public sealed class McpServerTests : IAsyncLifetime
         _output.WriteLine(text);
         Assert.True(result.IsError == true);
         Assert.DoesNotContain(OpaqueSdkError, text);
+        // Positively assert the message is actually corrective — names the field and
+        // tells the agent it is required. Without this, the test would still pass if the
+        // SDK front-ran us with some other unhelpful message that merely lacks the opaque
+        // string.
         Assert.Contains("type", text);
+        Assert.Contains("required", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -223,6 +228,8 @@ public sealed class McpServerTests : IAsyncLifetime
         _output.WriteLine(text);
         Assert.True(result.IsError == true);
         Assert.DoesNotContain(OpaqueSdkError, text);
+        // Corrective: the message must point the agent at the id format it should use.
+        Assert.Contains("UUID", text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]
@@ -243,5 +250,8 @@ public sealed class McpServerTests : IAsyncLifetime
         _output.WriteLine($"{tool}: {text}");
         Assert.True(result.IsError == true);
         Assert.DoesNotContain(OpaqueSdkError, text);
+        // Every tool with required params must name one as missing — a corrective message,
+        // not merely the absence of the opaque one.
+        Assert.Contains("required", text, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Memorizer.UnitTests/Tools/ToolArgumentGuardTests.cs
+++ b/src/Memorizer.UnitTests/Tools/ToolArgumentGuardTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Memorizer.Tools;
+
+namespace Memorizer.UnitTests.Tools;
+
+/// <summary>
+/// Unit tests for <see cref="ToolArgumentGuard"/> — the pure, schema-driven validation
+/// that backs the CallTool boundary. These assert that a malformed call yields a
+/// correctable message (and a well-formed one is allowed through) without booting the
+/// MCP SDK. The end-to-end proof that the filter fires before the SDK marshaller lives
+/// in the integration tests.
+/// </summary>
+public class ToolArgumentGuardTests
+{
+    private const string StoreSchema = """
+    {
+      "type": "object",
+      "properties": {
+        "type":       { "type": "string", "description": "The type of memory (e.g. 'reference', 'how-to')." },
+        "text":       { "type": "string" },
+        "source":     { "type": "string" },
+        "title":      { "type": "string" },
+        "confidence": { "type": "number" },
+        "tags":       { "type": "array" }
+      },
+      "required": ["type", "text", "source", "title"]
+    }
+    """;
+
+    private const string IdSchema = """
+    {
+      "type": "object",
+      "properties": { "id": { "type": "string", "format": "uuid" } },
+      "required": ["id"]
+    }
+    """;
+
+    private static string? Validate(string schemaJson, string argsJson, string tool = "store")
+    {
+        using var schemaDoc = JsonDocument.Parse(schemaJson);
+        using var argsDoc = JsonDocument.Parse(argsJson);
+        var args = argsDoc.RootElement.EnumerateObject().ToDictionary(p => p.Name, p => p.Value);
+        return ToolArgumentGuard.Validate(tool, schemaDoc.RootElement, args);
+    }
+
+    [Fact]
+    public void Missing_required_field_is_named_with_an_example()
+    {
+        // 'type' omitted — the exact shape that failed in the incident.
+        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""");
+
+        Assert.NotNull(msg);
+        Assert.Contains("type", msg);
+        Assert.Contains("required", msg, StringComparison.OrdinalIgnoreCase);
+        // The minimal example teaches the shape the agent must send.
+        Assert.Contains("\"type\"", msg);
+        Assert.Contains("\"text\"", msg);
+    }
+
+    [Fact]
+    public void Missing_required_field_surfaces_its_description_as_a_hint()
+    {
+        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""");
+        Assert.Contains("type of memory", msg!);
+    }
+
+    [Theory]
+    [InlineData("\"\"")]        // empty string
+    [InlineData("\"   \"")]     // whitespace
+    [InlineData("\"null\"")]    // literal "null" (Cursor-style), per #166
+    [InlineData("null")]        // JSON null
+    public void Empty_or_null_string_for_required_counts_as_missing(string typeValue)
+    {
+        var msg = Validate(StoreSchema, $$"""{ "type": {{typeValue}}, "text": "hi", "source": "LLM", "title": "T" }""");
+        Assert.NotNull(msg);
+        Assert.Contains("type", msg);
+    }
+
+    [Fact]
+    public void All_required_present_is_allowed_through()
+    {
+        var msg = Validate(StoreSchema, """{ "type": "reference", "text": "hi", "source": "LLM", "title": "T" }""");
+        Assert.Null(msg);
+    }
+
+    [Fact]
+    public void Wrong_json_type_for_a_field_is_reported()
+    {
+        // text declared string, sent as a number.
+        var msg = Validate(StoreSchema, """{ "type": "reference", "text": 42, "source": "LLM", "title": "T" }""");
+        Assert.NotNull(msg);
+        Assert.Contains("text", msg);
+        Assert.Contains("string", msg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Malformed_uuid_is_reported_as_invalid_id()
+    {
+        // The N-format id (no hyphens) the model lifted from a recall doc-id.
+        var msg = Validate(IdSchema, """{ "id": "dec906c7e5d14abebaf827af5a842ae5" }""", tool: "get");
+        Assert.NotNull(msg);
+        Assert.Contains("id", msg);
+        Assert.Contains("UUID", msg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Hyphenated_uuid_is_allowed_through()
+    {
+        var msg = Validate(IdSchema, """{ "id": "dec906c7-e5d1-4abe-baf8-27af5a842ae5" }""", tool: "get");
+        Assert.Null(msg);
+    }
+
+    [Fact]
+    public void Extra_unknown_argument_is_ignored_when_required_are_present()
+    {
+        var msg = Validate(StoreSchema,
+            """{ "type": "reference", "text": "hi", "source": "LLM", "title": "T", "_rationale": "why" }""");
+        Assert.Null(msg);
+    }
+
+    [Fact]
+    public void Non_object_schema_skips_validation()
+    {
+        // Fail open: if there's no object schema to check against, don't block the call.
+        var msg = Validate("\"not-a-schema\"", """{ "anything": 1 }""");
+        Assert.Null(msg);
+    }
+
+    [Fact]
+    public void Message_is_prefixed_with_the_tool_name()
+    {
+        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", tool: "store");
+        Assert.StartsWith("store:", msg);
+    }
+}

--- a/src/Memorizer.UnitTests/Tools/ToolArgumentGuardTests.cs
+++ b/src/Memorizer.UnitTests/Tools/ToolArgumentGuardTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Memorizer.Tools;
+using ModelContextProtocol.Server;
+using PostgMem.Tools;
 
 namespace Memorizer.UnitTests.Tools;
 
@@ -7,47 +9,38 @@ namespace Memorizer.UnitTests.Tools;
 /// Unit tests for <see cref="ToolArgumentGuard"/> — the pure, schema-driven validation
 /// that backs the CallTool boundary. These assert that a malformed call yields a
 /// correctable message (and a well-formed one is allowed through) without booting the
-/// MCP SDK. The end-to-end proof that the filter fires before the SDK marshaller lives
-/// in the integration tests.
+/// MCP SDK server. The end-to-end proof that the filter fires before the SDK marshaller
+/// lives in the integration tests.
+///
+/// The schemas here are generated from the real tool methods via the same SDK path the
+/// server uses (<see cref="McpServerTool.Create(Delegate, McpServerToolCreateOptions?)"/>
+/// → <c>ProtocolTool.InputSchema</c>), so the tests validate against the actual tool
+/// contract rather than a hand-maintained copy that could drift.
 /// </summary>
 public class ToolArgumentGuardTests
 {
-    private const string StoreSchema = """
-    {
-      "type": "object",
-      "properties": {
-        "type":       { "type": "string", "description": "The type of memory (e.g. 'reference', 'how-to')." },
-        "text":       { "type": "string" },
-        "source":     { "type": "string" },
-        "title":      { "type": "string" },
-        "confidence": { "type": "number" },
-        "tags":       { "type": "array" }
-      },
-      "required": ["type", "text", "source", "title"]
-    }
-    """;
+    // Field values are irrelevant — only the method signatures/attributes drive schema
+    // generation, which never invokes the tool, so null dependencies are fine.
+    private static readonly MemoryTools SampleTools = new(null!, null!, null!, null!);
 
-    private const string IdSchema = """
-    {
-      "type": "object",
-      "properties": { "id": { "type": "string", "format": "uuid" } },
-      "required": ["id"]
-    }
-    """;
+    private static JsonElement SchemaFor(Delegate toolMethod)
+        => McpServerTool.Create(toolMethod).ProtocolTool.InputSchema;
 
-    private static string? Validate(string schemaJson, string argsJson, string tool = "store")
+    private static JsonElement StoreSchema => SchemaFor(SampleTools.Store);
+    private static JsonElement GetSchema => SchemaFor(SampleTools.Get);
+
+    private static string? Validate(JsonElement schema, string argsJson, string tool)
     {
-        using var schemaDoc = JsonDocument.Parse(schemaJson);
         using var argsDoc = JsonDocument.Parse(argsJson);
         var args = argsDoc.RootElement.EnumerateObject().ToDictionary(p => p.Name, p => p.Value);
-        return ToolArgumentGuard.Validate(tool, schemaDoc.RootElement, args);
+        return ToolArgumentGuard.Validate(tool, schema, args);
     }
 
     [Fact]
     public void Missing_required_field_is_named_with_an_example()
     {
         // 'type' omitted — the exact shape that failed in the incident.
-        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""");
+        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", "store");
 
         Assert.NotNull(msg);
         Assert.Contains("type", msg);
@@ -60,7 +53,7 @@ public class ToolArgumentGuardTests
     [Fact]
     public void Missing_required_field_surfaces_its_description_as_a_hint()
     {
-        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""");
+        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", "store");
         Assert.Contains("type of memory", msg!);
     }
 
@@ -71,7 +64,7 @@ public class ToolArgumentGuardTests
     [InlineData("null")]        // JSON null
     public void Empty_or_null_string_for_required_counts_as_missing(string typeValue)
     {
-        var msg = Validate(StoreSchema, $$"""{ "type": {{typeValue}}, "text": "hi", "source": "LLM", "title": "T" }""");
+        var msg = Validate(StoreSchema, $$"""{ "type": {{typeValue}}, "text": "hi", "source": "LLM", "title": "T" }""", "store");
         Assert.NotNull(msg);
         Assert.Contains("type", msg);
     }
@@ -79,25 +72,26 @@ public class ToolArgumentGuardTests
     [Fact]
     public void All_required_present_is_allowed_through()
     {
-        var msg = Validate(StoreSchema, """{ "type": "reference", "text": "hi", "source": "LLM", "title": "T" }""");
+        var msg = Validate(StoreSchema, """{ "type": "reference", "text": "hi", "source": "LLM", "title": "T" }""", "store");
         Assert.Null(msg);
     }
 
     [Fact]
     public void Wrong_json_type_for_a_field_is_reported()
     {
-        // text declared string, sent as a number.
-        var msg = Validate(StoreSchema, """{ "type": "reference", "text": 42, "source": "LLM", "title": "T" }""");
+        // 'confidence' is declared as a number; send a string.
+        var msg = Validate(StoreSchema,
+            """{ "type": "reference", "text": "hi", "source": "LLM", "title": "T", "confidence": "high" }""", "store");
         Assert.NotNull(msg);
-        Assert.Contains("text", msg);
-        Assert.Contains("string", msg, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("confidence", msg);
+        Assert.Contains("number", msg, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
     public void Malformed_uuid_is_reported_as_invalid_id()
     {
         // The N-format id (no hyphens) the model lifted from a recall doc-id.
-        var msg = Validate(IdSchema, """{ "id": "dec906c7e5d14abebaf827af5a842ae5" }""", tool: "get");
+        var msg = Validate(GetSchema, """{ "id": "dec906c7e5d14abebaf827af5a842ae5" }""", "get");
         Assert.NotNull(msg);
         Assert.Contains("id", msg);
         Assert.Contains("UUID", msg, StringComparison.OrdinalIgnoreCase);
@@ -106,7 +100,7 @@ public class ToolArgumentGuardTests
     [Fact]
     public void Hyphenated_uuid_is_allowed_through()
     {
-        var msg = Validate(IdSchema, """{ "id": "dec906c7-e5d1-4abe-baf8-27af5a842ae5" }""", tool: "get");
+        var msg = Validate(GetSchema, """{ "id": "dec906c7-e5d1-4abe-baf8-27af5a842ae5" }""", "get");
         Assert.Null(msg);
     }
 
@@ -114,22 +108,23 @@ public class ToolArgumentGuardTests
     public void Extra_unknown_argument_is_ignored_when_required_are_present()
     {
         var msg = Validate(StoreSchema,
-            """{ "type": "reference", "text": "hi", "source": "LLM", "title": "T", "_rationale": "why" }""");
+            """{ "type": "reference", "text": "hi", "source": "LLM", "title": "T", "_rationale": "why" }""", "store");
         Assert.Null(msg);
     }
 
     [Fact]
     public void Non_object_schema_skips_validation()
     {
-        // Fail open: if there's no object schema to check against, don't block the call.
-        var msg = Validate("\"not-a-schema\"", """{ "anything": 1 }""");
-        Assert.Null(msg);
+        // Fail open: with no object schema to check against, don't block the call.
+        using var doc = JsonDocument.Parse("\"not-a-schema\"");
+        var args = new Dictionary<string, JsonElement>();
+        Assert.Null(ToolArgumentGuard.Validate("store", doc.RootElement, args));
     }
 
     [Fact]
     public void Message_is_prefixed_with_the_tool_name()
     {
-        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", tool: "store");
+        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", "store");
         Assert.StartsWith("store:", msg);
     }
 }

--- a/src/Memorizer/Extensions/McpToolValidationExtensions.cs
+++ b/src/Memorizer/Extensions/McpToolValidationExtensions.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Memorizer.Tools;
+
+namespace Memorizer.Extensions;
+
+/// <summary>
+/// Registers a CallTool boundary that owns the error surface for every MCP tool.
+///
+/// The 2.2.0 SDK marshals tool arguments strictly and throws before the tool method
+/// runs when a required parameter is missing or a typed parameter is malformed, which
+/// the client sees as an opaque <c>"An error occurred invoking '&lt;tool&gt;'"</c>. This
+/// filter validates the raw arguments against each tool's own advertised schema and
+/// short-circuits with a correctable, memorizer-authored message — so no opaque SDK
+/// error ever reaches an agent, for any tool, now or after a future SDK bump.
+/// </summary>
+public static class McpToolValidationExtensions
+{
+    public static IMcpServerBuilder AddToolArgumentValidation(this IMcpServerBuilder builder)
+    {
+        builder.WithRequestFilters(filters =>
+        {
+            filters.AddCallToolFilter(next => async (context, cancellationToken) =>
+            {
+                var toolName = context.Params?.Name ?? "tool";
+
+                // The tool's advertised JSON schema — the same one emitted in ListTools —
+                // is the single source of truth for what's required and typed. Reusing it
+                // means validation can never drift from the contract.
+                var schema = (context.MatchedPrimitive as McpServerTool)?.ProtocolTool.InputSchema
+                             ?? default;
+
+                var message = ToolArgumentGuard.Validate(toolName, schema, context.Params?.Arguments);
+                if (message is not null)
+                    return ErrorResult(message);
+
+                try
+                {
+                    return await next(context, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw; // Cancellation is not a tool error.
+                }
+                catch (Exception ex)
+                {
+                    // Backstop: something threw past validation (an argument shape we did
+                    // not anticipate, or a failure inside the tool body). Own the message
+                    // rather than let the SDK emit its opaque one.
+                    context.Services?.GetService<ILoggerFactory>()
+                        ?.CreateLogger("Memorizer.Tools.Validation")
+                        .LogError(ex, "Tool {Tool} threw after argument validation", toolName);
+
+                    return ErrorResult(
+                        $"{toolName}: the call could not be completed ({ex.Message}). "
+                        + "Check the arguments against the tool's schema and retry.");
+                }
+            });
+        });
+
+        return builder;
+    }
+
+    private static CallToolResult ErrorResult(string message) => new()
+    {
+        IsError = true,
+        Content = new List<ContentBlock> { new TextContentBlock { Text = message } },
+    };
+}

--- a/src/Memorizer/Program.cs
+++ b/src/Memorizer/Program.cs
@@ -45,7 +45,10 @@ builder.Services.AddMcpServer()
     .WithTools<MemoryTools>()
     .WithTools<WorkspaceTools>()
     .WithPrompts<MemorizerPrompts>()
-    .WithResources<MemorizerResources>();
+    .WithResources<MemorizerResources>()
+    // Own the error surface: validate tool arguments at the CallTool boundary and
+    // return correctable messages instead of the SDK's opaque marshaller errors.
+    .AddToolArgumentValidation();
 
 // Add MVC support for web UI
 builder.Services.AddControllersWithViews()

--- a/src/Memorizer/Tools/ToolArgumentGuard.cs
+++ b/src/Memorizer/Tools/ToolArgumentGuard.cs
@@ -1,0 +1,224 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Memorizer.Tools;
+
+/// <summary>
+/// Schema-driven validation of MCP tool arguments, run at the CallTool boundary
+/// <em>before</em> the SDK's argument marshaller. The 2.2.0 MCP SDK
+/// (<c>Microsoft.Extensions.AI.AIFunctionFactory</c>) throws an
+/// <see cref="ArgumentException"/> when a required parameter is missing or a typed
+/// parameter (e.g. <see cref="Guid"/>) is malformed, and that exception surfaces to
+/// the client as an opaque <c>"An error occurred invoking '&lt;tool&gt;'"</c>. Agents
+/// cannot recover from that. This guard inspects the raw arguments against the tool's
+/// own advertised JSON schema and returns a memorizer-authored, correctable message so
+/// the model can fix its next call.
+///
+/// The logic is a pure function of (tool name, schema, arguments) so it can be unit
+/// tested without booting the SDK. The CallTool filter is a thin adapter over it.
+/// </summary>
+public static class ToolArgumentGuard
+{
+    /// <summary>
+    /// Validate <paramref name="arguments"/> against <paramref name="inputSchema"/>.
+    /// Returns <c>null</c> when the call is well-formed (let it proceed), or a
+    /// correctable, agent-facing message describing the first problem found.
+    /// </summary>
+    /// <param name="toolName">Snake_case tool name, for the message prefix.</param>
+    /// <param name="inputSchema">The tool's advertised JSON schema (the same one the
+    /// SDK emits in ListTools). If it is not a JSON object, validation is skipped.</param>
+    /// <param name="arguments">The raw arguments the client sent.</param>
+    public static string? Validate(
+        string toolName,
+        JsonElement inputSchema,
+        IDictionary<string, JsonElement>? arguments)
+    {
+        if (inputSchema.ValueKind != JsonValueKind.Object)
+            return null; // No schema to validate against — fail open to the pipeline.
+
+        var properties = inputSchema.TryGetProperty("properties", out var props)
+            && props.ValueKind == JsonValueKind.Object
+                ? props
+                : default;
+
+        // 1. Required fields must be present and not effectively empty.
+        if (inputSchema.TryGetProperty("required", out var required)
+            && required.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var requiredField in required.EnumerateArray())
+            {
+                if (requiredField.ValueKind != JsonValueKind.String)
+                    continue;
+
+                var field = requiredField.GetString()!;
+                var declaredType = DeclaredType(properties, field);
+
+                if (arguments is null
+                    || !arguments.TryGetValue(field, out var value)
+                    || IsEffectivelyMissing(value, declaredType))
+                {
+                    return MissingRequiredMessage(toolName, field, properties, required);
+                }
+            }
+        }
+
+        // 2. Present fields must match their declared type / format.
+        if (arguments is not null && properties.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var (name, value) in arguments)
+            {
+                if (!properties.TryGetProperty(name, out var propSchema)
+                    || propSchema.ValueKind != JsonValueKind.Object)
+                    continue; // Unknown/extra arg — the marshaller ignores it; so do we.
+
+                if (value.ValueKind is JsonValueKind.Null)
+                    continue; // Null on an optional field is fine.
+
+                var declaredType = TypeOf(propSchema);
+
+                if (declaredType is { } t && !KindMatches(t, value.ValueKind))
+                    return TypeMismatchMessage(toolName, name, t, value);
+
+                if (IsUuidFormat(propSchema) && !IsBinderCompatibleGuid(value))
+                    return InvalidIdMessage(toolName, name, value);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// A string field counts as "missing" when absent, JSON null, whitespace, or the
+    /// literal string "null" — the shapes MCP clients (e.g. Cursor) send for an
+    /// omitted value. See #166.
+    /// </summary>
+    private static bool IsEffectivelyMissing(JsonElement value, string? declaredType)
+    {
+        if (value.ValueKind == JsonValueKind.Null)
+            return true;
+
+        if (declaredType == "string" && value.ValueKind == JsonValueKind.String)
+        {
+            var s = value.GetString();
+            return string.IsNullOrWhiteSpace(s) || string.Equals(s, "null", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static string? DeclaredType(JsonElement properties, string field)
+        => properties.ValueKind == JsonValueKind.Object
+            && properties.TryGetProperty(field, out var p)
+            && p.ValueKind == JsonValueKind.Object
+                ? TypeOf(p)
+                : null;
+
+    /// <summary>Reads a schema node's "type", tolerating the JSON-Schema union form
+    /// <c>["string","null"]</c> by taking the first non-null entry.</summary>
+    private static string? TypeOf(JsonElement propSchema)
+    {
+        if (!propSchema.TryGetProperty("type", out var type))
+            return null;
+
+        if (type.ValueKind == JsonValueKind.String)
+            return type.GetString();
+
+        if (type.ValueKind == JsonValueKind.Array)
+            foreach (var entry in type.EnumerateArray())
+                if (entry.ValueKind == JsonValueKind.String && entry.GetString() is { } s && s != "null")
+                    return s;
+
+        return null;
+    }
+
+    private static bool KindMatches(string declaredType, JsonValueKind kind) => declaredType switch
+    {
+        "string" => kind == JsonValueKind.String,
+        "boolean" => kind is JsonValueKind.True or JsonValueKind.False,
+        "number" or "integer" => kind == JsonValueKind.Number,
+        "array" => kind == JsonValueKind.Array,
+        "object" => kind == JsonValueKind.Object,
+        _ => true, // Unknown/composite schema — don't second-guess the marshaller.
+    };
+
+    private static bool IsUuidFormat(JsonElement propSchema)
+        => propSchema.TryGetProperty("format", out var fmt)
+            && fmt.ValueKind == JsonValueKind.String
+            && string.Equals(fmt.GetString(), "uuid", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when the value would bind to a <see cref="Guid"/> through the SDK's
+    /// System.Text.Json marshaller, which accepts only the hyphenated "D" form. A
+    /// 32-hex "N" form (as recall subsystems emit, e.g. <c>doc-…</c> ids) parses via
+    /// <see cref="Guid.TryParse"/> but is rejected by the binder — so we flag it here.
+    /// </summary>
+    private static bool IsBinderCompatibleGuid(JsonElement value)
+        => value.ValueKind == JsonValueKind.String
+            && Guid.TryParseExact(value.GetString(), "D", out _);
+
+    private static string MissingRequiredMessage(
+        string toolName, string field, JsonElement properties, JsonElement required)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"{toolName}: required field '{field}' is missing.");
+
+        if (Description(properties, field) is { Length: > 0 } desc)
+            sb.Append($" {desc}");
+
+        sb.Append(' ').Append("Provide it and retry. Minimal example: ")
+          .Append(MinimalExample(properties, required));
+        return sb.ToString();
+    }
+
+    private static string TypeMismatchMessage(string toolName, string field, string declaredType, JsonElement value)
+        => $"{toolName}: field '{field}' must be {Article(declaredType)} {declaredType}, but got {value.ValueKind}. "
+           + "Fix the value's type and retry.";
+
+    private static string InvalidIdMessage(string toolName, string field, JsonElement value)
+        => $"{toolName}: field '{field}' must be a UUID like '00000000-0000-0000-0000-000000000000'. "
+           + $"Got '{value.GetString()}'. Use the id exactly as returned by store/search (drop any 'doc-' prefix).";
+
+    private static string? Description(JsonElement properties, string field)
+    {
+        if (properties.ValueKind == JsonValueKind.Object
+            && properties.TryGetProperty(field, out var p)
+            && p.ValueKind == JsonValueKind.Object
+            && p.TryGetProperty("description", out var d)
+            && d.ValueKind == JsonValueKind.String)
+        {
+            var text = d.GetString();
+            return text is { Length: > 160 } ? text[..160] + "…" : text;
+        }
+        return null;
+    }
+
+    /// <summary>Builds a minimal JSON object containing exactly the required fields,
+    /// with placeholder values keyed off each field's declared type, so the agent sees
+    /// the shape it must send.</summary>
+    private static string MinimalExample(JsonElement properties, JsonElement required)
+    {
+        var sb = new StringBuilder("{");
+        var first = true;
+        foreach (var r in required.EnumerateArray())
+        {
+            if (r.ValueKind != JsonValueKind.String) continue;
+            var field = r.GetString()!;
+            if (!first) sb.Append(", ");
+            first = false;
+            sb.Append('"').Append(field).Append("\": ").Append(Placeholder(DeclaredType(properties, field)));
+        }
+        return sb.Append('}').ToString();
+    }
+
+    private static string Placeholder(string? type) => type switch
+    {
+        "number" or "integer" => "1",
+        "boolean" => "true",
+        "array" => "[]",
+        "object" => "{}",
+        _ => "\"…\"",
+    };
+
+    private static string Article(string word)
+        => word.Length > 0 && "aeiou".Contains(char.ToLowerInvariant(word[0])) ? "an" : "a";
+}


### PR DESCRIPTION
## Problem

After the 2.3.0 deploy, agents began getting opaque `An error occurred invoking '<tool>'` failures from `store` and `get`. Traced end to end (netclaw session logs → memorizer OTel logs in Seq):

- `store` (Seq, ~18:31 UTC): `System.ArgumentException: The arguments dictionary is missing a value for the required parameter 'type'` — thrown in `Microsoft.Extensions.AI.AIFunctionFactory` before the tool method runs.
- `get`: an unhyphenated 32-hex id (a recall `doc-…` id minus its prefix) rejected by strict `Guid` binding.

Root cause: **#211** bumped the MCP SDK (`ModelContextProtocol` `0.4.0-preview.3 → 2.2.0`). The stable SDK validates tool arguments strictly and throws before the method runs. The tool code itself did not change between 2.2.0 and 2.3.0. This defeated the in-body resilience from #166/#184, which relied on the preview SDK delivering loose/missing args to the method. First occurrence in Seq: Aug 18, none before — it started with the deploy.

## Fix (Piece 1: own the error surface)

A single `CallTool` filter validates raw arguments against each tool's advertised JSON schema **before** the SDK marshaller runs, and short-circuits with a correctable, agent-facing message. A backstop `catch` guarantees no opaque SDK error can escape, for any tool — present or future.

- `ToolArgumentGuard` — pure, schema-driven validation: required-present (with `""`/whitespace/`"null"` treated as missing, per #166), type-kind match, binder-compatible UUID format. Returns a correctable message or `null`.
- `AddToolArgumentValidation()` — the filter wiring on `AddMcpServer()`.
- Messages name the field, surface its description, and show a minimal valid example.

## Tests

- 13 unit tests over `ToolArgumentGuard` (no SDK).
- 6 integration tests through the real Streamable-HTTP pipeline:
  - `store` without `type` → correctable message, not the opaque string (the exact incident repro; proves the filter fires before the marshaller).
  - `get` with an unhyphenated id → correctable, not opaque.
  - a tripwire across `store`/`get`/`edit` that fails if any call returns `An error occurred invoking` — the standing guard for the next SDK bump.
  - a valid call (`create_workspace`) passes straight through the filter unblocked (no coupling to the embedding backend).

Build clean; unit 212/212; `McpServerTests` 10/10.

## Scope

Piece 1 of `docs/agent-resilient-tool-surface-plan.md` (included). Follow-ups: Piece 2 (defaults + loose id normalization so calls succeed rather than just fail-correctable), and Piece 4 (embedding-layer store failures from #215 — a separate class this boundary does not address).
