### PR TITLE
Release 2.3.1: update release notes and version metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,31 +3,19 @@
     <Copyright>© $([System.DateTime]::Now.Year)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/petabridge/memorizer-v1</PackageProjectUrl>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.3.1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
     <Deterministic>true</Deterministic>
     <PackageReleaseNotes>**Features**
-- [Upgrade Model Context Protocol SDK to 2.2.0](https://github.com/petabridge/memorizer/pull/211) - Moves Memorizer onto the stable MCP SDK
-  - The MCP server now runs in stateless Streamable HTTP mode
-  - Adds MCP endpoint integration tests driven by a lightweight SDK client
-- [Expose MCP prompts that teach correct Memorizer usage](https://github.com/petabridge/memorizer/pull/212) - Adds seven guided prompts written in Simplified Technical English
-  - `memorizer_overview`, `store_memory`, `find_context`, `review_project`, `organize_memory`, `maintain_memory`, and `start_project`
-- [Add start_project prompt and a workspace-tree MCP resource](https://github.com/petabridge/memorizer/pull/213) - Exposes the live workspace and project hierarchy as readable MCP context
-  - The `memorizer://workspaces` resource surfaces the current workspace/project tree so agents can orient before acting
-
-**Security**
-- [Pin SSH.NET to 2026.0.0 to fix high-severity advisory (GHSA-q939-rpr3-3284)](https://github.com/petabridge/memorizer/pull/207) - Addresses a high-severity advisory pulled in transitively via Testcontainers
-- [Bump OpenTelemetry packages to 1.17.0 to fix moderate advisories](https://github.com/petabridge/memorizer/pull/208) - Resolves four moderate denial-of-service advisories in `OpenTelemetry.Api` and the OTLP exporter
+- [Agent-friendly tool ergonomics: defaults and loose id parsing](https://github.com/petabridge/memorizer/pull/231) - Fewer well-intentioned tool calls fail
+  - `store` now requires only `text` and `title`; `type` defaults to `reference` and `source` to `LLM` (`title` stays required — it is the primary text indexed for search)
+  - Memory id parameters across `get`, `get_many`, `delete`, `edit`, `update_metadata`, `revert_to_version`, `archive`, `restore`, `create_reference`, and `move_memory` now accept ids as returned by store or search — tolerating `doc-`/`memory-` prefixes, the 32-hex form, and pasted `/view/{id}` URLs
 
 **Bug Fixes**
-- [Fix canonical URLs for projects and workspaces](https://github.com/petabridge/memorizer/pull/205) - MCP tool responses now link to the correct web UI routes ([#204](https://github.com/petabridge/memorizer/issues/204))
-  - Project and workspace links now use the plural `/projects/{id}` and `/workspaces/{id}` routes
-- [Fix connection-pool self-deadlock in Get/GetMany relationship loading](https://github.com/petabridge/memorizer/pull/209) - Prevents pool exhaustion under concurrency during relationship loading
-  - `Get`, `GetMany`, and the remaining query paths now reuse a single pooled connection instead of holding two ([#210](https://github.com/petabridge/memorizer/pull/210))
-- [Fix embedding search threshold trap and remove random-embedding fallback](https://github.com/petabridge/memorizer/pull/215) - Corrects similarity-threshold behavior and surfaces embedding failures
-  - `minSimilarity: 0.0` now means "no threshold" instead of filtering out all results
-  - Embedding failures now surface loudly instead of silently persisting a random vector</PackageReleaseNotes>
+- [Own the MCP tool-argument error surface](https://github.com/petabridge/memorizer/pull/229) - MCP tools now return a correctable message when a required argument is missing or malformed, instead of the opaque "An error occurred invoking '&lt;tool&gt;'" produced by the 2.2.0 SDK marshaller
+  - A CallTool validation boundary checks arguments against each tool's advertised schema before the SDK marshaller runs, so no opaque error reaches the client
+  - Restores the resilience intent of [#166](https://github.com/petabridge/memorizer/pull/166) and [#184](https://github.com/petabridge/memorizer/pull/184) that the 2.3.0 SDK upgrade had bypassed</PackageReleaseNotes>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 2.3.1 August 21st 2026 ####
+
+**Features**
+- [Agent-friendly tool ergonomics: defaults and loose id parsing](https://github.com/petabridge/memorizer/pull/231) - Fewer well-intentioned tool calls fail
+  - `store` now requires only `text` and `title`; `type` defaults to `reference` and `source` to `LLM` (`title` stays required — it is the primary text indexed for search)
+  - Memory id parameters across `get`, `get_many`, `delete`, `edit`, `update_metadata`, `revert_to_version`, `archive`, `restore`, `create_reference`, and `move_memory` now accept ids as returned by store or search — tolerating `doc-`/`memory-` prefixes, the 32-hex form, and pasted `/view/{id}` URLs
+
+**Bug Fixes**
+- [Own the MCP tool-argument error surface](https://github.com/petabridge/memorizer/pull/229) - MCP tools now return a correctable message when a required argument is missing or malformed, instead of the opaque "An error occurred invoking '<tool>'" produced by the 2.2.0 SDK marshaller
+  - A CallTool validation boundary checks arguments against each tool's advertised schema before the SDK marshaller runs, so no opaque error reaches the client
+  - Restores the resilience intent of [#166](https://github.com/petabridge/memorizer/pull/166) and [#184](https://github.com/petabridge/memorizer/pull/184) that the 2.3.0 SDK upgrade had bypassed
+
 #### 2.3.0 August 17th 2026 ####
 
 **Features**


### PR DESCRIPTION
Release **2.3.1**.

Bumps `VersionPrefix` to 2.3.1 and updates `RELEASE_NOTES.md` / `PackageReleaseNotes`.

### Included since 2.3.0
- **Feature** — [#231](https://github.com/petabridge/memorizer/pull/231): agent-friendly tool ergonomics (store defaults; loose id parsing across all id-taking tools).
- **Bug fix** — [#229](https://github.com/petabridge/memorizer/pull/229): own the MCP tool-argument error surface (correctable messages instead of the opaque SDK marshaller error introduced by the 2.3.0 SDK upgrade).

Internal-only changes not in the notes: [#230](https://github.com/petabridge/memorizer/pull/230) (test-isolation fix) and routine dependency bumps.

Tag `2.3.1` will be pushed after merge; CI/CD publishes the GitHub release.
