### PR TITLE
Return an honest error when a write can't generate its embedding

### DIFF
--- a/docs/agent-resilient-tool-surface-plan.md
+++ b/docs/agent-resilient-tool-surface-plan.md
@@ -159,17 +159,35 @@ Streamable HTTP). Assert graceful, correctable results — not exceptions:
 
 ### Piece 4 — Embedding-failure handling in the store path (Class B)
 
-Separate track; the boundary does not cover this. Catch
-`EmbeddingGenerationException` in the store path and return an actionable,
-retryable result instead of an opaque failure. Decide the real policy:
+**Decision (implemented): reply to the caller with an honest error in both
+cases** (text-too-long and backend-down). No truncation, no background queue, no
+changed write semantics — consistent with #215's "never persist a memory that is
+invisible to search."
 
-- chunk/truncate over-long text before embedding, and/or
-- queue a re-embed and store flagged-degraded, and/or
-- surface a clear "embedding backend unavailable, memory not stored" that the
-  agent can retry.
+- `EmbeddingApiClient` now reads the backend's error body on a non-success
+  response (instead of discarding it via `EnsureSuccessStatusCode`), so the real
+  reason (e.g. Ollama's "the input length exceeds the context length") survives.
+- `EmbeddingGenerationException` carries `Model` and `InputLength`.
+- The CallTool boundary detects an `EmbeddingGenerationException` (walking the
+  exception chain) and returns `ToolErrorMessages.EmbeddingUnavailable`: states
+  plainly that nothing was saved and why, reports the input length, classifies
+  too-long vs. backend-unavailable from the backend's text, and passes the
+  backend's own reason through. It no longer gives the misleading "check the
+  arguments" advice for this case.
 
-Also audit: memories written **before** 2.3.0 may carry random-fallback
-embeddings and be unfindable by semantic search — candidate for a re-embed pass.
+On "how far over the limit": we cannot tokenize in-process, so we surface the
+input's character count (always available) and the backend's own error text
+(which reports the limit when it chooses to). A tokenizer-based estimate was
+considered and rejected as not consistently reliable across backends.
+
+**Deferred follow-up — one-time re-embed audit.** Memories written *before* 2.3.0
+may carry random-fallback embeddings (from the fallback #215 removed) and be
+unfindable by semantic search. The fallback was silent, so we cannot tell which
+rows are affected from a flag; detection options are (a) re-embed each row and
+compare to the stored vector (low cosine ⇒ was garbage), which costs the same as
+just re-embedding, or (b) bulk re-embed everything predating the 2.3.0 deploy via
+the existing regeneration path. Decision deferred until this write-failure
+surface has shipped.
 
 ## Sequencing
 

--- a/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
+++ b/src/Memorizer.IntegrationTests/Mcp/McpServerTests.cs
@@ -274,4 +274,32 @@ public sealed class McpServerTests : IAsyncLifetime
         // not merely the absence of the opaque one.
         Assert.Contains("required", text, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task Store_with_text_too_long_to_embed_fails_honestly_never_opaque_or_misleading()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+        await using var mcp = await ConnectAsync(cts.Token);
+
+        // A body far beyond the embedding model's context window. Depending on the backend
+        // it may reject the embedding (fail) or truncate (succeed); either way the caller
+        // must never see the opaque SDK error or the misleading "check the arguments"
+        // advice, and if it fails it must be the honest "not saved" embedding message.
+        var longText = string.Concat(Enumerable.Repeat("context and detail. ", 600)); // ~12 KB
+        var result = await mcp.Client.CallToolAsync(
+            "store",
+            new Dictionary<string, object?>
+            {
+                ["text"] = longText,
+                ["title"] = "Very long memory",
+            },
+            cancellationToken: cts.Token);
+
+        var text = ResultText(result);
+        _output.WriteLine(text.Length > 300 ? text[..300] : text);
+        Assert.DoesNotContain(OpaqueSdkError, text);
+        Assert.DoesNotContain("Check the arguments", text);
+        if (result.IsError == true)
+            Assert.Contains("not saved", text, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/Memorizer.UnitTests/Tools/ToolErrorMessagesTests.cs
+++ b/src/Memorizer.UnitTests/Tools/ToolErrorMessagesTests.cs
@@ -1,0 +1,55 @@
+using Memorizer.Services;
+using Memorizer.Tools;
+
+namespace Memorizer.UnitTests.Tools;
+
+/// <summary>
+/// Unit tests for <see cref="ToolErrorMessages"/> — the honest, caller-facing message a
+/// tool returns when a write could not be saved because its search embedding could not be
+/// generated (Piece 4). The message must state plainly that nothing was saved, surface the
+/// backend's own reason, and never give the misleading "check the arguments" advice.
+/// </summary>
+public class ToolErrorMessagesTests
+{
+    private static EmbeddingGenerationException Failure(
+        string backendMessage, string model = "all-minilm", int length = 6000)
+        => new(
+            $"Failed to generate embedding using model '{model}' for input of length {length}.",
+            new HttpRequestException(backendMessage),
+            model,
+            length);
+
+    [Fact]
+    public void EmbeddingUnavailable_TooLong_TellsCallerToShorten_AndSurfacesLengthAndReason()
+    {
+        var ex = Failure("Embedding request failed with status 500 (InternalServerError): the input length exceeds the context length");
+
+        var msg = ToolErrorMessages.EmbeddingUnavailable("store", ex);
+
+        Assert.Contains("not saved", msg, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("too long", msg, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("6000", msg);                 // input length surfaced
+        Assert.Contains("context length", msg);       // backend's own reason passed through
+        Assert.DoesNotContain("Check the arguments", msg);
+    }
+
+    [Fact]
+    public void EmbeddingUnavailable_BackendDown_TellsCallerToRetry()
+    {
+        var ex = Failure("Connection refused (localhost:11434)");
+
+        var msg = ToolErrorMessages.EmbeddingUnavailable("store", ex);
+
+        Assert.Contains("not saved", msg, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unavailable", msg, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("retry", msg, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Check the arguments", msg);
+    }
+
+    [Fact]
+    public void EmbeddingUnavailable_IsPrefixedWithToolName()
+    {
+        var msg = ToolErrorMessages.EmbeddingUnavailable("store", Failure("boom"));
+        Assert.StartsWith("store:", msg);
+    }
+}

--- a/src/Memorizer/Extensions/McpToolValidationExtensions.cs
+++ b/src/Memorizer/Extensions/McpToolValidationExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using Memorizer.Services;
 using Memorizer.Tools;
 
 namespace Memorizer.Extensions;
@@ -47,13 +48,22 @@ public static class McpToolValidationExtensions
                 }
                 catch (Exception ex)
                 {
-                    // Backstop: something threw past validation (an argument shape we did
-                    // not anticipate, or a failure inside the tool body). Own the message
-                    // rather than let the SDK emit its opaque one.
-                    context.Services?.GetService<ILoggerFactory>()
-                        ?.CreateLogger("Memorizer.Tools.Validation")
-                        .LogError(ex, "Tool {Tool} threw after argument validation", toolName);
+                    var logger = context.Services?.GetService<ILoggerFactory>()
+                        ?.CreateLogger("Memorizer.Tools.Validation");
 
+                    // A write that could not generate its search embedding is an expected,
+                    // honest failure (see #215): tell the caller plainly it was not saved
+                    // and why, instead of the generic "check the arguments" message.
+                    if (FindEmbeddingFailure(ex) is { } embeddingFailure)
+                    {
+                        logger?.LogWarning(ex, "Tool {Tool} could not generate an embedding", toolName);
+                        return ErrorResult(ToolErrorMessages.EmbeddingUnavailable(toolName, embeddingFailure));
+                    }
+
+                    // Backstop: something else threw past validation (an argument shape we
+                    // did not anticipate, or another failure in the tool body). Own the
+                    // message rather than let the SDK emit its opaque one.
+                    logger?.LogError(ex, "Tool {Tool} threw after argument validation", toolName);
                     return ErrorResult(
                         $"{toolName}: the call could not be completed ({ex.Message}). "
                         + "Check the arguments against the tool's schema and retry.");
@@ -62,6 +72,15 @@ public static class McpToolValidationExtensions
         });
 
         return builder;
+    }
+
+    // Walk the exception chain — the SDK invocation layer may wrap the tool's exception.
+    private static EmbeddingGenerationException? FindEmbeddingFailure(Exception ex)
+    {
+        for (Exception? e = ex; e is not null; e = e.InnerException)
+            if (e is EmbeddingGenerationException embedding)
+                return embedding;
+        return null;
     }
 
     private static CallToolResult ErrorResult(string message) => new()

--- a/src/Memorizer/Services/EmbeddingApiClient.cs
+++ b/src/Memorizer/Services/EmbeddingApiClient.cs
@@ -56,7 +56,7 @@ public sealed class EmbeddingApiClient : IEmbeddingApiClient
 
         _logger.LogDebug("Sending Ollama embedding request to {ApiUrl}", Settings.ApiUrl);
         var response = await _httpClient.PostAsJsonAsync("api/embeddings", request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await EnsureSuccessAsync(response, cancellationToken);
 
         var result = await response.Content.ReadFromJsonAsync<EmbeddingResponse>(cancellationToken: cancellationToken);
         if (result?.Embedding is null || result.Embedding.Length == 0)
@@ -83,7 +83,7 @@ public sealed class EmbeddingApiClient : IEmbeddingApiClient
 
         _logger.LogDebug("Sending OpenAI-compatible embedding request to {ApiUrl}", Settings.ApiUrl);
         var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await EnsureSuccessAsync(response, cancellationToken);
 
         var result = await response.Content.ReadFromJsonAsync<OpenAIEmbeddingResponse>(cancellationToken: cancellationToken);
         var first = result?.Data.FirstOrDefault();
@@ -93,5 +93,37 @@ public sealed class EmbeddingApiClient : IEmbeddingApiClient
         }
 
         return first.Embedding;
+    }
+
+    /// <summary>
+    /// Like <see cref="HttpResponseMessage.EnsureSuccessStatusCode"/>, but reads the
+    /// response body on failure and includes it in the thrown exception. Embedding
+    /// backends put the real reason there (e.g. Ollama's "the input length exceeds the
+    /// context length"); the default helper discards it, leaving only a bare status code.
+    /// Preserving it lets tools give the caller an honest, actionable failure.
+    /// </summary>
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+
+        string body;
+        try
+        {
+            body = (await response.Content.ReadAsStringAsync(cancellationToken)).Trim();
+        }
+        catch
+        {
+            body = string.Empty;
+        }
+
+        if (body.Length > 500)
+            body = body[..500] + "…";
+
+        var detail = string.IsNullOrEmpty(body) ? string.Empty : $": {body}";
+        throw new HttpRequestException(
+            $"Embedding request failed with status {(int)response.StatusCode} ({response.StatusCode}){detail}",
+            inner: null,
+            statusCode: response.StatusCode);
     }
 }

--- a/src/Memorizer/Services/EmbeddingService.cs
+++ b/src/Memorizer/Services/EmbeddingService.cs
@@ -25,9 +25,17 @@ public interface IEmbeddingService
 /// </summary>
 public sealed class EmbeddingGenerationException : Exception
 {
-    public EmbeddingGenerationException(string message, Exception innerException)
+    /// <summary>The embedding model that failed.</summary>
+    public string Model { get; }
+
+    /// <summary>Length, in characters, of the input we tried to embed.</summary>
+    public int InputLength { get; }
+
+    public EmbeddingGenerationException(string message, Exception innerException, string model, int inputLength)
         : base(message, innerException)
     {
+        Model = model;
+        InputLength = inputLength;
     }
 }
 
@@ -91,7 +99,7 @@ public class EmbeddingService : IEmbeddingService
             throw new EmbeddingGenerationException(
                 $"Failed to generate embedding using model '{Settings.Model}' for input of length {text.Length}. " +
                 "Refusing to persist a fallback embedding, which would corrupt semantic search for this record.",
-                ex);
+                ex, Settings.Model, text.Length);
         }
     }
 

--- a/src/Memorizer/Tools/ToolErrorMessages.cs
+++ b/src/Memorizer/Tools/ToolErrorMessages.cs
@@ -1,0 +1,43 @@
+using Memorizer.Services;
+
+namespace Memorizer.Tools;
+
+/// <summary>
+/// Builds honest, caller-facing messages for tool failures that happen after argument
+/// validation — currently, when a write could not be saved because its search embedding
+/// could not be generated.
+/// </summary>
+public static class ToolErrorMessages
+{
+    // Substrings a backend uses when the input exceeded the model's context window. We
+    // cannot tokenize in-process, so we classify from the backend's own error text and
+    // otherwise fall back to a neutral message.
+    private static readonly string[] LengthIndicators =
+    [
+        "context length", "context window", "too long", "maximum context",
+        "exceeds", "max_tokens", "input is too large", "maximum number of tokens",
+    ];
+
+    /// <summary>
+    /// Message for when a tool could not complete because the embedding backend failed.
+    /// States plainly that nothing was saved (Memorizer will not store a memory that
+    /// would be invisible to search — see #215), and gives the most actionable remedy we
+    /// can determine, passing the backend's own reason through so "how far over" is
+    /// surfaced when the backend reports it.
+    /// </summary>
+    public static string EmbeddingUnavailable(string toolName, EmbeddingGenerationException ex)
+    {
+        var backend = ex.InnerException?.Message?.Trim();
+        var looksTooLong = !string.IsNullOrEmpty(backend)
+            && LengthIndicators.Any(k => backend.Contains(k, StringComparison.OrdinalIgnoreCase));
+
+        var remedy = looksTooLong
+            ? $"The text is too long for embedding model '{ex.Model}' — it was {ex.InputLength} characters. Shorten it and try again."
+            : $"The embedding backend (model '{ex.Model}') looks unavailable. If the text is very long ({ex.InputLength} characters) shorten it; otherwise retry shortly.";
+
+        var detail = string.IsNullOrEmpty(backend) ? string.Empty : $" Backend reported: {backend}";
+
+        return $"{toolName}: not saved. Its search embedding could not be generated, so nothing was written "
+             + $"— Memorizer will not store a memory that would be invisible to search. {remedy}{detail}";
+    }
+}


### PR DESCRIPTION
## What this does

When embedding generation fails, writes like `store` abort instead of saving. That behavior is intentional (#215): a memory with no embedding can't be found by semantic search. The problem is the error the caller gets back.

The validation boundary from #229 caught these failures in its generic backstop and returned `"...Check the arguments against the tool's schema and retry."` The failure has nothing to do with the arguments, so that advice points the caller in the wrong direction.

This returns a clear error for both cases: text too long for the model, and backend unreachable.

## Changes

- `EmbeddingApiClient` reads the response body on a non-2xx status instead of discarding it with `EnsureSuccessStatusCode`. The backend's actual error (e.g. Ollama's `the input length exceeds the context length`) now reaches the exception.
- `EmbeddingGenerationException` exposes `Model` and `InputLength`.
- The CallTool boundary recognizes an `EmbeddingGenerationException` in the exception chain and returns `ToolErrorMessages.EmbeddingUnavailable`, which reports that nothing was saved, the input length, whether the text looks too long or the backend looks down, and the backend's own error text.

Example response for an over-long body:

```
store: not saved. Its search embedding could not be generated, so nothing was written — Memorizer will not store a memory that would be invisible to search. The text is too long for embedding model 'all-minilm' — it was 12017 characters. Shorten it and try again. Backend reported: ... {"error":"the input length exceeds the context length"}
```

Memorizer doesn't tokenize input, so the message gives the character count and passes through the backend's limit error rather than estimating tokens.

## Tests

- Unit tests for the message across the too-long and backend-down cases.
- An integration test that stores an over-long body and checks the response is the honest "not saved" message, never the opaque SDK error or the "check the arguments" text.

## Follow-up (not in this PR)

Memories written before 2.3.0 may hold a random fallback embedding (from the fallback removed in #215) and be unfindable by search. Nothing flags them, so finding them means re-embedding. Tracked for a later change.
