### PR TITLE
Agent-friendly tool ergonomics: defaults + loose id parsing (Piece 2)

### DIFF
--- a/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
@@ -163,19 +163,18 @@ public sealed class McpServerTests : IAsyncLifetime
         string.Join("\n", result.Content.OfType<TextContentBlock>().Select(c => c.Text));
 
     [Fact]
-    public async Task Store_without_type_returns_a_correctable_error_not_the_opaque_sdk_error()
+    public async Task Store_without_a_required_field_returns_a_correctable_error_not_the_opaque_sdk_error()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         await using var mcp = await ConnectAsync(cts.Token);
 
-        // 'type' deliberately omitted — the exact shape that failed in the incident.
+        // 'title' omitted — still required (it's the search index). 'type'/'source' now
+        // default, so title is the probe for the boundary's required-field handling.
         var result = await mcp.Client.CallToolAsync(
             "store",
             new Dictionary<string, object?>
             {
                 ["text"] = "hello world",
-                ["source"] = "LLM",
-                ["title"] = "Boundary test",
             },
             cancellationToken: cts.Token);
 
@@ -187,7 +186,7 @@ public sealed class McpServerTests : IAsyncLifetime
         // tells the agent it is required. Without this, the test would still pass if the
         // SDK front-ran us with some other unhelpful message that merely lacks the opaque
         // string.
-        Assert.Contains("type", text);
+        Assert.Contains("title", text);
         Assert.Contains("required", text, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -212,24 +211,45 @@ public sealed class McpServerTests : IAsyncLifetime
         Assert.Contains("not found", text, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
-    public async Task Get_with_unhyphenated_id_returns_a_correctable_error_not_the_opaque_sdk_error()
+    [Theory]
+    [InlineData("dec906c7e5d14abebaf827af5a842ae5")]      // 32-hex, no hyphens (N-format)
+    [InlineData("doc-dec906c7e5d14abebaf827af5a842ae5")]  // recall doc- prefix, N-format
+    public async Task Get_with_lightly_mangled_id_is_normalized_and_resolves(string id)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
         await using var mcp = await ConnectAsync(cts.Token);
 
-        // 32-hex, no hyphens — as a recall doc-id (minus its 'doc-' prefix) would arrive.
+        // Piece 2: ids are parsed loosely, so these resolve to a real UUID and reach the
+        // tool (which returns a graceful "not found" since nothing is stored) instead of
+        // erroring at the boundary. No embedding is generated on a not-found get.
         var result = await mcp.Client.CallToolAsync(
             "get",
-            new Dictionary<string, object?> { ["id"] = "dec906c7e5d14abebaf827af5a842ae5" },
+            new Dictionary<string, object?> { ["id"] = id },
             cancellationToken: cts.Token);
 
         var text = ResultText(result);
         _output.WriteLine(text);
-        Assert.True(result.IsError == true);
+        Assert.NotEqual(true, result.IsError);
         Assert.DoesNotContain(OpaqueSdkError, text);
-        // Corrective: the message must point the agent at the id format it should use.
-        Assert.Contains("UUID", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not found", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Get_with_unparseable_id_returns_a_correctable_message()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        var result = await mcp.Client.CallToolAsync(
+            "get",
+            new Dictionary<string, object?> { ["id"] = "not-a-real-id" },
+            cancellationToken: cts.Token);
+
+        var text = ResultText(result);
+        _output.WriteLine(text);
+        Assert.DoesNotContain(OpaqueSdkError, text);
+        // Tool-body validation returns a plain, corrective string (the existing convention).
+        Assert.Contains("Invalid memory id", text);
     }
 
     [Theory]

--- a/src/Memorizer.IntegrationTests/MemoryToolsIntegrationTests.cs
+++ b/src/Memorizer.IntegrationTests/MemoryToolsIntegrationTests.cs
@@ -100,7 +100,7 @@ public class MemoryToolsIntegrationTests : IDisposable
 
         // Act - Check off "Write integration tests"
         var result = await tools.Edit(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             "- [ ] Write integration tests",
             "- [x] Write integration tests",
             replace_all: false);
@@ -147,7 +147,7 @@ Call foo() to start the process.";
 
         // Act - Replace all occurrences of "foo" with "initialize"
         var result = await tools.Edit(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             "foo",
             "initialize",
             replace_all: true);
@@ -185,7 +185,7 @@ Call foo() to start the process.";
 
         // Act - Replace without replace_all (defaults to false)
         var result = await tools.Edit(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             "apple",
             "orange");
 
@@ -218,7 +218,7 @@ Call foo() to start the process.";
 
         // Act - Try to replace text that doesn't exist
         var result = await tools.Edit(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             "Goodbye World",
             "New Text");
 
@@ -240,7 +240,7 @@ Call foo() to start the process.";
 
         // Act
         var result = await tools.Edit(
-            nonExistentId,
+            nonExistentId.ToString(),
             "old text",
             "new text");
 
@@ -276,7 +276,7 @@ that should be replaced.
 
         // Act - Replace multi-line section
         var result = await tools.Edit(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             @"Old paragraph here
 with multiple lines
 that should be replaced.",
@@ -313,9 +313,9 @@ that should be replaced.",
             "Version Test");
 
         // Act - Make multiple edits
-        await tools.Edit(memory.Id.Value, "Version 1", "Version 2");
-        await tools.Edit(memory.Id.Value, "Version 2", "Version 3");
-        await tools.Edit(memory.Id.Value, "Version 3", "Version 4");
+        await tools.Edit(memory.Id.Value.ToString(), "Version 1", "Version 2");
+        await tools.Edit(memory.Id.Value.ToString(), "Version 2", "Version 3");
+        await tools.Edit(memory.Id.Value.ToString(), "Version 3", "Version 4");
 
         // Assert - Check version history
         // Each edit creates a snapshot of the PREVIOUS state, so 3 edits = 3 version snapshots
@@ -348,7 +348,7 @@ that should be replaced.",
 
         // Act - Try to replace with identical text
         var result = await tools.Edit(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             "Same",
             "Same");
 
@@ -384,7 +384,7 @@ that should be replaced.",
 
         // Act
         var result = await tools.UpdateMetadata(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             title: "Updated Title");
 
         _output.WriteLine($"UpdateMetadata result: {result}");
@@ -417,7 +417,7 @@ that should be replaced.",
 
         // Act
         var result = await tools.UpdateMetadata(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             tags: new[] { "new-tag-1", "new-tag-2" });
 
         _output.WriteLine($"UpdateMetadata result: {result}");
@@ -451,7 +451,7 @@ that should be replaced.",
 
         // Act
         var result = await tools.UpdateMetadata(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             type: "published");
 
         _output.WriteLine($"UpdateMetadata result: {result}");
@@ -481,7 +481,7 @@ that should be replaced.",
 
         // Act
         var result = await tools.UpdateMetadata(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             confidence: 0.95);
 
         _output.WriteLine($"UpdateMetadata result: {result}");
@@ -511,7 +511,7 @@ that should be replaced.",
 
         // Act - Update everything at once
         var result = await tools.UpdateMetadata(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             title: "Final Title",
             type: "reference",
             tags: new[] { "final", "tested" },
@@ -551,7 +551,7 @@ that should be replaced.",
 
         // Act - Only update title, everything else should be preserved
         var result = await tools.UpdateMetadata(
-            memory.Id.Value,
+            memory.Id.Value.ToString(),
             title: "Updated Important Memory");
 
         _output.WriteLine($"UpdateMetadata result: {result}");
@@ -577,7 +577,7 @@ that should be replaced.",
 
         // Act
         var result = await tools.UpdateMetadata(
-            nonExistentId,
+            nonExistentId.ToString(),
             title: "New Title");
 
         _output.WriteLine($"UpdateMetadata result: {result}");
@@ -718,7 +718,7 @@ that should be replaced.",
 
         foreach (var (oldText, newText) in tasks)
         {
-            var editResult = await tools.Edit(memoryId, oldText, newText);
+            var editResult = await tools.Edit(memoryId.ToString(), oldText, newText);
             _output.WriteLine($"Edit '{oldText}' -> {editResult}");
             Assert.Contains("Edit successful", editResult);
         }
@@ -760,7 +760,7 @@ that should be replaced.",
         var memoryId = Guid.Parse(idMatch.Groups[1].Value);
 
         // Make a mistake
-        await tools.Edit(memoryId, "original correct", "wrong");
+        await tools.Edit(memoryId.ToString(), "original correct", "wrong");
 
         var wrongMemory = await storage.Get((MemoryId)memoryId);
         Assert.NotNull(wrongMemory);
@@ -768,7 +768,7 @@ that should be replaced.",
         Assert.Equal(new VersionNumber(2), wrongMemory.CurrentVersion);
 
         // Revert to original
-        var revertResult = await tools.RevertToVersion(memoryId, new VersionNumber(1));
+        var revertResult = await tools.RevertToVersion(memoryId.ToString(), new VersionNumber(1));
         _output.WriteLine($"Revert result: {revertResult}");
 
         Assert.Contains("successfully reverted", revertResult);

--- a/src/Memorizer.UnitTests/EntityIdTests.cs
+++ b/src/Memorizer.UnitTests/EntityIdTests.cs
@@ -68,6 +68,13 @@ public class EntityIdTests
     [InlineData("memory-dec906c7-e5d1-4abe-baf8-27af5a842ae5")]       // memory- prefix
     [InlineData("https://memory.testlab.petabridge.net/view/dec906c7-e5d1-4abe-baf8-27af5a842ae5")] // pasted URL
     [InlineData("https://memory.testlab.petabridge.net/view/dec906c7-e5d1-4abe-baf8-27af5a842ae5?v=2")] // URL + query
+    [InlineData("DOC-dec906c7e5d14abebaf827af5a842ae5")]             // prefix is case-insensitive
+    [InlineData("Memory-dec906c7-e5d1-4abe-baf8-27af5a842ae5")]      // mixed-case prefix
+    [InlineData("DEC906C7-E5D1-4ABE-BAF8-27AF5A842AE5")]             // uppercase hex (D-format)
+    [InlineData("DEC906C7E5D14ABEBAF827AF5A842AE5")]                 // uppercase hex (N-format)
+    [InlineData("https://memory.testlab.petabridge.net/view/dec906c7-e5d1-4abe-baf8-27af5a842ae5/")]        // trailing slash
+    [InlineData("https://memory.testlab.petabridge.net/view/dec906c7-e5d1-4abe-baf8-27af5a842ae5#details")] // URL fragment
+    [InlineData("{dec906c7-e5d1-4abe-baf8-27af5a842ae5}")]           // braced form (GUID 'B')
     public void MemoryId_TryParseLoose_AcceptsAgentShapes(string input)
     {
         var ok = MemoryId.TryParseLoose(input, out var id);
@@ -82,6 +89,10 @@ public class EntityIdTests
     [InlineData("   ")]
     [InlineData("not-a-guid")]
     [InlineData("doc-not-a-guid")]
+    [InlineData("doc-")]                                              // prefix only, no id
+    [InlineData("doc-memory-dec906c7e5d14abebaf827af5a842ae5")]       // only one prefix is stripped
+    [InlineData("https://memory.testlab.petabridge.net/view/")]       // URL with no id segment
+    [InlineData("12345")]                                             // too short to be a GUID
     public void MemoryId_TryParseLoose_RejectsGarbage(string? input)
     {
         var ok = MemoryId.TryParseLoose(input, out var id);

--- a/src/Memorizer.UnitTests/EntityIdTests.cs
+++ b/src/Memorizer.UnitTests/EntityIdTests.cs
@@ -102,6 +102,27 @@ public class EntityIdTests
     }
 
     [Fact]
+    public void MemoryId_TryParseLoose_NeverMisreadsAValidGuid()
+    {
+        // Collision guard: normalization must never turn one valid GUID into a different
+        // one. It only strips non-hex wrappers, and every strip-prefix (doc-/memory-/mem-)
+        // begins with a non-hex letter while a canonical GUID string begins with a hex
+        // digit — so no valid id can be mis-stripped. Verified over many random GUIDs in
+        // both D and N forms; if a future prefix could ever lead a GUID, a round-trip here
+        // would fail (either a mismatch or a rejected parse).
+        for (var i = 0; i < 500; i++)
+        {
+            var g = Guid.NewGuid();
+
+            Assert.True(MemoryId.TryParseLoose(g.ToString("D"), out var d));
+            Assert.Equal(g, d.Value);
+
+            Assert.True(MemoryId.TryParseLoose(g.ToString("N"), out var n));
+            Assert.Equal(g, n.Value);
+        }
+    }
+
+    [Fact]
     public void MemoryId_ExplicitCast_ToGuid_Works()
     {
         var guid = Guid.NewGuid();

--- a/src/Memorizer.UnitTests/EntityIdTests.cs
+++ b/src/Memorizer.UnitTests/EntityIdTests.cs
@@ -60,6 +60,36 @@ public class EntityIdTests
         Assert.Equal(MemoryId.Empty, id);
     }
 
+    [Theory]
+    [InlineData("dec906c7-e5d1-4abe-baf8-27af5a842ae5")]              // hyphenated (D)
+    [InlineData("dec906c7e5d14abebaf827af5a842ae5")]                  // 32-hex (N)
+    [InlineData("  dec906c7-e5d1-4abe-baf8-27af5a842ae5  ")]          // surrounding whitespace
+    [InlineData("doc-dec906c7e5d14abebaf827af5a842ae5")]              // recall doc- prefix
+    [InlineData("memory-dec906c7-e5d1-4abe-baf8-27af5a842ae5")]       // memory- prefix
+    [InlineData("https://memory.testlab.petabridge.net/view/dec906c7-e5d1-4abe-baf8-27af5a842ae5")] // pasted URL
+    [InlineData("https://memory.testlab.petabridge.net/view/dec906c7-e5d1-4abe-baf8-27af5a842ae5?v=2")] // URL + query
+    public void MemoryId_TryParseLoose_AcceptsAgentShapes(string input)
+    {
+        var ok = MemoryId.TryParseLoose(input, out var id);
+
+        Assert.True(ok);
+        Assert.Equal(Guid.Parse("dec906c7-e5d1-4abe-baf8-27af5a842ae5"), id.Value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-guid")]
+    [InlineData("doc-not-a-guid")]
+    public void MemoryId_TryParseLoose_RejectsGarbage(string? input)
+    {
+        var ok = MemoryId.TryParseLoose(input, out var id);
+
+        Assert.False(ok);
+        Assert.Equal(MemoryId.Empty, id);
+    }
+
     [Fact]
     public void MemoryId_ExplicitCast_ToGuid_Works()
     {

--- a/src/Memorizer.UnitTests/Tools/McpToolParameterValidationTests.cs
+++ b/src/Memorizer.UnitTests/Tools/McpToolParameterValidationTests.cs
@@ -32,33 +32,20 @@ public class McpToolParameterValidationTests
         new FakeCanonicalUrlService { IsConfigured = false });
 
     // ===== Store =====
-
-    [Fact]
-    public async Task Store_WhenTypeMissing_ReturnsErrorNotException()
-    {
-        var result = await CreateMemoryTools().Store(type: "", text: "body", source: "LLM", title: "Title");
-        Assert.Contains("'type' is required", result);
-    }
+    // Only text and title are required now; 'type' and 'source' default (see Store defaults
+    // coverage in MemoryToolsCanonicalUrlTests / ToolArgumentGuardTests).
 
     [Fact]
     public async Task Store_WhenTextMissing_ReturnsErrorNotException()
     {
-        var result = await CreateMemoryTools().Store(type: "reference", text: "   ", source: "LLM", title: "Title");
+        var result = await CreateMemoryTools().Store(text: "   ", title: "Title", type: "reference", source: "LLM");
         Assert.Contains("'text' is required", result);
-    }
-
-    [Fact]
-    public async Task Store_WhenSourceMissing_ReturnsErrorNotException()
-    {
-        // 'source' omitted was observed 4x in production logs.
-        var result = await CreateMemoryTools().Store(type: "reference", text: "body", source: "", title: "Title");
-        Assert.Contains("'source' is required", result);
     }
 
     [Fact]
     public async Task Store_WhenTitleMissing_ReturnsErrorNotException()
     {
-        var result = await CreateMemoryTools().Store(type: "reference", text: "body", source: "LLM", title: "");
+        var result = await CreateMemoryTools().Store(text: "body", title: "", type: "reference", source: "LLM");
         Assert.Contains("'title' is required", result);
     }
 
@@ -68,14 +55,14 @@ public class McpToolParameterValidationTests
     public async Task Edit_WhenOldTextMissing_ReturnsErrorNotException()
     {
         // 'old_text' omitted was observed 8x in production logs.
-        var result = await CreateMemoryTools().Edit(id: Guid.NewGuid(), old_text: "", new_text: "replacement");
+        var result = await CreateMemoryTools().Edit(id: Guid.NewGuid().ToString(), old_text: "", new_text: "replacement");
         Assert.Contains("'old_text' is required", result);
     }
 
     [Fact]
     public async Task Edit_WhenNewTextNull_ReturnsErrorNotException()
     {
-        var result = await CreateMemoryTools().Edit(id: Guid.NewGuid(), old_text: "find me", new_text: null!);
+        var result = await CreateMemoryTools().Edit(id: Guid.NewGuid().ToString(), old_text: "find me", new_text: null!);
         Assert.Contains("'new_text' is required", result);
     }
 

--- a/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
+++ b/src/Memorizer.UnitTests/Tools/MemoryToolsCanonicalUrlTests.cs
@@ -310,7 +310,7 @@ public class MemoryToolsCanonicalUrlTests
         var tools = CreateTools(fakeStorage, fakeUrlService);
 
         // Act
-        var result = await tools.Get(memoryId.Value, includeSimilar: false);
+        var result = await tools.Get(memoryId.Value.ToString(), includeSimilar: false);
 
         // Assert
         Assert.Contains(TestCanonicalUrl, result);
@@ -339,7 +339,7 @@ public class MemoryToolsCanonicalUrlTests
         var tools = CreateTools(fakeStorage, fakeUrlService);
 
         // Act
-        var result = await tools.GetMany(memoryIds);
+        var result = await tools.GetMany(memoryIds.Select(x => x.ToString()).ToArray());
 
         // Assert
         Assert.Contains(TestCanonicalUrl, result);

--- a/src/Memorizer.UnitTests/Tools/ToolArgumentGuardTests.cs
+++ b/src/Memorizer.UnitTests/Tools/ToolArgumentGuardTests.cs
@@ -27,7 +27,13 @@ public class ToolArgumentGuardTests
         => McpServerTool.Create(toolMethod).ProtocolTool.InputSchema;
 
     private static JsonElement StoreSchema => SchemaFor(SampleTools.Store);
-    private static JsonElement GetSchema => SchemaFor(SampleTools.Get);
+
+    // Synthetic schema for a uuid-format field. The memory tools now take ids as loosely
+    // parsed strings (Piece 2), so no real tool advertises format:uuid — but the guard's
+    // uuid check is still exercised here for any tool that might.
+    private const string UuidSchema = """
+    { "type": "object", "properties": { "id": { "type": "string", "format": "uuid" } }, "required": ["id"] }
+    """;
 
     private static string? Validate(JsonElement schema, string argsJson, string tool)
     {
@@ -36,25 +42,31 @@ public class ToolArgumentGuardTests
         return ToolArgumentGuard.Validate(tool, schema, args);
     }
 
+    private static string? Validate(string schemaJson, string argsJson, string tool)
+    {
+        using var schemaDoc = JsonDocument.Parse(schemaJson);
+        return Validate(schemaDoc.RootElement, argsJson, tool);
+    }
+
     [Fact]
     public void Missing_required_field_is_named_with_an_example()
     {
-        // 'type' omitted — the exact shape that failed in the incident.
-        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", "store");
+        // 'text' omitted — a required field (type/source now default, so they can't be the probe).
+        var msg = Validate(StoreSchema, """{ "title": "T" }""", "store");
 
         Assert.NotNull(msg);
-        Assert.Contains("type", msg);
+        Assert.Contains("text", msg);
         Assert.Contains("required", msg, StringComparison.OrdinalIgnoreCase);
-        // The minimal example teaches the shape the agent must send.
-        Assert.Contains("\"type\"", msg);
+        // The minimal example teaches the required shape.
         Assert.Contains("\"text\"", msg);
+        Assert.Contains("\"title\"", msg);
     }
 
     [Fact]
     public void Missing_required_field_surfaces_its_description_as_a_hint()
     {
-        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", "store");
-        Assert.Contains("type of memory", msg!);
+        var msg = Validate(StoreSchema, """{ "title": "T" }""", "store");
+        Assert.Contains("Plain text", msg!);
     }
 
     [Theory]
@@ -62,11 +74,11 @@ public class ToolArgumentGuardTests
     [InlineData("\"   \"")]     // whitespace
     [InlineData("\"null\"")]    // literal "null" (Cursor-style), per #166
     [InlineData("null")]        // JSON null
-    public void Empty_or_null_string_for_required_counts_as_missing(string typeValue)
+    public void Empty_or_null_string_for_required_counts_as_missing(string textValue)
     {
-        var msg = Validate(StoreSchema, $$"""{ "type": {{typeValue}}, "text": "hi", "source": "LLM", "title": "T" }""", "store");
+        var msg = Validate(StoreSchema, $$"""{ "text": {{textValue}}, "title": "T" }""", "store");
         Assert.NotNull(msg);
-        Assert.Contains("type", msg);
+        Assert.Contains("text", msg);
     }
 
     [Fact]
@@ -88,20 +100,31 @@ public class ToolArgumentGuardTests
     }
 
     [Fact]
-    public void Malformed_uuid_is_reported_as_invalid_id()
+    public void Malformed_uuid_is_reported_as_invalid_id_when_schema_declares_uuid_format()
     {
-        // The N-format id (no hyphens) the model lifted from a recall doc-id.
-        var msg = Validate(GetSchema, """{ "id": "dec906c7e5d14abebaf827af5a842ae5" }""", "get");
+        var msg = Validate(UuidSchema, """{ "id": "dec906c7e5d14abebaf827af5a842ae5" }""", "get");
         Assert.NotNull(msg);
         Assert.Contains("id", msg);
         Assert.Contains("UUID", msg, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Hyphenated_uuid_is_allowed_through()
+    public void Hyphenated_uuid_is_allowed_through_when_schema_declares_uuid_format()
     {
-        var msg = Validate(GetSchema, """{ "id": "dec906c7-e5d1-4abe-baf8-27af5a842ae5" }""", "get");
+        var msg = Validate(UuidSchema, """{ "id": "dec906c7-e5d1-4abe-baf8-27af5a842ae5" }""", "get");
         Assert.Null(msg);
+    }
+
+    [Fact]
+    public void Store_schema_requires_only_text_and_title()
+    {
+        // Piece 2: 'type' and 'source' now default, so they must not be advertised as required.
+        var required = StoreSchema.GetProperty("required").EnumerateArray()
+            .Select(e => e.GetString()).ToHashSet();
+        Assert.Contains("text", required);
+        Assert.Contains("title", required);
+        Assert.DoesNotContain("type", required);
+        Assert.DoesNotContain("source", required);
     }
 
     [Fact]
@@ -124,7 +147,7 @@ public class ToolArgumentGuardTests
     [Fact]
     public void Message_is_prefixed_with_the_tool_name()
     {
-        var msg = Validate(StoreSchema, """{ "text": "hi", "source": "LLM", "title": "T" }""", "store");
+        var msg = Validate(StoreSchema, """{ "title": "T" }""", "store");
         Assert.StartsWith("store:", msg);
     }
 }

--- a/src/Memorizer/Models/EntityIds.cs
+++ b/src/Memorizer/Models/EntityIds.cs
@@ -70,6 +70,48 @@ public readonly record struct MemoryId(Guid Value) : IEntityId, IComparable<Memo
     /// </summary>
     public static MemoryId Parse(string s) => new(Guid.Parse(s));
 
+    // Prefixes that recall/other subsystems attach to a raw GUID (e.g. "doc-{guid}").
+    private static readonly string[] KnownIdPrefixes = ["doc-", "memory-", "mem-"];
+
+    /// <summary>
+    /// Attempts to parse a string as a MemoryId, tolerating the shapes agents actually
+    /// send instead of a bare GUID: surrounding whitespace, a pasted URL or path
+    /// (".../view/{id}"), a query/fragment tail, and the "doc-"/"memory-"/"mem-" prefixes
+    /// that recall subsystems attach. Accepts both the hyphenated ("D") and 32-hex ("N")
+    /// GUID forms. Use this for MCP tool id parameters so a lightly-mangled id resolves
+    /// instead of erroring.
+    /// </summary>
+    public static bool TryParseLoose(string? s, out MemoryId result)
+    {
+        result = Empty;
+        if (string.IsNullOrWhiteSpace(s))
+            return false;
+
+        var candidate = s.Trim();
+
+        // Keep only the last segment if a URL/path was pasted.
+        var lastSlash = candidate.LastIndexOf('/');
+        if (lastSlash >= 0)
+            candidate = candidate[(lastSlash + 1)..];
+
+        // Drop any query/fragment tail.
+        var tail = candidate.IndexOfAny(['?', '#']);
+        if (tail >= 0)
+            candidate = candidate[..tail];
+
+        // Strip a known id prefix, if present.
+        foreach (var prefix in KnownIdPrefixes)
+        {
+            if (candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                candidate = candidate[prefix.Length..];
+                break;
+            }
+        }
+
+        return TryParse(candidate, out result);
+    }
+
     public int CompareTo(MemoryId other) => Value.CompareTo(other.Value);
 
     public override string ToString() => Value.ToString();

--- a/src/Memorizer/Models/EntityIds.cs
+++ b/src/Memorizer/Models/EntityIds.cs
@@ -89,15 +89,17 @@ public readonly record struct MemoryId(Guid Value) : IEntityId, IComparable<Memo
 
         var candidate = s.Trim();
 
-        // Keep only the last segment if a URL/path was pasted.
-        var lastSlash = candidate.LastIndexOf('/');
-        if (lastSlash >= 0)
-            candidate = candidate[(lastSlash + 1)..];
-
-        // Drop any query/fragment tail.
+        // Drop any query/fragment tail (a pasted URL may carry "?v=2" or "#section").
         var tail = candidate.IndexOfAny(['?', '#']);
         if (tail >= 0)
             candidate = candidate[..tail];
+
+        // Ignore trailing slashes, then keep only the last path segment if a URL/path
+        // was pasted (".../view/{id}" or ".../view/{id}/").
+        candidate = candidate.TrimEnd('/');
+        var lastSlash = candidate.LastIndexOf('/');
+        if (lastSlash >= 0)
+            candidate = candidate[(lastSlash + 1)..];
 
         // Strip a known id prefix, if present.
         foreach (var prefix in KnownIdPrefixes)

--- a/src/Memorizer/Tools/MemoryTools.cs
+++ b/src/Memorizer/Tools/MemoryTools.cs
@@ -30,12 +30,12 @@ public class MemoryTools
         _canonicalUrlService = canonicalUrlService;
     }
 
-    [McpServerTool, Description("Store a new memory in the database, optionally creating a relationship to another memory. Use this to save reference material, how-to guides, coding standards, or any information you (the LLM) may want to refer to when completing tasks. Include as much context as possible, such as markdown, code samples, and detailed explanations. Create relationships to link related reference materials or examples. REQUIRED parameters: type, text, source, title - all four MUST be provided.")]
+    [McpServerTool, Description("Store a new memory in the database, optionally creating a relationship to another memory. Use this to save reference material, how-to guides, coding standards, or any information you (the LLM) may want to refer to when completing tasks. Include as much context as possible, such as markdown, code samples, and detailed explanations. Create relationships to link related reference materials or examples. REQUIRED: text and title. 'type' defaults to 'reference' and 'source' to 'LLM' when omitted.")]
     public async Task<string> Store(
-        [Description("REQUIRED. The type of memory (e.g., 'conversation', 'document', 'reference', 'how-to', 'todo-list', etc.). Use 'reference' or 'how-to' for reusable knowledge.")] string type,
         [Description("REQUIRED. Plain text (markdown, code, prose, etc.) to store. Include as much context as possible.")] string text,
-        [Description("REQUIRED. The source of the memory (e.g., 'user', 'system', 'LLM', etc.). Use 'LLM' if you are storing knowledge for your own future use.")] string source,
-        [Description("REQUIRED. Title for the memory. Should be descriptive and searchable.")] string title,
+        [Description("REQUIRED. Title for the memory. This is the primary text indexed for semantic search, so make it specific and descriptive.")] string title,
+        [Description("Optional. The type/category of memory (e.g. 'reference', 'how-to', 'todo-list', 'conversation'). Defaults to 'reference' when omitted.")] string? type = null,
+        [Description("Optional. The source of the memory (e.g. 'user', 'system', 'LLM'). Defaults to 'LLM' when omitted.")] string? source = null,
         [Description("Optional tags to categorize the memory. Use tags like 'coding-standard', 'unit-test', 'reference', 'how-to', 'todo', etc. to make retrieval easier.")] string[]? tags = null,
         [Description("Confidence score for the memory (0.0 to 1.0)")] double confidence = 1.0,
         [Description("Optionally, the ID of a related memory. Use this to link related reference materials, how-tos, or examples.")] string? relatedTo = null,
@@ -46,15 +46,16 @@ public class MemoryTools
         CancellationToken cancellationToken = default
     )
     {
-        // Validate required parameters — MCP clients sometimes omit these entirely
-        if (string.IsNullOrWhiteSpace(type))
-            return "Error: 'type' is required. Provide a memory type such as 'document', 'reference', 'how-to', 'todo-list', or 'conversation'.";
+        // text and title are required; title is the primary text indexed for search.
         if (string.IsNullOrWhiteSpace(text))
             return "Error: 'text' is required. Provide the content to store as plain text (markdown, code, prose, etc.).";
-        if (string.IsNullOrWhiteSpace(source))
-            return "Error: 'source' is required. Provide the source of the memory (e.g., 'user', 'system', or 'LLM').";
         if (string.IsNullOrWhiteSpace(title))
-            return "Error: 'title' is required. Provide a descriptive, searchable title for the memory.";
+            return "Error: 'title' is required. It is the primary text indexed for semantic search, so make it specific and descriptive.";
+
+        // Default the organizational fields when omitted — they are not load-bearing for
+        // search the way title is, so a missing value should not fail the write.
+        type = string.IsNullOrWhiteSpace(type) ? "reference" : type.Trim();
+        source = string.IsNullOrWhiteSpace(source) ? "LLM" : source.Trim();
 
         // Parse archetype string to enum
         var archetypeEnum = ArchetypeEnumExtensions.ParseArchetype(archetype);
@@ -119,7 +120,7 @@ public class MemoryTools
 
     [McpServerTool, Description("Edit an existing memory using find-and-replace. Ideal for checking off to-do items, updating sections, or fixing typos. IMPORTANT: The edit will FAIL if old_text is not found exactly - always use Get first to see current content and copy the exact text to replace. All changes are versioned and can be reverted. REQUIRED parameters: id, old_text, new_text - all three MUST be provided.")]
     public async Task<string> Edit(
-        [Description("REQUIRED. The ID of the memory to edit.")] Guid id,
+        [Description("REQUIRED. The ID of the memory to edit.")] string id,
         [Description("REQUIRED. The exact text to find and replace. Must match exactly (case-sensitive). For multi-line replacements, include the full text including newlines.")] string old_text,
         [Description("REQUIRED. The text to replace it with. Can be different length than old_text.")] string new_text,
         [Description("If true, replaces ALL occurrences of old_text. If false (default), only replaces the first occurrence. Use false for safety when editing unique content.")] bool replace_all = false,
@@ -142,7 +143,8 @@ public class MemoryTools
             {"replace_all", replace_all.ToString()}
         }));
 
-        var memoryId = (MemoryId)id;
+        if (!MemoryId.TryParseLoose(id, out var memoryId))
+            return $"Invalid memory id '{id}'. Use the id exactly as returned by store or search (a UUID, optionally with a 'doc-' prefix).";
 
         // Get existing memory
         var existingMemory = await _storage.Get(memoryId, cancellationToken);
@@ -249,7 +251,7 @@ public class MemoryTools
 
     [McpServerTool, Description("Update a memory's metadata (title, type, tags, confidence) without changing the content or regenerating embeddings. Use Edit tool for content changes. All changes are versioned and can be reverted.")]
     public async Task<string> UpdateMetadata(
-        [Description("The ID of the memory to update.")] Guid id,
+        [Description("The ID of the memory to update.")] string id,
         [Description("Optional: New title for the memory. Pass null to keep existing.")] string? title = null,
         [Description("Optional: New type for the memory. Pass null to keep existing.")] string? type = null,
         [Description("Optional: New tags for the memory. Pass null to keep existing, pass empty array to clear tags.")] string[]? tags = null,
@@ -259,7 +261,8 @@ public class MemoryTools
     {
         using var activity = TelemetryConfig.ActivitySource.StartActivity("MemoryTools.UpdateMetadata");
 
-        var memoryId = (MemoryId)id;
+        if (!MemoryId.TryParseLoose(id, out var memoryId))
+            return $"Invalid memory id '{id}'. Use the id exactly as returned by store or search (a UUID, optionally with a 'doc-' prefix).";
 
         // Get existing memory
         var existingMemory = await _storage.Get(memoryId, cancellationToken);
@@ -520,7 +523,7 @@ public class MemoryTools
 
     [McpServerTool, Description("Retrieve a specific memory by ID. Use this to fetch a particular reference, how-to, or example by its unique identifier. Optionally include version history or retrieve a specific past version. By default, also shows similar memories that may be candidates for consolidation or linking.")]
     public async Task<string> Get(
-        [Description("The ID of the memory to retrieve. Use this to fetch a specific piece of reference or how-to information.")] Guid id,
+        [Description("The ID of the memory to retrieve. Use this to fetch a specific piece of reference or how-to information.")] string id,
         [Description("Optional: If true, includes version history summary in the response (recent versions, change count).")] bool includeVersionHistory = false,
         [Description("Optional: Specific version number to retrieve. If provided, returns that version's content instead of current.")] int? versionNumber = null,
         [Description("Optional: Maximum number of versions to include in history (default: 5, max: 20).")] int versionLimit = 5,
@@ -542,7 +545,8 @@ public class MemoryTools
             {"query.includeArchivedRelationships", includeArchivedRelationships.ToString()}
         }));
 
-        var memoryId = (MemoryId)id;
+        if (!MemoryId.TryParseLoose(id, out var memoryId))
+            return $"Invalid memory id '{id}'. Use the id exactly as returned by store or search (a UUID, optionally with a 'doc-' prefix).";
 
         // If requesting a specific version, get that version
         if (versionNumber.HasValue)
@@ -735,18 +739,21 @@ public class MemoryTools
 
     [McpServerTool, Description("Delete a memory by ID. This permanently removes the memory including all version history. Use this to remove outdated or incorrect reference or how-to information.")]
     public async Task<string> Delete(
-        [Description("The ID of the memory to delete. Use this to remove a specific piece of knowledge.")] Guid id,
+        [Description("The ID of the memory to delete. Use this to remove a specific piece of knowledge.")] string id,
         CancellationToken cancellationToken = default
     )
     {
-        bool success = await _storage.Delete((MemoryId)id, cancellationToken);
+        if (!MemoryId.TryParseLoose(id, out var memoryId))
+            return $"Invalid memory id '{id}'. Use the id exactly as returned by store or search (a UUID, optionally with a 'doc-' prefix).";
+
+        bool success = await _storage.Delete(memoryId, cancellationToken);
 
         return success ? $"Memory with ID {id} deleted successfully." : $"Memory with ID {id} not found or could not be deleted.";
     }
 
     [McpServerTool, Description("Fetch multiple memories by their IDs. Use this to retrieve a set of related reference materials, how-tos, or examples.")]
     public async Task<string> GetMany(
-        [Description("The list of memory IDs to fetch. Use this to retrieve multiple related pieces of knowledge at once.")] Guid[] ids,
+        [Description("The list of memory IDs to fetch. Use this to retrieve multiple related pieces of knowledge at once.")] string[] ids,
         CancellationToken cancellationToken = default
     )
     {
@@ -759,7 +766,16 @@ public class MemoryTools
             {"query.count", ids.Length.ToString()}
         }));
 
-        var memoryIds = ids.Select(id => (MemoryId)id).ToArray();
+        // Parse ids loosely; skip any that don't resolve rather than failing the whole call.
+        var parsedIds = new List<MemoryId>();
+        foreach (var raw in ids)
+        {
+            if (MemoryId.TryParseLoose(raw, out var parsed))
+                parsedIds.Add(parsed);
+        }
+        if (parsedIds.Count == 0)
+            return $"No valid memory ids provided. Received: {string.Join(", ", ids)}. Use ids exactly as returned by store or search.";
+        var memoryIds = parsedIds.ToArray();
         var memories = await _storage.GetMany(memoryIds, cancellationToken);
         
         // Log results count
@@ -861,18 +877,18 @@ public class MemoryTools
         if (string.IsNullOrWhiteSpace(type))
             return "Error: 'type' is required. Provide the relationship type (e.g., 'example-of', 'explains', 'related-to').";
 
-        if (!Guid.TryParse(fromId, out var parsedFromId))
+        if (!MemoryId.TryParseLoose(fromId, out var parsedFromId))
             return $"Error: 'fromId' must be a valid GUID. Received: '{fromId}'.";
-        if (!Guid.TryParse(toId, out var parsedToId))
+        if (!MemoryId.TryParseLoose(toId, out var parsedToId))
             return $"Error: 'toId' must be a valid GUID. Received: '{toId}'.";
 
-        var rel = await _storage.CreateRelationship((MemoryId)parsedFromId, (MemoryId)parsedToId, type, cancellationToken);
+        var rel = await _storage.CreateRelationship(parsedFromId, parsedToId, type, cancellationToken);
         return $"Reference created: {rel.Id} from {rel.FromMemoryId} to {rel.ToMemoryId} (type: {rel.Type})";
     }
 
     [McpServerTool, Description("Revert a memory to a previous version. Restores all content and metadata (title, type, tags, confidence) from the specified version. Creates a new version recording the revert operation and regenerates embeddings. Use Get with includeVersionHistory=true to see available versions first.")]
     public async Task<string> RevertToVersion(
-        [Description("The ID of the memory to revert.")] Guid id,
+        [Description("The ID of the memory to revert.")] string id,
         [Description("The version number to revert to. Use Get with includeVersionHistory=true to see available versions.")] int versionNumber,
         [Description("Optional: Identifier of who is requesting the revert (e.g., 'user', 'LLM', 'system').")] string? changedBy = null,
         CancellationToken cancellationToken = default
@@ -887,7 +903,8 @@ public class MemoryTools
             {"changed.by", changedBy ?? "unspecified"}
         }));
 
-        var memoryId = (MemoryId)id;
+        if (!MemoryId.TryParseLoose(id, out var memoryId))
+            return $"Invalid memory id '{id}'. Use the id exactly as returned by store or search (a UUID, optionally with a 'doc-' prefix).";
         var targetVersion = new VersionNumber(versionNumber);
 
         // First check the memory exists
@@ -941,13 +958,14 @@ public class MemoryTools
 
     [McpServerTool, Description("Archive a memory, marking it as obsolete. Archived memories are hidden from default searches and relationship displays but preserved for historical reference and audit trails. Use this when consolidating memories or marking outdated content.")]
     public async Task<string> ArchiveMemory(
-        [Description("The ID of the memory to archive.")] Guid id,
+        [Description("The ID of the memory to archive.")] string id,
         CancellationToken cancellationToken = default
     )
     {
         using var activity = TelemetryConfig.ActivitySource.StartActivity("MemoryTools.ArchiveMemory");
 
-        var memoryId = (MemoryId)id;
+        if (!MemoryId.TryParseLoose(id, out var memoryId))
+            return $"Invalid memory id '{id}'. Use the id exactly as returned by store or search (a UUID, optionally with a 'doc-' prefix).";
 
         // First check the memory exists
         var existingMemory = await _storage.Get(memoryId, cancellationToken);
@@ -995,14 +1013,15 @@ public class MemoryTools
 
     [McpServerTool, Description("Restore an archived memory back to active status. The memory will become visible in searches and relationship displays again.")]
     public async Task<string> RestoreMemory(
-        [Description("The ID of the archived memory to restore.")] Guid id,
+        [Description("The ID of the archived memory to restore.")] string id,
         [Description("The archetype to restore to: 'document' for living, editable content or 'record' for historical, immutable records. Default is 'document'.")] string restoreAs = "document",
         CancellationToken cancellationToken = default
     )
     {
         using var activity = TelemetryConfig.ActivitySource.StartActivity("MemoryTools.RestoreMemory");
 
-        var memoryId = (MemoryId)id;
+        if (!MemoryId.TryParseLoose(id, out var memoryId))
+            return $"Invalid memory id '{id}'. Use the id exactly as returned by store or search (a UUID, optionally with a 'doc-' prefix).";
 
         // Parse the restore archetype
         var targetArchetype = ArchetypeEnumExtensions.ParseArchetype(restoreAs);

--- a/src/Memorizer/Tools/WorkspaceTools.cs
+++ b/src/Memorizer/Tools/WorkspaceTools.cs
@@ -836,13 +836,14 @@ public class WorkspaceTools
             return "Error: 'memoryIds' is required. Provide one or more memory GUIDs to move. Use Search or Get to find memory IDs.";
         }
 
-        // Parse memory IDs defensively — MCP clients may send malformed values
+        // Parse memory IDs loosely — accept the shapes agents send (doc-/memory- prefixes,
+        // N-format, pasted URLs), consistent with the memory tools' id handling.
         var parsedIds = new List<Guid>();
         var invalidIds = new List<string>();
         foreach (var idStr in memoryIds)
         {
-            if (Guid.TryParse(idStr, out var parsed))
-                parsedIds.Add(parsed);
+            if (MemoryId.TryParseLoose(idStr, out var parsed))
+                parsedIds.Add(parsed.Value);
             else if (!string.IsNullOrWhiteSpace(idStr))
                 invalidIds.Add(idStr);
         }


### PR DESCRIPTION
## Piece 2: agent-friendly tool ergonomics

Second piece of `docs/agent-resilient-tool-surface-plan.md`. Piece 1 (#229) made bad calls *correctable*; this makes fewer calls bad in the first place — the "pit of success" — while keeping the one field that matters strict.

### Store defaults
- Only `text` and `title` are required now. `type` defaults to `reference`, `source` to `LLM`.
- `title` stays required **by design**: it dominates the metadata embedding (`embedding_metadata = title + tags`), so it's the search index, not cosmetic. Defaulting it would silently wreck findability — the same failure mode #215 removed. Its description now says so.
- The exact field the incident dropped (`type`) now simply defaults instead of failing the write.

### Loose id parsing
- `MemoryId.TryParseLoose` accepts the shapes agents actually send: surrounding whitespace, a pasted `/view/{id}` URL, and `doc-`/`memory-`/`mem-` prefixes (as recall subsystems emit), in both hyphenated and 32-hex GUID forms.
- `get`/`get_many`/`delete`/`edit`/`update_metadata`/`revert_to_version`/`archive`/`restore`/`create_reference` take ids as loosely-parsed strings. A lightly-mangled id resolves; a truly unparseable one returns a plain corrective message. (Extends the #166 pattern — optional ids were already `string` — to the required id.)

### Tests
- `MemoryId.TryParseLoose` unit cases (agent shapes + garbage).
- Schema test proving `type`/`source` are no longer advertised as required.
- Updated boundary tests: a mangled id now normalizes to "not found" rather than erroring; new `doc-` prefix and garbage-id integration cases.
- Full unit suite (223) + `McpServerTests` (12) green locally.

Builds on #229 and #230 (both merged).
