### PR TITLE
Fix provider-settings test contamination leaking a bogus embedding model

### DIFF
--- a/src/Memorizer.IntegrationTests/ProviderSettingsSyncTests.cs
+++ b/src/Memorizer.IntegrationTests/ProviderSettingsSyncTests.cs
@@ -32,11 +32,8 @@ public class ProviderSettingsSyncTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        // Clean up provider_settings table before each test
-        await using var dataSource = NpgsqlDataSource.Create(_fixture.PostgresConnectionString);
-        await using var conn = await dataSource.OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("DELETE FROM provider_settings", conn);
-        await cmd.ExecuteNonQueryAsync();
+        // Clean up provider_settings before each test (in case a prior run leaked rows).
+        await CleanProviderSettingsAsync();
     }
 
     public async Task DisposeAsync()
@@ -46,6 +43,22 @@ public class ProviderSettingsSyncTests : IAsyncLifetime
             await _host.StopAsync();
             _host.Dispose();
         }
+
+        // Symmetric cleanup — this class shares the Postgres container with the rest of
+        // the collection and writes ACTIVE provider_settings rows to prove DB settings
+        // override config. Without removing them on teardown, the last row (e.g. the
+        // nonexistent 'custom-embedding-model') survives into other tests: their full-app
+        // startup (InitializationService) applies it, so their embedding calls target a
+        // model Ollama has not pulled and fail. Clean on the way out, not just in.
+        await CleanProviderSettingsAsync();
+    }
+
+    private async Task CleanProviderSettingsAsync()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(_fixture.PostgresConnectionString);
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var cmd = new NpgsqlCommand("DELETE FROM provider_settings", conn);
+        await cmd.ExecuteNonQueryAsync();
     }
 
     private IHost CreateHost(Dictionary<string, string?> configOverrides)


### PR DESCRIPTION
## Problem

Integration tests in the `IntegrationTestCollection` share one Postgres container. `ProviderSettingsSyncTests` inserts an **active** `provider_settings` row with a deliberately nonexistent `custom-embedding-model` (to prove DB provider settings override appsettings), but it cleaned the table only in `InitializeAsync` — before each of its own tests — not on teardown.

The last row therefore survived in the shared database. Any later test in the collection that boots the full app (`McpServerTests` via `WebApplicationFactory<Program>`) had `InitializationService` apply that row at startup, so its embedding calls targeted a model Ollama never pulled and failed with `EmbeddingGenerationException`. This is order-dependent test contamination, not a production or model problem — the real settings flow (`SettingsController`) verifies a model against the backend before saving, which the raw `INSERT` bypasses.

## Fix

Clean `provider_settings` on the way **out** as well as in (symmetric teardown), so this class no longer pollutes the shared database for the rest of the collection.

## Verification

`ProviderSettingsSyncTests` + `McpServerTests` run together → 16/16 green, build clean.
